### PR TITLE
Use [MarshalAs(UnmanagedType.U1)]bool for boolean FFI

### DIFF
--- a/rust/src/prepared_statement.rs
+++ b/rust/src/prepared_statement.rs
@@ -22,9 +22,9 @@ pub extern "C" fn prepared_statement_free(
 #[unsafe(no_mangle)]
 pub extern "C" fn prepared_statement_is_lwt(
     prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
-) -> i32 {
+) -> bool {
     ArcFFI::as_ref(prepared_statement_ptr)
         .unwrap()
         .inner
-        .is_confirmed_lwt() as _
+        .is_confirmed_lwt()
 }

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -173,11 +173,10 @@ pub extern "C" fn session_use_keyspace(
     tcb: Tcb,
     session_ptr: BridgedBorrowedSharedPtr<'_, BridgedSession>,
     keyspace: CSharpStr<'_>,
-    case_sensitive: i32,
+    case_sensitive: bool,
 ) {
     let keyspace = keyspace.as_cstr().unwrap().to_str().unwrap().to_owned();
     let bridged_session = ArcFFI::cloned_from_ptr(session_ptr).unwrap();
-    let case_sensitive = case_sensitive != 0;
 
     tracing::trace!(
         "[FFI] Scheduling use_keyspace: \"{}\" (case_sensitive: {})",

--- a/src/Cassandra/PreparedStatement.cs
+++ b/src/Cassandra/PreparedStatement.cs
@@ -40,7 +40,8 @@ namespace Cassandra
         }
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern int prepared_statement_is_lwt(IntPtr prepared_statement);
+        [return: MarshalAs(UnmanagedType.U1)]
+        unsafe private static extern bool prepared_statement_is_lwt(IntPtr prepared_statement);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern void prepared_statement_free(IntPtr prepared_statement);
@@ -136,7 +137,7 @@ namespace Cassandra
         internal PreparedStatement(IntPtr preparedStatementPtr, string cql, RowSetMetadata variablesRowsMetadata) : base(IntPtr.Zero, true)
         {
             handle = preparedStatementPtr;
-            bool isLwt = prepared_statement_is_lwt(preparedStatementPtr) != 0;
+            bool isLwt = prepared_statement_is_lwt(preparedStatementPtr);
 
             _variablesRowsMetadata = variablesRowsMetadata;
             Cql = cql;

--- a/src/Cassandra/RowPopulators/RowSet.cs
+++ b/src/Cassandra/RowPopulators/RowSet.cs
@@ -63,8 +63,9 @@ namespace Cassandra
         unsafe private static extern void row_set_free(IntPtr rowSetPtr);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        // bool does not work well with C FFI, use int instead (0 = false, non-0 = true).
-        unsafe private static extern int row_set_next_row(IntPtr rowSetPtr, IntPtr deserializeValue, IntPtr columnsPtr, IntPtr valuesPtr, IntPtr serializerPtr);
+
+        [return: MarshalAs(UnmanagedType.U1)]
+        unsafe private static extern bool row_set_next_row(IntPtr rowSetPtr, IntPtr deserializeValue, IntPtr columnsPtr, IntPtr valuesPtr, IntPtr serializerPtr);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern nuint row_set_get_columns_count(IntPtr rowSetPtr);
@@ -383,7 +384,7 @@ namespace Cassandra
             {
                 unsafe
                 {
-                    bool has_row = row_set_next_row(handle, (IntPtr)deserializeValue, columnsPtr, valuesPtr, serializerPtr) != 0;
+                    bool has_row = row_set_next_row(handle, (IntPtr)deserializeValue, columnsPtr, valuesPtr, serializerPtr);
                     if (!has_row)
                     {
                         _exhausted = true;

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -58,7 +58,7 @@ namespace Cassandra
         /// </summary>
         
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern void session_use_keyspace(Tcb tcb, IntPtr session, [MarshalAs(UnmanagedType.LPUTF8Str)] string keyspace, int isCaseSensitive);
+        unsafe private static extern void session_use_keyspace(Tcb tcb, IntPtr session, [MarshalAs(UnmanagedType.LPUTF8Str)] string keyspace, [MarshalAs(UnmanagedType.U1)] bool isCaseSensitive);
         
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern void session_prepare(Tcb tcb, IntPtr session, [MarshalAs(UnmanagedType.LPUTF8Str)] string statement);
@@ -349,8 +349,8 @@ namespace Cassandra
                         if (isUseStatement)
                         {
                             // For USE statements, call the dedicated use_keyspace method
-                            // case_sensitive = 1 (true) to respect the exact casing provided.
-                            session_use_keyspace(tcb, handle, newKeyspace, 1);
+                            // case_sensitive = true to respect the exact casing provided.
+                            session_use_keyspace(tcb, handle, newKeyspace, true);
                         }
                         else
                         {


### PR DESCRIPTION
This PR changes all occurences where we pass a true/false statement as an integer to be passed as bool in DLLImports.

Trying to use bool in an UnmanagedCallersOnly function resulted in:
`System.InvalidProgramException: Non-blittable parameter types are invalid for UnmanagedCallersOnly methods.`

Addresses #60 