### PR TITLE
Bridge getReplicas API

### DIFF
--- a/docs/source/migration-guide/index.md
+++ b/docs/source/migration-guide/index.md
@@ -95,6 +95,13 @@ In the DataStax C# driver, `Metadata` is accessible at the `Cluster` level witho
 
 **Migration Impact:** Ensure you establish a session before querying any metadata properties or methods.
 
+**GetReplicas API update:**
+Legacy `GetReplicas(..., byte[] partitionKey)` overloads are still available for backward compatibility, but they are now marked obsolete because they cannot support tablet-aware routing and always use Murmur3-compatible token computation.
+
+Prefer `GetReplicas(string keyspace, string table, IReadOnlyList<object> partitionKeyValues)`, which serializes partition-key values with the configured type serializers and uses table metadata for tablet-aware routing.
+
+If you still need the legacy serialized `byte[]` overloads, there is no dedicated public serializer for that format. The practical workaround is to reuse a routing key already computed by the driver, for example via `prepared.Bind(values).RoutingKey.RawRoutingKey`.
+
 ## SocketOptions API
 
 ### Added APIs

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 thiserror = "2"
 tracing = "0.1.41"
+uuid = "1"
 # This is just for development. In production, we will probably get rid of this dependency.
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 
@@ -34,7 +35,6 @@ panic = "abort"
 
 [dev-dependencies]
 ntest = "0.9"
-uuid = "1"
 
 [lints.rust]
 unsafe-op-in-unsafe-fn = "warn"

--- a/rust/src/error_conversion.rs
+++ b/rust/src/error_conversion.rs
@@ -329,8 +329,20 @@ pub(crate) enum MetadataBridgeError {
     #[error("Keyspace name is null")]
     NullKeyspaceName,
 
+    #[error("Keyspace name is empty")]
+    EmptyKeyspaceName,
+
     #[error("Keyspace name is not valid UTF-8")]
     InvalidKeyspaceNameUtf8(#[source] std::str::Utf8Error),
+
+    #[error("Table name is null")]
+    NullTableName,
+
+    #[error("Table name is empty")]
+    EmptyTableName,
+
+    #[error("Table name is not valid UTF-8")]
+    InvalidTableNameUtf8(#[source] std::str::Utf8Error),
 
     #[error("Invalid partition key encoding: {0}")]
     InvalidPartitionKeyEncoding(#[from] SerializationError),
@@ -705,7 +717,11 @@ impl ErrorToException for MetadataBridgeError {
     fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self {
             MetadataBridgeError::NullKeyspaceName
-            | MetadataBridgeError::InvalidKeyspaceNameUtf8(_) => ctors
+            | MetadataBridgeError::EmptyKeyspaceName
+            | MetadataBridgeError::InvalidKeyspaceNameUtf8(_)
+            | MetadataBridgeError::NullTableName
+            | MetadataBridgeError::EmptyTableName
+            | MetadataBridgeError::InvalidTableNameUtf8(_) => ctors
                 .invalid_argument_exception_constructor
                 .construct_from_rust(&self.to_string()),
 

--- a/rust/src/error_conversion.rs
+++ b/rust/src/error_conversion.rs
@@ -1,8 +1,9 @@
 use crate::ffi::{FFIGCHandle, FFIMaybeGCHandle, FFISlice, FFIStr};
 use scylla::errors::{
-    BadKeyspaceName, ConnectionError, ConnectionPoolError, DbError, DeserializationError,
-    MetadataError, NewSessionError, NextPageError, NextRowError, PagerExecutionError, PrepareError,
-    RequestAttemptError, RequestError, SerializationError, TypeCheckError, UseKeyspaceError,
+    BadKeyspaceName, ClusterStateTokenError, ConnectionError, ConnectionPoolError, DbError,
+    DeserializationError, MetadataError, NewSessionError, NextPageError, NextRowError,
+    PagerExecutionError, PrepareError, RequestAttemptError, RequestError, SerializationError,
+    TypeCheckError, UseKeyspaceError,
 };
 use std::fmt::{Debug, Display};
 use std::mem::size_of;
@@ -321,6 +322,21 @@ pub(crate) enum SessionOperationError<E> {
 
     #[error("Invalid argument: {0}")]
     InvalidArgument(String),
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum MetadataBridgeError {
+    #[error("Keyspace name is null")]
+    NullKeyspaceName,
+
+    #[error("Keyspace name is not valid UTF-8")]
+    InvalidKeyspaceNameUtf8(#[source] std::str::Utf8Error),
+
+    #[error("Invalid partition key encoding: {0}")]
+    InvalidPartitionKeyEncoding(#[from] SerializationError),
+
+    #[error("Token computation failed: {0}")]
+    TokenComputationFailed(#[from] ClusterStateTokenError),
 }
 
 /// Trait for converting Rust error types into pointers to C# exceptions using constructors from the TCB.
@@ -681,6 +697,26 @@ impl ErrorToException for TypeCheckError {
         ctors
             .invalid_type_exception_constructor
             .construct_from_rust(&self.to_string())
+    }
+}
+
+#[deny(clippy::wildcard_enum_match_arm)]
+impl ErrorToException for MetadataBridgeError {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
+        match self {
+            MetadataBridgeError::NullKeyspaceName
+            | MetadataBridgeError::InvalidKeyspaceNameUtf8(_) => ctors
+                .invalid_argument_exception_constructor
+                .construct_from_rust(&self.to_string()),
+
+            MetadataBridgeError::InvalidPartitionKeyEncoding(_) => ctors
+                .serialization_exception_constructor
+                .construct_from_rust(&self.to_string()),
+
+            MetadataBridgeError::TokenComputationFailed(_) => ctors
+                .invalid_query_constructor
+                .construct_from_rust(&self.to_string()),
+        }
     }
 }
 

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -802,6 +802,16 @@ pub struct FFINonNullPtr<'a, T: Sized> {
     _phantom: PhantomData<&'a ()>,
 }
 
+impl<'a, T> FFINonNullPtr<'a, T> {
+    #[expect(dead_code)]
+    pub(crate) fn from_ref(value: &'a T) -> Self {
+        Self {
+            ptr: NonNull::from(value),
+            _phantom: PhantomData,
+        }
+    }
+}
+
 // Manual implementation to avoid `T: Clone` bound.
 impl<T> Clone for FFINonNullPtr<'_, T> {
     fn clone(&self) -> Self {

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -803,7 +803,6 @@ pub struct FFINonNullPtr<'a, T: Sized> {
 }
 
 impl<'a, T> FFINonNullPtr<'a, T> {
-    #[expect(dead_code)]
     pub(crate) fn from_ref(value: &'a T) -> Self {
         Self {
             ptr: NonNull::from(value),

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -3,7 +3,7 @@ use crate::ffi::{
     ArcFFI, BridgedBorrowedSharedPtr, CSharpStr, FFI, FFIBool, FFINonNullPtr, FFIPtr, FFISlice,
     FFIStr, FromArc, IpOctets, RefFFI, ffi_callback_for_each,
 };
-use crate::pre_serialized_values::PreSerializedValues;
+use crate::pre_serialized_values::{PopulateValues, PopulateValuesContext, PreSerializedValues};
 use crate::row_set::column_type_to_code;
 use crate::task::ExceptionConstructors;
 use scylla::cluster::ClusterState;
@@ -143,6 +143,12 @@ struct RustReplicaBridge<'a> {
     cluster_state: &'a ClusterState,
     keyspace_name: &'a str,
     token: Token,
+    routing_mode: ReplicaRoutingMode<'a>,
+}
+
+enum ReplicaRoutingMode<'a> {
+    TabletAware { table_name: &'a str },
+    TokenRingCompat,
 }
 
 impl<'a> RustReplicaBridge<'a> {
@@ -161,6 +167,44 @@ impl<'a> RustReplicaBridge<'a> {
         let mut pre_serialized_partition_key = PreSerializedValues::new();
         pre_serialized_partition_key.add_value(partition_key)?;
         Ok(pre_serialized_partition_key)
+    }
+
+    /// Constructs a bridge for table-aware replica routing.
+    fn new_tablet_based(
+        cluster_state: &'a ClusterState,
+        keyspace: CSharpStr<'a>,
+        table: CSharpStr<'a>,
+        pre_serialized_partition_key: PreSerializedValues,
+    ) -> Result<Self, MetadataBridgeError> {
+        let keyspace_name = keyspace
+            .as_cstr()
+            .ok_or(MetadataBridgeError::NullKeyspaceName)?
+            .to_str()
+            .map_err(MetadataBridgeError::InvalidKeyspaceNameUtf8)?;
+        if keyspace_name.is_empty() {
+            return Err(MetadataBridgeError::EmptyKeyspaceName);
+        }
+        let table_name = table
+            .as_cstr()
+            .ok_or(MetadataBridgeError::NullTableName)?
+            .to_str()
+            .map_err(MetadataBridgeError::InvalidTableNameUtf8)?;
+        if table_name.is_empty() {
+            return Err(MetadataBridgeError::EmptyTableName);
+        }
+
+        let serialized_values = pre_serialized_partition_key.into_serialized_values();
+
+        let token = cluster_state
+            .compute_token_preserialized(keyspace_name, table_name, &serialized_values)
+            .map_err(MetadataBridgeError::TokenComputationFailed)?;
+
+        Ok(Self {
+            cluster_state,
+            keyspace_name,
+            token,
+            routing_mode: ReplicaRoutingMode::TabletAware { table_name },
+        })
     }
 
     /// Constructs a bridge for token-ring-based replica routing.
@@ -190,6 +234,7 @@ impl<'a> RustReplicaBridge<'a> {
             cluster_state,
             keyspace_name,
             token,
+            routing_mode: ReplicaRoutingMode::TokenRingCompat,
         })
     }
 
@@ -197,30 +242,31 @@ impl<'a> RustReplicaBridge<'a> {
         TableSpec::borrowed(self.keyspace_name, Self::NO_TABLE_NAME_PROVIDED)
     }
 
-    /// Returns the replication strategy that should be used for token-ring replica lookup.
+    /// Returns the replication strategy to use for replica lookup.
     ///
     /// If the keyspace metadata is available, we reuse its configured strategy.
     /// Otherwise we fall back to [`Self::FALLBACK_STRATEGY`], matching the driver.
-    fn token_ring_strategy(&self) -> &Strategy {
+    /// Used by both routing modes; on the tablet-aware path the strategy is only
+    /// consulted when the table is not tablet-based (tablet tables ignore it).
+    fn replication_strategy(&self) -> &Strategy {
         self.cluster_state
             .get_keyspace(self.keyspace_name)
             .map(|ks| &ks.strategy)
             .unwrap_or(&Self::FALLBACK_STRATEGY)
     }
 
-    fn get_replicas<'ctx>(
+    fn lookup_replicas<'ctx>(
         &self,
+        token: Token,
+        table_spec: &TableSpec<'_>,
+        strategy: &Strategy,
         callback_context: ReplicasCallbackContext<'ctx>,
         callback: OnReplicaPair<'ctx>,
     ) -> FFIMaybeException {
-        let table_spec = self.token_ring_table_spec();
-        let strategy = self.token_ring_strategy();
-        let replicas = self.cluster_state.replica_locator().replicas_for_token(
-            self.token,
-            strategy,
-            None,
-            &table_spec,
-        );
+        let replicas = self
+            .cluster_state
+            .replica_locator()
+            .replicas_for_token(token, strategy, None, table_spec);
         unsafe {
             ffi_callback_for_each(
                 callback_context,
@@ -230,6 +276,37 @@ impl<'a> RustReplicaBridge<'a> {
                     shard,
                 }),
             )
+        }
+    }
+
+    fn get_replicas<'ctx>(
+        &self,
+        callback_context: ReplicasCallbackContext<'ctx>,
+        callback: OnReplicaPair<'ctx>,
+    ) -> FFIMaybeException {
+        match self.routing_mode {
+            ReplicaRoutingMode::TabletAware { table_name } => {
+                let table_spec = TableSpec::borrowed(self.keyspace_name, table_name);
+                let strategy = self.replication_strategy();
+                self.lookup_replicas(
+                    self.token,
+                    &table_spec,
+                    strategy,
+                    callback_context,
+                    callback,
+                )
+            }
+            ReplicaRoutingMode::TokenRingCompat => {
+                let table_spec = self.token_ring_table_spec();
+                let strategy = self.replication_strategy();
+                self.lookup_replicas(
+                    self.token,
+                    &table_spec,
+                    strategy,
+                    callback_context,
+                    callback,
+                )
+            }
         }
     }
 }
@@ -857,6 +934,42 @@ pub extern "C" fn cluster_state_get_replicas_legacy_murmur3<'ctx>(
         cluster_state,
         keyspace,
         PartitionerName::Murmur3,
+        pre_serialized_partition_key,
+    ) {
+        Ok(b) => b,
+        Err(e) => return FFIMaybeException::from_error(e, exception_constructors),
+    };
+
+    bridge.get_replicas(callback_context, callback)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn cluster_state_get_replicas<'ctx>(
+    cluster_state_ptr: BridgedBorrowedSharedPtr<'_, ClusterState>,
+    keyspace: CSharpStr<'_>,
+    table: CSharpStr<'_>,
+    populate_values_context: PopulateValuesContext<'_>,
+    populate_values: PopulateValues,
+    callback_context: ReplicasCallbackContext<'ctx>,
+    callback: OnReplicaPair<'ctx>,
+    exception_constructors: &'static ExceptionConstructors,
+) -> FFIMaybeException {
+    let cluster_state =
+        ArcFFI::as_ref(cluster_state_ptr).expect("valid and non-null ClusterState pointer");
+
+    // The partition key supplied by the C# caller: one serialized value per key column
+    // (composite keys have several), assembled here via the populate callback.
+    let pre_serialized_partition_key =
+        match PreSerializedValues::from_populate_callback(populate_values_context, populate_values)
+        {
+            Ok(v) => v,
+            Err(exception) => return FFIMaybeException::from_exception(exception),
+        };
+
+    let bridge = match RustReplicaBridge::new_tablet_based(
+        cluster_state,
+        keyspace,
+        table,
         pre_serialized_partition_key,
     ) {
         Ok(b) => b,

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -1,12 +1,17 @@
-use crate::error_conversion::FFIMaybeException;
+use crate::error_conversion::{FFIMaybeException, MetadataBridgeError};
 use crate::ffi::{
-    ArcFFI, BridgedBorrowedSharedPtr, CSharpStr, FFI, FFIBool, FFIPtr, FFISlice, FFIStr, FromArc,
-    IpOctets, RefFFI, ffi_callback_for_each,
+    ArcFFI, BridgedBorrowedSharedPtr, CSharpStr, FFI, FFIBool, FFINonNullPtr, FFIPtr, FFISlice,
+    FFIStr, FromArc, IpOctets, RefFFI, ffi_callback_for_each,
 };
+use crate::pre_serialized_values::PreSerializedValues;
 use crate::row_set::column_type_to_code;
 use crate::task::ExceptionConstructors;
 use scylla::cluster::ClusterState;
-use scylla::cluster::metadata::ColumnType;
+use scylla::cluster::metadata::{ColumnType, Strategy};
+use scylla::frame::response::result::TableSpec;
+use scylla::routing::partitioner::PartitionerName;
+use scylla::routing::{Shard, Token};
+use uuid::Uuid;
 
 impl FFI for ClusterState {
     type Origin = FromArc;
@@ -45,6 +50,29 @@ pub struct CSharpHostData<'a> {
     datacenter: FFIStr<'a>,
     rack: FFIStr<'a>,
 }
+
+enum ReplicaList {}
+
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct ReplicasCallbackContext<'a>(FFINonNullPtr<'a, ReplicaList>);
+
+/// A replica handed to C#: a pointer to the node's host ID (`Uuid`, which C# copies
+/// into a `Guid`) plus its shard.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ReplicaPair<'a> {
+    host_id_ptr: FFINonNullPtr<'a, Uuid>,
+    shard: Shard,
+}
+
+// Ensure the memory layout matches C#'s expectation for a Guid/UUID
+const _: () = assert!(size_of::<Uuid>() == 16);
+
+type OnReplicaPair<'a> = unsafe extern "C" fn(
+    callback_context: ReplicasCallbackContext<'a>,
+    replica: ReplicaPair<'_>,
+) -> FFIMaybeException;
 
 /// Populates a C# RefreshContext with node information from the cluster state.
 /// For each node in the cluster state, this function:
@@ -107,6 +135,103 @@ pub extern "C" fn cluster_state_fill_nodes(
     }
 
     FFIMaybeException::ok()
+}
+
+/// Ephemeral per-call helper: separates validation, serialization, and token computation
+/// from the actual replica lookup and callback invocation logic.
+struct RustReplicaBridge<'a> {
+    cluster_state: &'a ClusterState,
+    keyspace_name: &'a str,
+    token: Token,
+}
+
+impl<'a> RustReplicaBridge<'a> {
+    const NO_TABLE_NAME_PROVIDED: &'static str = "";
+
+    /// Replication strategy used when the keyspace is absent from cluster metadata
+    /// (unknown keyspace, or the empty-keyspace sentinel of the legacy overloads).
+    ///
+    /// This mirrors the Rust driver's own replica lookup, which falls back to
+    /// `LocalStrategy` for an unknown keyspace (see `ClusterState::get_token_endpoints_iter`).
+    const FALLBACK_STRATEGY: Strategy = Strategy::LocalStrategy;
+
+    fn pre_serialized_values_from(
+        partition_key: FFISlice<'a, u8>,
+    ) -> Result<PreSerializedValues, MetadataBridgeError> {
+        let mut pre_serialized_partition_key = PreSerializedValues::new();
+        pre_serialized_partition_key.add_value(partition_key)?;
+        Ok(pre_serialized_partition_key)
+    }
+
+    /// Constructs a bridge for token-ring-based replica routing.
+    ///
+    /// This path intentionally supports Cassandra backward-compatible behavior where
+    /// callers may not provide table context. It computes token ownership against the
+    /// explicit partitioner (currently Murmur3) and then resolves replicas from the ring.
+    fn new_token_ring_based(
+        cluster_state: &'a ClusterState,
+        keyspace: CSharpStr<'a>,
+        partitioner: PartitionerName,
+        pre_serialized_partition_key: PreSerializedValues,
+    ) -> Result<Self, MetadataBridgeError> {
+        let keyspace_name = keyspace
+            .as_cstr()
+            .ok_or(MetadataBridgeError::NullKeyspaceName)?
+            .to_str()
+            .map_err(MetadataBridgeError::InvalidKeyspaceNameUtf8)?;
+
+        let serialized_values = pre_serialized_partition_key.into_serialized_values();
+
+        let token = cluster_state
+            .compute_token_preserialized_with_partitioner(&partitioner, &serialized_values)
+            .map_err(MetadataBridgeError::TokenComputationFailed)?;
+
+        Ok(Self {
+            cluster_state,
+            keyspace_name,
+            token,
+        })
+    }
+
+    fn token_ring_table_spec(&self) -> TableSpec<'a> {
+        TableSpec::borrowed(self.keyspace_name, Self::NO_TABLE_NAME_PROVIDED)
+    }
+
+    /// Returns the replication strategy that should be used for token-ring replica lookup.
+    ///
+    /// If the keyspace metadata is available, we reuse its configured strategy.
+    /// Otherwise we fall back to [`Self::FALLBACK_STRATEGY`], matching the driver.
+    fn token_ring_strategy(&self) -> &Strategy {
+        self.cluster_state
+            .get_keyspace(self.keyspace_name)
+            .map(|ks| &ks.strategy)
+            .unwrap_or(&Self::FALLBACK_STRATEGY)
+    }
+
+    fn get_replicas<'ctx>(
+        &self,
+        callback_context: ReplicasCallbackContext<'ctx>,
+        callback: OnReplicaPair<'ctx>,
+    ) -> FFIMaybeException {
+        let table_spec = self.token_ring_table_spec();
+        let strategy = self.token_ring_strategy();
+        let replicas = self.cluster_state.replica_locator().replicas_for_token(
+            self.token,
+            strategy,
+            None,
+            &table_spec,
+        );
+        unsafe {
+            ffi_callback_for_each(
+                callback_context,
+                callback,
+                replicas.into_iter().map(|(node, shard)| ReplicaPair {
+                    host_id_ptr: FFINonNullPtr::from_ref(&node.host_id),
+                    shard,
+                }),
+            )
+        }
+    }
 }
 
 /// Opaque type representing the C# KeyspaceNameList.
@@ -707,4 +832,36 @@ pub extern "C" fn cluster_state_get_table_metadata(
     }
 
     FFIMaybeException::ok()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn cluster_state_get_replicas_legacy_murmur3<'ctx>(
+    cluster_state_ptr: BridgedBorrowedSharedPtr<'_, ClusterState>,
+    keyspace: CSharpStr<'_>,
+    partition_key: FFISlice<'_, u8>,
+    callback_context: ReplicasCallbackContext<'ctx>,
+    callback: OnReplicaPair<'ctx>,
+    exception_constructors: &'static ExceptionConstructors,
+) -> FFIMaybeException {
+    let cluster_state =
+        ArcFFI::as_ref(cluster_state_ptr).expect("valid and non-null ClusterState pointer");
+
+    // The partition key supplied by the C# caller, already serialized to wire bytes.
+    let pre_serialized_partition_key =
+        match RustReplicaBridge::pre_serialized_values_from(partition_key) {
+            Ok(value) => value,
+            Err(e) => return FFIMaybeException::from_error(e, exception_constructors),
+        };
+
+    let bridge = match RustReplicaBridge::new_token_ring_based(
+        cluster_state,
+        keyspace,
+        PartitionerName::Murmur3,
+        pre_serialized_partition_key,
+    ) {
+        Ok(b) => b,
+        Err(e) => return FFIMaybeException::from_error(e, exception_constructors),
+    };
+
+    bridge.get_replicas(callback_context, callback)
 }

--- a/src/Cassandra.IntegrationTests/Core/MetadataGetReplicasTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MetadataGetReplicasTests.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Cassandra.IntegrationTests.TestBase;
+using Cassandra.Tests;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Cassandra.IntegrationTests.Core
+{
+    [Category(TestCategory.Short), Category(TestCategory.RealCluster)]
+    public class MetadataGetReplicasTests : SharedClusterTest
+    {
+        public MetadataGetReplicasTests() : base(3)
+        {
+        }
+
+        #region Simple Partition Key Tests
+
+        [TestCase("text", "simple_text_key", TestName = "GetReplicas_SimpleKey_Text")]
+        [TestCase("int", 12345, TestName = "GetReplicas_SimpleKey_Int")]
+        [TestCase("bigint", 9876543210L, TestName = "GetReplicas_SimpleKey_BigInt")]
+        [TestCase("boolean", true, TestName = "GetReplicas_SimpleKey_Boolean")]
+        [TestCase("float", 3.14f, TestName = "GetReplicas_SimpleKey_Float")]
+        [TestCase("double", 2.718281828, TestName = "GetReplicas_SimpleKey_Double")]
+        public void GetReplicas_ReturnsValidReplicas_ForSimplePartitionKey(string cqlType, object keyValue)
+        {
+            var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+            Session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (pk {cqlType} PRIMARY KEY, value text)");
+            var allHosts = Cluster.AllHosts();
+
+            var replicas = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, new object[] { keyValue });
+
+            Assert.IsNotNull(replicas);
+            Assert.Greater(replicas.Count, 0);
+            foreach (var replica in replicas)
+            {
+                Assert.IsNotNull(replica.Host);
+                Assert.IsTrue(allHosts.Any(h => h.Address.Equals(replica.Host.Address)));
+            }
+        }
+
+        [Test]
+        public void GetReplicas_ReturnsConsistentReplicas_ForSimpleKey_UUID()
+        {
+            var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+            Session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (pk uuid PRIMARY KEY, value text)");
+            var uuid = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+
+            var replicas1 = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, new object[] { uuid });
+            var replicas2 = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, new object[] { uuid });
+
+            Assert.AreEqual(replicas1.Count, replicas2.Count);
+            var addresses1 = replicas1.Select(r => r.Host.Address).OrderBy(a => a.ToString()).ToList();
+            var addresses2 = replicas2.Select(r => r.Host.Address).OrderBy(a => a.ToString()).ToList();
+            CollectionAssert.AreEqual(addresses1, addresses2);
+        }
+
+        [TestCase("", TestName = "GetReplicas_SimpleKey_EmptyString")]
+        [TestCase("a", TestName = "GetReplicas_SimpleKey_SingleChar")]
+        [TestCase("very_long_key_with_many_characters_to_test_edge_cases_" +
+                  "abcdefghijklmnopqrstuvwxyz_0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+                  TestName = "GetReplicas_SimpleKey_LongString")]
+        [TestCase("key with spaces and special chars: !@#$%", TestName = "GetReplicas_SimpleKey_SpecialChars")]
+        public void GetReplicas_HandlesEdgeCases_ForTextKeys(string keyValue)
+        {
+            var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+            Session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (pk text PRIMARY KEY, value text)");
+            var replicas = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, new object[] { keyValue });
+
+            Assert.IsNotNull(replicas);
+            Assert.Greater(replicas.Count, 0);
+        }
+
+        [TestCase(0, TestName = "GetReplicas_SimpleKey_Int_Zero")]
+        [TestCase(-1, TestName = "GetReplicas_SimpleKey_Int_Negative")]
+        [TestCase(int.MaxValue, TestName = "GetReplicas_SimpleKey_Int_MaxValue")]
+        [TestCase(int.MinValue, TestName = "GetReplicas_SimpleKey_Int_MinValue")]
+        public void GetReplicas_HandlesEdgeCases_ForIntKeys(int keyValue)
+        {
+            var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+            Session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (pk int PRIMARY KEY, value text)");
+            var replicas = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, new object[] { keyValue });
+
+            Assert.IsNotNull(replicas);
+            Assert.Greater(replicas.Count, 0);
+        }
+
+        #endregion
+
+        #region Composite Partition Key Tests
+
+        [TestCase("text", "int", "key1", 100, TestName = "GetReplicas_CompositeKey_TextInt")]
+        [TestCase("int", "text", 200, "key2", TestName = "GetReplicas_CompositeKey_IntText")]
+        [TestCase("bigint", "boolean", 9999999L, true, TestName = "GetReplicas_CompositeKey_BigIntBoolean")]
+        [TestCase("text", "text", "pk1", "pk2", TestName = "GetReplicas_CompositeKey_TextText")]
+        public void GetReplicas_ReturnsValidReplicas_ForCompositePartitionKey_TwoComponents(
+            string type1, string type2, object value1, object value2)
+        {
+            var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+            Session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (pk1 {type1}, pk2 {type2}, value text, PRIMARY KEY ((pk1, pk2)))");
+            var allHosts = Cluster.AllHosts();
+
+            var replicas = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, new object[] { value1, value2 });
+
+            Assert.IsNotNull(replicas);
+            Assert.Greater(replicas.Count, 0);
+            foreach (var replica in replicas)
+            {
+                Assert.IsNotNull(replica.Host);
+                Assert.IsTrue(allHosts.Any(h => h.Address.Equals(replica.Host.Address)));
+            }
+        }
+
+        [Test]
+        public void GetReplicas_ReturnsValidReplicas_ForCompositeKey_ThreeComponents()
+        {
+            var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+            Session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (pk1 text, pk2 int, pk3 bigint, value text, PRIMARY KEY ((pk1, pk2, pk3)))");
+            var replicas = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, new object[] { "component1", 42, 9876543210L });
+
+            Assert.IsNotNull(replicas);
+            Assert.Greater(replicas.Count, 0);
+        }
+
+        [Test]
+        public void GetReplicas_ReturnsValidReplicas_ForCompositeKey_FourComponents()
+        {
+            var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+            Session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (pk1 text, pk2 int, pk3 boolean, pk4 double, value text, " +
+                           $"PRIMARY KEY ((pk1, pk2, pk3, pk4)))");
+            var replicas = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, new object[] { "part1", 100, false, 3.14159 });
+
+            Assert.IsNotNull(replicas);
+            Assert.Greater(replicas.Count, 0);
+        }
+
+        [Test]
+        public void GetReplicas_ReturnsConsistentReplicas_ForSameCompositeKey()
+        {
+            var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+            Session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (pk1 text, pk2 int, value text, PRIMARY KEY ((pk1, pk2)))");
+            IReadOnlyList<object> key = new object[] { "consistency_test", 999 };
+
+            var replicas1 = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, key);
+            var replicas2 = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, key);
+            var replicas3 = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, key);
+
+            Assert.AreEqual(replicas1.Count, replicas2.Count);
+            Assert.AreEqual(replicas1.Count, replicas3.Count);
+            var addresses1 = replicas1.Select(r => r.Host.Address).OrderBy(a => a.ToString()).ToList();
+            var addresses2 = replicas2.Select(r => r.Host.Address).OrderBy(a => a.ToString()).ToList();
+            var addresses3 = replicas3.Select(r => r.Host.Address).OrderBy(a => a.ToString()).ToList();
+            CollectionAssert.AreEqual(addresses1, addresses2);
+            CollectionAssert.AreEqual(addresses1, addresses3);
+        }
+
+        [TestCase("", 0, TestName = "GetReplicas_CompositeKey_EmptyStringAndZero")]
+        [TestCase("key", int.MaxValue, TestName = "GetReplicas_CompositeKey_IntMaxValue")]
+        [TestCase("key", int.MinValue, TestName = "GetReplicas_CompositeKey_IntMinValue")]
+        public void GetReplicas_HandlesEdgeCases_ForCompositeKeys(string textValue, int intValue)
+        {
+            var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+            Session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (pk1 text, pk2 int, value text, PRIMARY KEY ((pk1, pk2)))");
+            var replicas = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, new object[] { textValue, intValue });
+
+            Assert.IsNotNull(replicas);
+            Assert.Greater(replicas.Count, 0);
+        }
+
+        [Test]
+        public void GetReplicas_DifferentKeys_ReturnValidReplicas()
+        {
+            var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+            Session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (pk1 text, pk2 int, value text, PRIMARY KEY ((pk1, pk2)))");
+            var keys = new object[][]
+            {
+                new object[] { "key_a", 1 },
+                new object[] { "key_b", 2 },
+                new object[] { "key_c", 3 },
+                new object[] { "different_prefix", 1000 },
+            };
+
+            var allReplicas = keys.Select(k => Cluster.Metadata.GetReplicas(KeyspaceName, tableName, k)).ToList();
+
+            foreach (var replicas in allReplicas)
+            {
+                Assert.IsNotNull(replicas);
+                Assert.Greater(replicas.Count, 0);
+            }
+        }
+
+        #endregion
+
+        [Test]
+        public void GetReplicas_ReturnsHosts_ForGivenPartitionKey()
+        {
+            var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+            Session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (id text PRIMARY KEY, value text)");
+            var allHosts = Cluster.AllHosts();
+
+            var replicas = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, new object[] { "key1" });
+
+            Assert.IsNotNull(replicas);
+            Assert.Greater(replicas.Count, 0);
+            foreach (var replica in replicas)
+            {
+                Assert.IsNotNull(replica.Host);
+                Assert.IsTrue(allHosts.Any(h => h.Address.Equals(replica.Host.Address)));
+            }
+        }
+
+        [Test]
+        public void GetReplicas_ReturnsSameReplicas_ForSameKey()
+        {
+            var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+            Session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (id text PRIMARY KEY, value text)");
+            var replicas1 = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, new object[] { "consistent_key" });
+            var replicas2 = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, new object[] { "consistent_key" });
+
+            Assert.AreEqual(replicas1.Count, replicas2.Count);
+            var addresses1 = replicas1.Select(r => r.Host.Address).OrderBy(a => a.ToString()).ToList();
+            var addresses2 = replicas2.Select(r => r.Host.Address).OrderBy(a => a.ToString()).ToList();
+            CollectionAssert.AreEqual(addresses1, addresses2);
+        }
+
+        #region NetworkTopologyStrategy / tablet-aware path
+
+        [Test]
+        public void GetReplicas_ReturnsCorrectReplicaCount_ForNetworkTopologyStrategy()
+        {
+            var dc = Cluster.AllHosts().First().Datacenter;
+            var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLowerInvariant();
+            Session.Execute($"CREATE KEYSPACE {keyspaceName} WITH replication = " +
+                            $"{{ 'class' : 'NetworkTopologyStrategy', '{dc}' : 2 }}");
+            var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+            Session.Execute($"CREATE TABLE {keyspaceName}.{tableName} (id text PRIMARY KEY, value text)");
+            var allHosts = Cluster.AllHosts();
+
+            var replicas = Cluster.Metadata.GetReplicas(keyspaceName, tableName, new object[] { "key1" });
+
+            Assert.IsNotNull(replicas);
+            Assert.AreEqual(2, replicas.Count);
+            foreach (var replica in replicas)
+            {
+                Assert.IsNotNull(replica.Host);
+                Assert.IsTrue(allHosts.Any(h => h.Address.Equals(replica.Host.Address)));
+            }
+        }
+
+        #endregion
+
+        #region Cluster facade delegation
+
+        [Test]
+        public void GetReplicas_Cluster_DelegatesToMetadata()
+        {
+            var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+            Session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (id text PRIMARY KEY, value text)");
+            IReadOnlyList<object> key = new object[] { "facade_key" };
+
+            var viaCluster = Cluster.GetReplicas(KeyspaceName, tableName, key);
+            var viaMetadata = Cluster.Metadata.GetReplicas(KeyspaceName, tableName, key);
+
+            Assert.IsNotNull(viaCluster);
+            var clusterAddresses = viaCluster.Select(r => r.Host.Address).OrderBy(a => a.ToString()).ToList();
+            var metadataAddresses = viaMetadata.Select(r => r.Host.Address).OrderBy(a => a.ToString()).ToList();
+            CollectionAssert.AreEqual(metadataAddresses, clusterAddresses);
+        }
+
+        #endregion
+
+        #region Argument validation
+
+        [Test]
+        public void GetReplicas_Throws_WhenKeyspaceIsNull()
+        {
+            NUnit.Framework.Assert.Throws<ArgumentNullException>(
+                () => Cluster.Metadata.GetReplicas(null, "table", new object[] { "key" }));
+        }
+
+        [Test]
+        public void GetReplicas_Throws_WhenTableIsNull()
+        {
+            NUnit.Framework.Assert.Throws<ArgumentNullException>(
+                () => Cluster.Metadata.GetReplicas("keyspace", null, new object[] { "key" }));
+        }
+
+        [Test]
+        public void GetReplicas_Throws_WhenPartitionKeyValuesIsNull()
+        {
+            NUnit.Framework.Assert.Throws<ArgumentNullException>(
+                () => Cluster.Metadata.GetReplicas("keyspace", "table", null));
+        }
+
+        [Test]
+        public void GetReplicas_Throws_WhenPartitionKeyValuesIsEmpty()
+        {
+            NUnit.Framework.Assert.Throws<ArgumentException>(
+                () => Cluster.Metadata.GetReplicas("keyspace", "table", Array.Empty<object>()));
+        }
+
+        #endregion
+    }
+
+    // Parametrized by node count only: replication factor is a per-keyspace setting, not a
+    // topology, so all RF cases for a given cluster size share a single CCM cluster instead of
+    // spinning up one cluster per (nodeCount, RF) pair. We cap at 3 nodes to keep CI affordable;
+    // 3 nodes already covers the structurally distinct cases (single owner, partial, all nodes).
+    [Category(TestCategory.Short), Category(TestCategory.RealCluster)]
+    [TestFixture(1)]
+    [TestFixture(3)]
+    public class MetadataGetReplicasReplicationFactorTests : SharedClusterTest
+    {
+        public MetadataGetReplicasReplicationFactorTests(int nodeCount) : base(nodeCount)
+        {
+        }
+
+        [Test]
+        public void GetReplicas_ReturnsReplicaCountMatchingReplicationFactor()
+        {
+            for (var rf = 1; rf <= AmountOfNodes; rf++)
+            {
+                var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLowerInvariant() + $"_rf{rf}_n{AmountOfNodes}";
+                Session.Execute($"CREATE KEYSPACE IF NOT EXISTS {keyspaceName} WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : {rf} }}");
+                var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
+                Session.Execute($"CREATE TABLE {keyspaceName}.{tableName} (id text PRIMARY KEY, value text)");
+
+                var replicas = Cluster.Metadata.GetReplicas(keyspaceName, tableName, new object[] { "key1" });
+
+                Assert.IsNotNull(replicas);
+                Assert.AreEqual(rf, replicas.Count, $"RF={rf} on {AmountOfNodes}-node cluster");
+            }
+        }
+    }
+}

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -244,15 +244,21 @@ namespace Cassandra
         }
 
         /// <inheritdoc />
+        [Obsolete("This overload does not support tablet routing. Use GetReplicas(keyspace, table, partitionKeyValues) instead.")]
         public ICollection<HostShard> GetReplicas(byte[] partitionKey)
         {
+#pragma warning disable CS0618
             return Metadata.GetReplicas(partitionKey);
+#pragma warning restore CS0618
         }
 
         /// <inheritdoc />
+        [Obsolete("This overload does not support tablet routing. Use GetReplicas(keyspace, table, partitionKeyValues) instead.")]
         public ICollection<HostShard> GetReplicas(string keyspace, byte[] partitionKey)
         {
+#pragma warning disable CS0618
             return Metadata.GetReplicas(keyspace, partitionKey);
+#pragma warning restore CS0618
         }
 
         /// <inheritdoc />

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -138,7 +138,6 @@ namespace Cassandra
         private Cluster(IEnumerable<object> contactPoints, Configuration configuration)
         {
             Configuration = configuration;
-            _metadata = new Metadata(configuration, GetActiveSessionOrThrow);
             var protocolVersion = _maxProtocolVersion;
             if (Configuration.ProtocolOptions.MaxProtocolVersionValue != null &&
                 Configuration.ProtocolOptions.MaxProtocolVersionValue.Value.IsSupported(configuration))
@@ -149,6 +148,7 @@ namespace Cassandra
                 protocolVersion,
                 Configuration.Policies.ColumnEncryptionPolicy,
                 Configuration.TypeSerializers);
+            _metadata = new Metadata(configuration, GetActiveSessionOrThrow, _serializerManager);
             _contactPoints = configuration.ParseContactPoints(contactPoints);
         }
 
@@ -253,6 +253,12 @@ namespace Cassandra
         public ICollection<HostShard> GetReplicas(string keyspace, byte[] partitionKey)
         {
             return Metadata.GetReplicas(keyspace, partitionKey);
+        }
+
+        /// <inheritdoc />
+        public ICollection<HostShard> GetReplicas(string keyspace, string table, IReadOnlyList<object> partitionKeyValues)
+        {
+            return Metadata.GetReplicas(keyspace, table, partitionKeyValues);
         }
 
         /// <inheritdoc />

--- a/src/Cassandra/ICluster.cs
+++ b/src/Cassandra/ICluster.cs
@@ -112,6 +112,7 @@ namespace Cassandra
         /// </summary>
         /// <param name="partitionKey">Byte array representing the partition key</param>
         /// <returns></returns>
+        [Obsolete("This overload does not support tablet routing. Use GetReplicas(keyspace, table, partitionKeyValues) instead.")]
         ICollection<HostShard> GetReplicas(byte[] partitionKey);
 
         /// <summary>
@@ -120,6 +121,7 @@ namespace Cassandra
         /// <param name="keyspace">Byte array representing the partition key</param>
         /// <param name="partitionKey">Byte array representing the partition key</param>
         /// <returns></returns>
+        [Obsolete("This overload does not support tablet routing. Use GetReplicas(keyspace, table, partitionKeyValues) instead.")]
         ICollection<HostShard> GetReplicas(string keyspace, byte[] partitionKey);
 
         /// <summary>

--- a/src/Cassandra/ICluster.cs
+++ b/src/Cassandra/ICluster.cs
@@ -123,6 +123,19 @@ namespace Cassandra
         ICollection<HostShard> GetReplicas(string keyspace, byte[] partitionKey);
 
         /// <summary>
+        /// Gets a collection of replicas for a given partition key on a given keyspace and table.
+        /// The partition key values are serialized using the configured type serializers.
+        /// This method enables tablet-aware routing and uses the table's configured partitioner.
+        /// </summary>
+        /// <param name="keyspace">The keyspace name (case-sensitive)</param>
+        /// <param name="table">The table name (case-sensitive)</param>
+        /// <param name="partitionKeyValues">The partition key column values in order</param>
+        /// <returns>A collection of replicas for the partition</returns>
+        /// <exception cref="ArgumentNullException">If keyspace, table, or partitionKeyValues is null</exception>
+        /// <exception cref="InvalidOperationException">If the cluster is not connected or metadata is not ready</exception>
+        ICollection<HostShard> GetReplicas(string keyspace, string table, IReadOnlyList<object> partitionKeyValues);
+
+        /// <summary>
         ///  Shutdown this cluster instance. This closes all connections from all the
         ///  sessions of this <c>* Cluster</c> instance and reclaim all resources
         ///  used by it. <p> This method has no effect if the cluster was already shutdown.</p>

--- a/src/Cassandra/Metadata.cs
+++ b/src/Cassandra/Metadata.cs
@@ -372,6 +372,7 @@ namespace Cassandra
         /// a routing key already computed by the driver, for example from
         /// <c>prepared.Bind(values).RoutingKey.RawRoutingKey</c>.
         /// </remarks>
+        [Obsolete("This overload does not support tablet routing. Use GetReplicas(keyspace, table, partitionKeyValues) instead.")]
         public ICollection<HostShard> GetReplicas(string keyspaceName, byte[] partitionKey)
         {
             ArgumentNullException.ThrowIfNull(partitionKey);
@@ -388,9 +389,12 @@ namespace Cassandra
                 keyspaceName ?? NoSpecifiedKeyspace, snapshot.Registry.HostsById, partitionKey);
         }
 
+        [Obsolete("This overload does not support tablet routing. Use GetReplicas(keyspace, table, partitionKeyValues) instead.")]
         public ICollection<HostShard> GetReplicas(byte[] partitionKey)
         {
+#pragma warning disable CS0618
             return GetReplicas(NoSpecifiedKeyspace, partitionKey);
+#pragma warning restore CS0618
         }
 
         /// <summary>

--- a/src/Cassandra/Metadata.cs
+++ b/src/Cassandra/Metadata.cs
@@ -15,9 +15,7 @@
 //
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,7 +35,6 @@ namespace Cassandra
 
         public event SchemaChangedEventHandler SchemaChangedEvent;
 #pragma warning restore CS0067
-
         /// <summary>
         ///  Returns the name of currently connected cluster.
         /// </summary>
@@ -244,19 +241,6 @@ namespace Cassandra
         }
 
         /// <summary>
-        /// Get the replicas for a given partition key and keyspace
-        /// </summary>
-        public ICollection<HostShard> GetReplicas(string keyspaceName, byte[] partitionKey)
-        {
-            throw new NotImplementedException();
-        }
-
-        public ICollection<HostShard> GetReplicas(byte[] partitionKey)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
         /// Returns a registry instance, refreshing topology if needed.
         /// </summary>
         private ClusterSnapshot GetSnapshot()
@@ -356,6 +340,39 @@ namespace Cassandra
                     _session.DecreaseReferenceCount();
                 }
             }
+        }
+
+        /// <summary>
+        /// When the caller doesn't specify a keyspace (either by passing `null` or using
+        /// the overload that omits the keyspace), we send this empty sentinel value to
+        /// the Rust bridge. No keyspace matches the empty name in cluster metadata, so the
+        /// bridge applies its fallback replication strategy (LocalStrategy), which resolves
+        /// to the single primary token owner.
+        /// </summary>
+        private const string NoSpecifiedKeyspace = "";
+
+        /// <summary>
+        /// Get the replicas for a given partition key and keyspace
+        /// </summary>
+        public ICollection<HostShard> GetReplicas(string keyspaceName, byte[] partitionKey)
+        {
+            ArgumentNullException.ThrowIfNull(partitionKey);
+
+            using var snapshot = GetSnapshot();
+
+            // This legacy overload takes no table name, so token computation is forced to
+            // Murmur3. The original driver resolved the partitioner from system.local instead;
+            // FIXME: bridge that lookup from the Rust driver so non-Murmur3 clusters are handled.
+
+            // Coalesce null keyspace to the empty sentinel; with no matching keyspace the Rust
+            // side falls back to LocalStrategy, returning only the primary token owner.
+            return snapshot.State.GetReplicasLegacyMurmur3(
+                keyspaceName ?? NoSpecifiedKeyspace, snapshot.Registry.HostsById, partitionKey);
+        }
+
+        public ICollection<HostShard> GetReplicas(byte[] partitionKey)
+        {
+            return GetReplicas(NoSpecifiedKeyspace, partitionKey);
         }
 
         /// <summary>

--- a/src/Cassandra/Metadata.cs
+++ b/src/Cassandra/Metadata.cs
@@ -20,6 +20,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Cassandra.Data.Linq;
+using Cassandra.Serialization;
 using Cassandra.Tasks;
 
 namespace Cassandra
@@ -55,6 +56,11 @@ namespace Cassandra
         // Provided by Cluster during construction. It never returns null.
         // It either returns a valid Session or throws InvalidOperationException.
         private readonly Func<Session> _getActiveSessionOrThrow;
+
+        // Cluster's serializer manager — carries protocol version, custom type serializers,
+        // UDT mappings, and column encryption policy. Used wherever the partition key (or
+        // other CLR values) must be encoded to the same bytes the server would see on the wire.
+        private readonly ISerializerManager _serializerManager;
 
         internal class RefreshContext(IReadOnlyDictionary<Guid, Host> oldHosts)
         {
@@ -194,10 +200,14 @@ namespace Cassandra
 
         private readonly object _hostLock = new object();
 
-        internal Metadata(Configuration configuration, Func<Session> getActiveSessionOrThrow)
+        internal Metadata(
+            Configuration configuration,
+            Func<Session> getActiveSessionOrThrow,
+            ISerializerManager serializerManager)
         {
             Configuration = configuration;
             _getActiveSessionOrThrow = getActiveSessionOrThrow ?? throw new ArgumentNullException(nameof(getActiveSessionOrThrow));
+            _serializerManager = serializerManager ?? throw new ArgumentNullException(nameof(serializerManager));
         }
 
         public void Dispose()
@@ -301,7 +311,6 @@ namespace Cassandra
             }
         }
 
-
         private ClusterStateLease AcquireClusterState()
         {
             var session = _getActiveSessionOrThrow();
@@ -354,6 +363,15 @@ namespace Cassandra
         /// <summary>
         /// Get the replicas for a given partition key and keyspace
         /// </summary>
+        /// <remarks>
+        /// This overload is not table-aware and always uses the Murmur3 partitioner.
+        /// It does not support tablet-aware routing. Prefer
+        /// <see cref="GetReplicas(string, string, IReadOnlyList{object})"/> instead.
+        /// The <paramref name="partitionKey"/> must already be serialized in routing-key format.
+        /// There is no dedicated public serializer for this legacy API; existing code can often reuse
+        /// a routing key already computed by the driver, for example from
+        /// <c>prepared.Bind(values).RoutingKey.RawRoutingKey</c>.
+        /// </remarks>
         public ICollection<HostShard> GetReplicas(string keyspaceName, byte[] partitionKey)
         {
             ArgumentNullException.ThrowIfNull(partitionKey);
@@ -373,6 +391,30 @@ namespace Cassandra
         public ICollection<HostShard> GetReplicas(byte[] partitionKey)
         {
             return GetReplicas(NoSpecifiedKeyspace, partitionKey);
+        }
+
+        /// <summary>
+        /// Gets replicas for a partition key using table-aware routing.
+        /// Each partition key column value is serialized individually and passed to the Rust bridge,
+        /// enabling tablet-aware replica lookup and proper partitioner selection.
+        /// </summary>
+        public ICollection<HostShard> GetReplicas(string keyspace, string table, IReadOnlyList<object> partitionKeyValues)
+        {
+            ArgumentNullException.ThrowIfNull(keyspace);
+            ArgumentNullException.ThrowIfNull(table);
+            ArgumentNullException.ThrowIfNull(partitionKeyValues);
+
+            if (partitionKeyValues.Count == 0)
+                throw new ArgumentException("Partition key values cannot be empty", nameof(partitionKeyValues));
+
+            // The borrowed clone keeps the native state's refcount elevated for the duration
+            // of the FFI call, so a concurrent cache swap on another thread can only bring it
+            // down to 1, never to 0 — the native pointer stays valid until `using` disposes
+            // the clone here.
+            using var snapshot = GetSnapshot();
+            return snapshot.State.GetReplicas(
+                keyspace, table, snapshot.Registry.HostsById, partitionKeyValues,
+                _serializerManager.GetCurrentSerializer());
         }
 
         /// <summary>

--- a/src/Cassandra/RustBridge/BridgedClusterState.cs
+++ b/src/Cassandra/RustBridge/BridgedClusterState.cs
@@ -1,9 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Net;
 using System.Runtime.CompilerServices;
 using static Cassandra.RustBridge;
-using System.Collections.Generic;
 
 namespace Cassandra
 {
@@ -36,6 +36,15 @@ namespace Cassandra
             IntPtr callback);
 
         private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, CSharpHostData, FFIMaybeException> AddHostPtr = &AddHostToList;
+        [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
+        private static extern RustBridge.FFIMaybeException cluster_state_get_replicas_legacy_murmur3(
+            IntPtr clusterStatePtr,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string keyspace,
+            RustBridge.FFISlice<byte> partitionKey,
+            IntPtr callbackContext,
+            IntPtr callback,
+            IntPtr constructors);
+
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
         private static unsafe FFIMaybeException AddHostToList(
             IntPtr contextPtr,
@@ -105,6 +114,81 @@ namespace Cassandra
             GC.KeepAlive(context);
         }
 
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct ReplicaPair
+        {
+            // Points to a 16-byte UUID (Rust side: *const [u8; 16]).
+            public readonly IntPtr HostIdBytesPtr;
+            public readonly uint Shard;
+        }
+
+        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, ReplicaPair, RustBridge.FFIMaybeException> OnReplicaPairPtr = &OnReplicaPairCallback;
+
+        [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        private static unsafe RustBridge.FFIMaybeException OnReplicaPairCallback(IntPtr contextPtr, ReplicaPair replica)
+        {
+            try
+            {
+                var context = Unsafe.AsRef<GetReplicasContext>((void*)contextPtr);
+
+                const int HostIdLength = 16;
+                var hostIdBytes = new ReadOnlySpan<byte>((void*)replica.HostIdBytesPtr, HostIdLength);
+                var hostId = new Guid(hostIdBytes);
+
+                if (context.HostsById.TryGetValue(hostId, out var host))
+                {
+                    context.AddReplica(new HostShard(host, (int)replica.Shard));
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"Retrieved an unrecognized Replica: hostId={hostId}, shard={replica.Shard}");
+                }
+
+                return RustBridge.FFIMaybeException.Ok();
+            }
+            catch (Exception ex)
+            {
+                return RustBridge.FFIMaybeException.FromException(ex);
+            }
+        }
+
+        private class GetReplicasContext(IReadOnlyDictionary<Guid, Host> hostsById)
+        {
+            private readonly List<HostShard> _replicas = [];
+            internal IReadOnlyDictionary<Guid, Host> HostsById { get; } = hostsById;
+
+            internal void AddReplica(HostShard hostShard) => _replicas.Add(hostShard);
+            internal ICollection<HostShard> Replicas => _replicas;
+        }
+
+        internal ICollection<HostShard> GetReplicasLegacyMurmur3(
+            string keyspace, IReadOnlyDictionary<Guid, Host> hostsById, byte[] partitionKey)
+        {
+            var context = new GetReplicasContext(hostsById);
+
+            unsafe
+            {
+                fixed (byte* partitionKeyPtr = partitionKey)
+                {
+                    var partitionKeySlice = new FFISlice<byte>(
+                        (IntPtr)partitionKeyPtr,
+                        (nuint)partitionKey.Length
+                    );
+                    RunWithIncrement(ptr => cluster_state_get_replicas_legacy_murmur3(
+                        ptr,
+                        keyspace,
+                        partitionKeySlice,
+                        (IntPtr)Unsafe.AsPointer(ref context),
+                        (IntPtr)OnReplicaPairPtr,
+                        (IntPtr)Globals.ConstructorsPtr
+                    ));
+                }
+            }
+
+            GC.KeepAlive(context);
+            return context.Replicas;
+        }
         [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern FFIMaybeException cluster_state_get_keyspace_metadata(
             IntPtr clusterState,

--- a/src/Cassandra/RustBridge/BridgedClusterState.cs
+++ b/src/Cassandra/RustBridge/BridgedClusterState.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Net;
 using System.Runtime.CompilerServices;
+using Cassandra.Serialization;
 using static Cassandra.RustBridge;
 
 namespace Cassandra
@@ -42,6 +43,17 @@ namespace Cassandra
             [MarshalAs(UnmanagedType.LPUTF8Str)] string keyspace,
             RustBridge.FFISlice<byte> partitionKey,
             IntPtr callbackContext,
+            IntPtr callback,
+            IntPtr constructors);
+
+        [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
+        private static extern RustBridge.FFIMaybeException cluster_state_get_replicas(
+            IntPtr clusterStatePtr,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string keyspace,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string table,
+            IntPtr populateValuesContext,
+            IntPtr populateValuesCallback,
+            IntPtr callbackState,
             IntPtr callback,
             IntPtr constructors);
 
@@ -189,6 +201,37 @@ namespace Cassandra
             GC.KeepAlive(context);
             return context.Replicas;
         }
+
+        /// <summary>
+        /// Gets replicas using table-aware routing.
+        /// Each partition key value is serialized individually via the populate-callback pattern.
+        /// </summary>
+        internal unsafe ICollection<HostShard> GetReplicas(
+            string keyspace,
+            string table,
+            IReadOnlyDictionary<Guid, Host> hostsById,
+            IReadOnlyList<object> partitionKeyValues,
+            ISerializer serializer)
+        {
+            var context = new GetReplicasContext(hostsById);
+            var populateCtx = SerializationHandler.CreateContext(partitionKeyValues, serializer);
+
+            RunWithIncrement(ptr => cluster_state_get_replicas(
+                ptr,
+                keyspace,
+                table,
+                (IntPtr)Unsafe.AsPointer(ref populateCtx),
+                (IntPtr)SerializationHandler.PopulateValuesPtr,
+                (IntPtr)Unsafe.AsPointer(ref context),
+                (IntPtr)OnReplicaPairPtr,
+                (IntPtr)Globals.ConstructorsPtr
+            ));
+
+            GC.KeepAlive(populateCtx);
+            GC.KeepAlive(context);
+            return context.Replicas;
+        }
+
         [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern FFIMaybeException cluster_state_get_keyspace_metadata(
             IntPtr clusterState,


### PR DESCRIPTION
# Implement Metadata GetReplicas API via Rust Bridge

## Overview

This PR implements the C# Driver's `Metadata` and `Cluster` replica retrieval API by bridging to the Rust Driver's `ClusterState` and its internal `ReplicaLocator`. It enables efficient replica lookups using the Rust driver's topology- and replication-aware machinery, while maintaining compatibility with the existing C# driver semantics.

In addition to the existing serialized-partition-key API, this PR also extends the public API with overloads that accept **non-serialized partition key values**. These values are serialized per partition-key column on the C# side and passed to Rust as `PreSerializedValues`, which allows the Rust side to compute tokens without requiring the caller to manually compose a serialized partition key blob.

## Implemented API

### Cluster API (delegates to Metadata)
```csharp
public ICollection<HostShard> GetReplicas(byte[] partitionKey);
public ICollection<HostShard> GetReplicas(string keyspace, byte[] partitionKey);
public ICollection<HostShard> GetReplicas(string keyspace, string table, IReadOnlyList<object> partitionKeyValues);
```

### Metadata API
```csharp
public ICollection<HostShard> GetReplicas(string keyspaceName, byte[] partitionKey);
public ICollection<HostShard> GetReplicas(byte[] partitionKey);
public ICollection<HostShard> GetReplicas(string keyspace, string table, IReadOnlyList<object> partitionKeyValues);
```

Both `Cluster` methods delegate directly to the corresponding `Metadata` methods.

## Implementation Details

### 1. Token Calculation

#### Serialized `byte[]` path

The `byte[] partitionKey` parameter is assumed to already contain the serialized partition key (the same format expected by the partitioner). No additional serialization is performed on the C# side.

**Rust side:**
- The partition key bytes are wrapped in a `PreSerializedValues` structure, which is compatible with the Rust driver's token computation API.
- `ClusterState::compute_token_preserialized_with_partitioner` is called with an explicit `PartitionerName::Murmur3`.
- **Limitation:** These overloads still don't accept a table name, so token computation remains hardcoded to Murmur3.

#### Non-serialized `params object[]` path

For the new overloads, the C# side serializes each partition key column value individually using the existing serializer infrastructure and passes the resulting values to Rust as `PreSerializedValues`.

This gives us two modes:

- **Without table name**  
  Rust uses `compute_token_preserialized_with_partitioner(..., PartitionerName::Murmur3, ...)`.  
  This improves ergonomics and supports composite partition keys, but remains non-table-aware.

- **With table name**  
  Rust uses `compute_token_preserialized(keyspace, table, ...)`.  
  This enables table-specific partitioner selection and is the basis for tablet-aware routing.

### 2. Replica Retrieval

The bridge struct `RustReplicaBridge` encapsulates validation and token computation in its constructors (`new_with_partitioner` / `new_with_table`), making the actual `get_replicas` call infallible. This separation keeps the FFI layer clean:

- `cluster_state_get_replicas_murmur3`  
  Used by the existing serialized-key API. Forces Murmur3 partitioner, no table name required.

- `cluster_state_get_replicas_murmur3_preserialized`  
  Used by the new non-table `params object[]` overloads. Accepts `PreSerializedValues`, but still forces Murmur3.

- `cluster_state_get_replicas`  
  Used by the new table-aware overload. Accepts a table name and `PreSerializedValues`, enabling table-specific partitioner lookup and tablet-aware routing.

### 3. Missing Table-Aware Routing Gap Addressed

Previously we implemented only the legacy API - the bridge only had enough information to do token-ring / strategy-based lookup:
- token computation was Murmur3-forced
- replica lookup had no real table context
- tablet-aware routing could not be used

**The newest commits fix that!!**:

```csharp
public ICollection<HostShard> GetReplicas(string keyspace, string table, params object[] partitionKeyValues);
```

On this path:
- C# passes `keyspace + table + PreSerializedValues`
- Rust computes the token with `compute_token_preserialized(keyspace, table, ...)`
- Rust resolves replicas with `get_token_endpoints(keyspace, table, token)`

That means the Rust side can now:
- use the **table-specific partitioner**
- consult **table/tablet metadata**
- perform **tablet-aware replica lookup**

The non-table overloads remain intentionally Murmur3-based and non-table-aware.

### 4. Host Management and the ClusterSnapshot Architecture

**Problem:** We'd like `Host` objects returned by `GetReplicas` to be the *same instances* used by other Metadata API methods (`AllHosts`, `GetHost`, etc.), and to persist across different GetReplicas calls to ensure identity-based equality and caching work correctly.

**Solution — `ClusterSnapshot`:**

The PR introduces `ClusterSnapshot`, a value that couples a `BridgedClusterState` (a reference-counted handle to the native Rust `Arc<ClusterState>`) with a `HostRegistry` derived from that state. This guarantees that any consumer holding a snapshot always sees a consistent view of topology and hosts.

```
ClusterSnapshot
├── BridgedClusterState   ← ref-counted native Rust ClusterState handle
└── HostRegistry
    ├── HostsById         ← Dictionary<Guid, Host>   (primary index)
    └── HostIdsByIp       ← Dictionary<IPEndPoint, Guid> (secondary index for IP lookups)
```

**`HostRegistry` dual-index design:**
- `HostsById` — keyed by host UUID. Used by `GetReplicas` to map Rust replica results (host UUIDs) to C# `Host` objects.
- `HostIdsByIp` — keyed by IP endpoint. Used by `GetHost(IPEndPoint)` and related IP-based lookups.

**Cache lifecycle (`GetSnapshotCore`):**

```
┌─ Fast path (lock-free) ──────────────────────────────────┐
│ 1. Probe current ClusterState via session.GetClusterState │
│ 2. Compare (pointer equality) with _cachedSnapshot.State  │
│ 3. If equal → return cached snapshot (cache hit)          │
└───────────────────────────────────────────────────────────┘
          │ (cache miss)
          ▼
┌─ Slow path (under _snapshotLock) ────────────────────────┐
│ 1. Re-acquire fresh ClusterState                          │
│ 2. Double-check against cache (concurrent update guard)   │
│ 3. Build new snapshot (FillHostCache + HostRegistry)      │
│ 4. Atomically swap into _cachedSnapshot, dispose old      │
└───────────────────────────────────────────────────────────┘
```

**Host object reuse:**
During `BuildSnapshot`, the `RefreshContext` iterates over all nodes from the Rust side (via `cluster_state_fill_nodes`). For each node, the FFI callback (`AddHostToList`) checks if a `Host` with the same UUID and IP address already exists in the old registry. If so, the existing instance is reused — preserving object identity across metadata refreshes.

**Reference counting for memory safety:**
- `BridgedClusterState` wraps a `ManuallyDestructible` resource with reference counting.
- `GetSnapshotWithRef` pins the snapshot's state (elevates ref-count by one) during `GetReplicas`, guaranteeing the native memory is not freed while FFI callbacks are executing.
- The ref-count is decreased in a `finally` block after replica retrieval completes.

### 5. FFI Callbacks

**`cluster_state_fill_nodes` (Rust → C# `AddHostToList` callback):**
Populates the `RefreshContext` with node metadata. For each node, Rust passes raw bytes (host UUID, IP address) and borrowed UTF-8 strings (datacenter, rack). The C# callback copies all data immediately since the pointers are only valid for the duration of the invocation.

**Replica callbacks (Rust → C# `OnReplicaPairCallback`):**
After computing the token and resolving replicas, Rust invokes the callback once per replica with `(host_id_bytes, shard)`. The C# callback looks up the `Host` in the snapshot's `HostsById` dictionary and constructs a `HostShard`.

Both callbacks use the `FFIException` protocol to safely propagate managed exceptions back across the FFI boundary without unwinding through Rust frames.

## Known Limitations

1. **Fixed Murmur3 partitioner for non-table overloads:**  
   Without a table name, we cannot resolve the per-table partitioner from cluster metadata. Token computation always uses Murmur3 on those paths.

2. **Tablet-aware routing only on the table-aware overload:**  
   Tablet metadata is only usable when a real table name is supplied. The new table-aware overload fixes this; the older overloads remain non-table-aware.

3. **Empty-keyspace semantics:**  
   When no keyspace is specified, the result is equivalent to `SimpleStrategy` with RF=1 — returning only the primary token owner. This is consistent with the old C# driver's behavior but may surprise users in multi-datacenter setups.

4. **Per-value serialization APIs require PK order:**  
   For the `params object[]` overloads, callers must provide partition key values in the table's declared partition key order.
