### PR TITLE
Bridge WaitForSchemaAgreement

### DIFF
--- a/rust/src/error_conversion.rs
+++ b/rust/src/error_conversion.rs
@@ -765,3 +765,19 @@ where
         }
     }
 }
+
+#[derive(Error, Debug, Clone)]
+pub(crate) enum HostIdError {
+    #[error("invalid host id: not a valid uuid: {0}")]
+    InvalidUuidBytes(#[from] uuid::Error),
+}
+
+impl ErrorToException for HostIdError {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
+        match self {
+            HostIdError::InvalidUuidBytes(_) => ctors
+                .invalid_argument_exception_constructor
+                .construct_from_rust(&self.to_string()),
+        }
+    }
+}

--- a/rust/src/error_conversion.rs
+++ b/rust/src/error_conversion.rs
@@ -191,6 +191,58 @@ impl ArgumentExceptionConstructor {
     }
 }
 
+/// FFI constructor for C# `SchemaAgreementRequiredHostAbsentException`.
+#[repr(transparent)]
+pub struct SchemaAgreementRequiredHostAbsentExceptionConstructor(
+    unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException,
+);
+
+impl SchemaAgreementRequiredHostAbsentExceptionConstructor {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
+        let message = FFIStr::new(message);
+        unsafe { (self.0)(message) }
+    }
+}
+
+/// FFI constructor for C# `SchemaAgreementRowsResultException`.
+#[repr(transparent)]
+pub struct SchemaAgreementRowsResultExceptionConstructor(
+    unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException,
+);
+
+impl SchemaAgreementRowsResultExceptionConstructor {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
+        let message = FFIStr::new(message);
+        unsafe { (self.0)(message) }
+    }
+}
+
+/// FFI constructor for C# `SchemaAgreementSingleRowException`.
+#[repr(transparent)]
+pub struct SchemaAgreementSingleRowExceptionConstructor(
+    unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException,
+);
+
+impl SchemaAgreementSingleRowExceptionConstructor {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
+        let message = FFIStr::new(message);
+        unsafe { (self.0)(message) }
+    }
+}
+
+/// FFI constructor for C# `SchemaAgreementTimeoutException`.
+#[repr(transparent)]
+pub struct SchemaAgreementTimeoutExceptionConstructor(
+    unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException,
+);
+
+impl SchemaAgreementTimeoutExceptionConstructor {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
+        let message = FFIStr::new(message);
+        unsafe { (self.0)(message) }
+    }
+}
+
 /// FFI constructor for C# `SyntaxErrorException`.
 #[repr(transparent)]
 pub struct SyntaxErrorExceptionConstructor(
@@ -782,11 +834,28 @@ impl ErrorToException for HostIdError {
 
 impl ErrorToException for SchemaAgreementError {
     fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
-        ctors.rust_exception_constructor.construct_from_rust(&self)
+        match self {
+            SchemaAgreementError::ConnectionPoolError(e) => e.to_exception(ctors),
+            SchemaAgreementError::PrepareError(e) => e.to_exception(ctors),
+            SchemaAgreementError::RequestError(e) => e.to_exception(ctors),
+            e @ SchemaAgreementError::TracesEventsIntoRowsResultError(_) => ctors
+                .schema_agreement_rows_result_exception_constructor
+                .construct_from_rust(&e.to_string()),
+            e @ SchemaAgreementError::SingleRowError(_) => ctors
+                .schema_agreement_single_row_exception_constructor
+                .construct_from_rust(&e.to_string()),
+            e @ SchemaAgreementError::Timeout(_) => ctors
+                .schema_agreement_timeout_exception_constructor
+                .construct_from_rust(&e.to_string()),
+            e @ SchemaAgreementError::RequiredHostAbsent(_) => ctors
+                .schema_agreement_required_host_absent_exception_constructor
+                .construct_from_rust(&e.to_string()),
+            e => ctors.rust_exception_constructor.construct_from_rust(e),
+        }
     }
 }
 
-pub(crate) struct InvalidArgumentError<'a>(pub &'a str);
+pub(crate) struct InvalidArgumentError<'a>(pub(crate) &'a str);
 
 impl ErrorToException for InvalidArgumentError<'_> {
     fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {

--- a/rust/src/error_conversion.rs
+++ b/rust/src/error_conversion.rs
@@ -2,8 +2,8 @@ use crate::ffi::{FFIGCHandle, FFIMaybeGCHandle, FFISlice, FFIStr};
 use scylla::errors::{
     BadKeyspaceName, ClusterStateTokenError, ConnectionError, ConnectionPoolError, DbError,
     DeserializationError, MetadataError, NewSessionError, NextPageError, NextRowError,
-    PagerExecutionError, PrepareError, RequestAttemptError, RequestError, SerializationError,
-    TypeCheckError, UseKeyspaceError,
+    PagerExecutionError, PrepareError, RequestAttemptError, RequestError, SchemaAgreementError,
+    SerializationError, TypeCheckError, UseKeyspaceError,
 };
 use std::fmt::{Debug, Display};
 use std::mem::size_of;
@@ -425,9 +425,7 @@ impl ErrorToException for PagerExecutionError {
 
             PagerExecutionError::UseKeyspaceError(e) => e.to_exception(ctors),
 
-            PagerExecutionError::SchemaAgreementError(_) => {
-                ctors.rust_exception_constructor.construct_from_rust(&self)
-            }
+            PagerExecutionError::SchemaAgreementError(e) => e.to_exception(ctors),
 
             PagerExecutionError::MetadataError(e) => e.to_exception(ctors),
 
@@ -779,5 +777,21 @@ impl ErrorToException for HostIdError {
                 .invalid_argument_exception_constructor
                 .construct_from_rust(&self.to_string()),
         }
+    }
+}
+
+impl ErrorToException for SchemaAgreementError {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
+        ctors.rust_exception_constructor.construct_from_rust(&self)
+    }
+}
+
+pub(crate) struct InvalidArgumentError<'a>(pub &'a str);
+
+impl ErrorToException for InvalidArgumentError<'_> {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
+        ctors
+            .invalid_argument_exception_constructor
+            .construct_from_rust(self.0)
     }
 }

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -858,6 +858,12 @@ impl<'a, T> Debug for FFIPtr<'a, T> {
     }
 }
 
+impl<'a, T: Sized> FFIPtr<'a, T> {
+    pub(crate) fn as_non_null(&self) -> Option<std::ptr::NonNull<T>> {
+        self.ptr.map(|nn| nn.ptr)
+    }
+}
+
 // Compile-time assertion that `FFIPtr` is pointer-sized.
 // Ensures ABI compatibility with C# (opaque GCHandle/IntPtr across FFI).
 const _: [(); std::mem::size_of::<FFIPtr<'_, ()>>()] = [(); std::mem::size_of::<*const ()>()];

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -705,6 +705,27 @@ impl<'a> SchemaAgreementBridge<'a> {
         }
     }
 
+    fn new_from_row_set(
+        session_ptr: BridgedBorrowedSharedPtr<'a, BridgedSession>,
+        row_set_ptr: BridgedBorrowedSharedPtr<'_, RowSet>,
+    ) -> Result<Self, InvalidArgumentError<'static>> {
+        let Some(row_set) = ArcFFI::as_ref(row_set_ptr) else {
+            return Err(InvalidArgumentError("invalid or null row_set pointer"));
+        };
+
+        let required_node: Option<Uuid> = row_set
+            .pager
+            .blocking_lock()
+            .request_coordinators()
+            .next()
+            .map(|c| c.node().host_id);
+
+        Ok(Self {
+            session_ptr,
+            required_node,
+        })
+    }
+
     fn spawn(self, tcb: Tcb<EmptyAsyncResult>) {
         let Some(session_arc) = ArcFFI::cloned_from_ptr(self.session_ptr) else {
             tcb.fail_sync(InvalidArgumentError("invalid or null session pointer"));
@@ -747,4 +768,16 @@ pub extern "C" fn session_await_schema_agreement(
     session_ptr: BridgedBorrowedSharedPtr<'_, BridgedSession>,
 ) {
     SchemaAgreementBridge::new(session_ptr).spawn(tcb);
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn session_await_schema_agreement_with_row_set(
+    tcb: Tcb<EmptyAsyncResult>,
+    session_ptr: BridgedBorrowedSharedPtr<'_, BridgedSession>,
+    row_set_ptr: BridgedBorrowedSharedPtr<'_, RowSet>,
+) {
+    match SchemaAgreementBridge::new_from_row_set(session_ptr, row_set_ptr) {
+        Ok(bridge) => bridge.spawn(tcb),
+        Err(e) => tcb.fail_sync(e),
+    }
 }

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -28,10 +28,8 @@ use crate::task::{BridgedFuture, ExceptionConstructors, ManuallyDestructible, Tc
 use uuid::Uuid;
 
 // Number of bytes in an RFC-4122 UUID.
-// NOTE: Used in the next commit when bridging WaitForSchemaAgreement with a required node.
 const UUID_BYTE_LEN: usize = 16;
 
-// NOTE: Used in the next commit when bridging WaitForSchemaAgreement with a required node.
 enum HostId {}
 
 #[repr(transparent)]
@@ -46,7 +44,6 @@ impl HostIdPtr<'_> {
     /// - When non-null, assumes the caller provided exactly `UUID_BYTE_LEN` bytes at the
     ///   address in big-endian order.
     /// - The caller (managed side) is responsible for ensuring the memory is valid and pinned.
-    #[expect(dead_code, reason = "Used in a further commit")]
     pub fn parse_uuid(&self) -> Result<Option<Uuid>, HostIdError> {
         let Some(nn) = self.inner.as_non_null() else {
             return Ok(None);
@@ -726,6 +723,16 @@ impl<'a> SchemaAgreementBridge<'a> {
         })
     }
 
+    fn new_with_required_node(
+        session_ptr: BridgedBorrowedSharedPtr<'a, BridgedSession>,
+        host_id: HostIdPtr<'_>,
+    ) -> Result<Self, HostIdError> {
+        Ok(Self {
+            session_ptr,
+            required_node: host_id.parse_uuid()?,
+        })
+    }
+
     fn spawn(self, tcb: Tcb<EmptyAsyncResult>) {
         let Some(session_arc) = ArcFFI::cloned_from_ptr(self.session_ptr) else {
             tcb.fail_sync(InvalidArgumentError("invalid or null session pointer"));
@@ -777,6 +784,18 @@ pub extern "C" fn session_await_schema_agreement_with_row_set(
     row_set_ptr: BridgedBorrowedSharedPtr<'_, RowSet>,
 ) {
     match SchemaAgreementBridge::new_from_row_set(session_ptr, row_set_ptr) {
+        Ok(bridge) => bridge.spawn(tcb),
+        Err(e) => tcb.fail_sync(e),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn session_await_schema_agreement_with_required_node(
+    tcb: Tcb<EmptyAsyncResult>,
+    session_ptr: BridgedBorrowedSharedPtr<'_, BridgedSession>,
+    host_id: HostIdPtr<'_>,
+) {
+    match SchemaAgreementBridge::new_with_required_node(session_ptr, host_id) {
         Ok(bridge) => bridge.spawn(tcb),
         Err(e) => tcb.fail_sync(e),
     }

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -4,6 +4,7 @@ use std::sync::RwLock as StdRwLock;
 
 use scylla::client::session::Session;
 use scylla::cluster::ClusterState;
+use scylla::errors::SchemaAgreementError;
 use scylla::errors::{NewSessionError, PagerExecutionError, PrepareError};
 use scylla::statement::Statement;
 use scylla_cql::serialize::row::SerializedValues;
@@ -11,6 +12,7 @@ use tokio::sync::RwLock;
 
 use crate::error_conversion::FFIMaybeException;
 use crate::error_conversion::HostIdError;
+use crate::error_conversion::InvalidArgumentError;
 use crate::error_conversion::SessionOperationError;
 use crate::ffi::FFIPtr;
 use crate::ffi::{
@@ -21,6 +23,7 @@ use crate::pre_serialized_values::{PopulateValues, PopulateValuesContext, PreSer
 use crate::prepared_statement::BridgedPreparedStatement;
 use crate::row_set::RowSet;
 use crate::session_config::{BridgedSessionConfig, BridgedSessionConfigResult};
+use crate::task::EmptyAsyncResult;
 use crate::task::{BridgedFuture, ExceptionConstructors, ManuallyDestructible, Tcb};
 use uuid::Uuid;
 
@@ -686,4 +689,62 @@ pub extern "C" fn session_get_cluster_state(
         *out_cluster_state = md;
     }
     FFIMaybeException::ok()
+}
+
+/// Ephemeral bridge for the `WaitForSchemaAgreement` family of FFI calls.
+struct SchemaAgreementBridge<'a> {
+    session_ptr: BridgedBorrowedSharedPtr<'a, BridgedSession>,
+    required_node: Option<Uuid>,
+}
+
+impl<'a> SchemaAgreementBridge<'a> {
+    fn new(session_ptr: BridgedBorrowedSharedPtr<'a, BridgedSession>) -> Self {
+        Self {
+            session_ptr,
+            required_node: None,
+        }
+    }
+
+    fn spawn(self, tcb: Tcb<EmptyAsyncResult>) {
+        let Some(session_arc) = ArcFFI::cloned_from_ptr(self.session_ptr) else {
+            tcb.fail_sync(InvalidArgumentError("invalid or null session pointer"));
+            return;
+        };
+
+        let session_guard_res = session_arc.try_read_owned();
+        let required_node = self.required_node;
+
+        tracing::trace!(
+            "[FFI] Scheduling session_await_schema_agreement (required_node: {:?})",
+            required_node
+        );
+
+        BridgedFuture::spawn::<_, _, SessionOperationError<SchemaAgreementError>, _>(
+            tcb,
+            async move {
+                let Ok(session_guard) = session_guard_res else {
+                    return Err(SessionOperationError::AlreadyShutdown);
+                };
+
+                let Some(session) = session_guard.session.as_ref() else {
+                    return Err(SessionOperationError::AlreadyShutdown);
+                };
+
+                session
+                    .await_schema_agreement_with_required_node_external(required_node)
+                    .await
+                    .map_err(SessionOperationError::Inner)?;
+
+                Ok(())
+            },
+        );
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn session_await_schema_agreement(
+    tcb: Tcb<EmptyAsyncResult>,
+    session_ptr: BridgedBorrowedSharedPtr<'_, BridgedSession>,
+) {
+    SchemaAgreementBridge::new(session_ptr).spawn(tcb);
 }

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -9,7 +9,10 @@ use scylla::statement::Statement;
 use scylla_cql::serialize::row::SerializedValues;
 use tokio::sync::RwLock;
 
-use crate::error_conversion::{FFIMaybeException, SessionOperationError};
+use crate::error_conversion::FFIMaybeException;
+use crate::error_conversion::HostIdError;
+use crate::error_conversion::SessionOperationError;
+use crate::ffi::FFIPtr;
 use crate::ffi::{
     ArcFFI, BridgedBorrowedSharedPtr, BridgedOwnedSharedPtr, CSharpManagedStringPtr, CSharpStr,
     FFI, FFIBool, FFIStr, FromArc, WriteStringCallback,
@@ -19,6 +22,40 @@ use crate::prepared_statement::BridgedPreparedStatement;
 use crate::row_set::RowSet;
 use crate::session_config::{BridgedSessionConfig, BridgedSessionConfigResult};
 use crate::task::{BridgedFuture, ExceptionConstructors, ManuallyDestructible, Tcb};
+use uuid::Uuid;
+
+// Number of bytes in an RFC-4122 UUID.
+// NOTE: Used in the next commit when bridging WaitForSchemaAgreement with a required node.
+const UUID_BYTE_LEN: usize = 16;
+
+// NOTE: Used in the next commit when bridging WaitForSchemaAgreement with a required node.
+enum HostId {}
+
+#[repr(transparent)]
+pub struct HostIdPtr<'a> {
+    inner: FFIPtr<'a, HostId>,
+}
+
+impl HostIdPtr<'_> {
+    /// Parse an optional UUID from this host-id pointer.
+    ///
+    /// - Returns `Ok(None)` when the pointer is null (no required node).
+    /// - When non-null, assumes the caller provided exactly `UUID_BYTE_LEN` bytes at the
+    ///   address in big-endian order.
+    /// - The caller (managed side) is responsible for ensuring the memory is valid and pinned.
+    #[expect(dead_code, reason = "Used in a further commit")]
+    pub fn parse_uuid(&self) -> Result<Option<Uuid>, HostIdError> {
+        let Some(nn) = self.inner.as_non_null() else {
+            return Ok(None);
+        };
+
+        let bytes = unsafe { std::slice::from_raw_parts(nn.as_ptr() as *const u8, UUID_BYTE_LEN) };
+
+        Uuid::from_slice(bytes)
+            .map(Some)
+            .map_err(HostIdError::InvalidUuidBytes)
+    }
+}
 
 /// Internal representation of a session bridged to C#.
 /// It contains optional connected session state to allow for shutdown.

--- a/rust/src/task.rs
+++ b/rust/src/task.rs
@@ -15,9 +15,11 @@ use crate::error_conversion::{
     InvalidTypeExceptionConstructor, NoHostAvailableExceptionConstructor,
     OperationTimedOutExceptionConstructor, PreparedQueryNotFoundExceptionConstructor,
     RequestInvalidExceptionConstructor, RustExceptionConstructor,
-    SerializationExceptionConstructor, SyntaxErrorExceptionConstructor,
-    TraceRetrievalExceptionConstructor, TruncateExceptionConstructor,
-    UnauthorizedExceptionConstructor,
+    SchemaAgreementRequiredHostAbsentExceptionConstructor,
+    SchemaAgreementRowsResultExceptionConstructor, SchemaAgreementSingleRowExceptionConstructor,
+    SchemaAgreementTimeoutExceptionConstructor, SerializationExceptionConstructor,
+    SyntaxErrorExceptionConstructor, TraceRetrievalExceptionConstructor,
+    TruncateExceptionConstructor, UnauthorizedExceptionConstructor,
 };
 use crate::ffi::{ArcFFI, BridgedOwnedSharedPtr, FFIGCHandle};
 
@@ -177,6 +179,13 @@ pub struct ExceptionConstructors {
     pub prepared_query_not_found_exception_constructor: PreparedQueryNotFoundExceptionConstructor,
     pub request_invalid_exception_constructor: RequestInvalidExceptionConstructor,
     pub rust_exception_constructor: RustExceptionConstructor,
+    pub schema_agreement_required_host_absent_exception_constructor:
+        SchemaAgreementRequiredHostAbsentExceptionConstructor,
+    pub schema_agreement_rows_result_exception_constructor:
+        SchemaAgreementRowsResultExceptionConstructor,
+    pub schema_agreement_single_row_exception_constructor:
+        SchemaAgreementSingleRowExceptionConstructor,
+    pub schema_agreement_timeout_exception_constructor: SchemaAgreementTimeoutExceptionConstructor,
     pub serialization_exception_constructor: SerializationExceptionConstructor,
     pub syntax_error_exception_constructor: SyntaxErrorExceptionConstructor,
     pub trace_retrieval_exception_constructor: TraceRetrievalExceptionConstructor,

--- a/rust/src/task.rs
+++ b/rust/src/task.rs
@@ -128,7 +128,6 @@ struct Tcs<T> {
 /// struct parameter.
 #[repr(C)]
 #[derive(Default)]
-#[expect(dead_code, reason = "Used in the next commit")]
 pub struct EmptyAsyncResult {
     // Dummy field to ensure non-zero size for C# FFI compatibility (1 byte).
     _dummy: u8,
@@ -156,7 +155,7 @@ pub struct Tcb<R> {
     /// Pointer to the collection of exception constructors.
     // SAFETY: The memory is a leaked unmanaged allocation on the C# side.
     // This guarantees that the pointer remains valid and is not moved or deallocated.
-    constructors: &'static ExceptionConstructors,
+    pub(crate) constructors: &'static ExceptionConstructors,
 }
 
 /// Collection of exception constructors passed from C#.
@@ -198,6 +197,11 @@ impl<R> Tcb<R> {
         unsafe {
             (self.fail_task)(self.tcs, exception);
         }
+    }
+
+    pub(crate) fn fail_sync(self, e: impl ErrorToException) {
+        let exception = e.to_exception(self.constructors);
+        self.fail_task(exception);
     }
 }
 

--- a/rust/src/task.rs
+++ b/rust/src/task.rs
@@ -119,6 +119,27 @@ struct Tcs<T> {
     _phantom: PhantomData<T>,
 }
 
+/// Represents an empty async result for operations that don't return a value.
+///
+/// This struct matches the C# `EmptyAsyncResult` layout: a single `byte` field
+/// to ensure a consistent non-zero size across the FFI boundary. Use this type
+/// as the `R` parameter for `Tcb<R>` when an async API returns no value (i.e. `()`),
+/// so the runtime can safely call the managed completion callback with a concrete
+/// struct parameter.
+#[repr(C)]
+#[derive(Default)]
+#[expect(dead_code, reason = "Used in the next commit")]
+pub struct EmptyAsyncResult {
+    // Dummy field to ensure non-zero size for C# FFI compatibility (1 byte).
+    _dummy: u8,
+}
+
+impl From<()> for EmptyAsyncResult {
+    fn from(_: ()) -> Self {
+        EmptyAsyncResult::default()
+    }
+}
+
 /// **Task Control Block** (TCB)
 ///
 /// Contains the necessary information to manually control a Task execution from Rust.

--- a/src/Cassandra.IntegrationTests/Core/SessionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionTests.cs
@@ -294,5 +294,48 @@ namespace Cassandra.IntegrationTests.Core
             // Assert.AreEqual(0, rowSet.Count());
             // Assert.AreEqual(0, rowSet.GetAvailableWithoutFetching());
         }
+
+        private static System.Collections.Generic.IEnumerable<TestCaseData> WaitForSchemaAgreementCases()
+        {
+            yield return new TestCaseData(
+                (Func<ISession, ICluster, string, Task>)((session, cluster, tableName) =>
+                {
+                    session.WaitForSchemaAgreement();
+                    session.Execute($"INSERT INTO {tableName} (id, value) VALUES (1, '1')");
+                    return Task.CompletedTask;
+                }),
+                null).SetName("WaitForSchemaAgreement_NoRequiredNode");
+
+            yield return new TestCaseData(
+                (Func<ISession, ICluster, string, Task>)(async (session, cluster, tableName) =>
+                {
+                    await session.WaitForSchemaAgreementAsync().ConfigureAwait(false);
+                    await session.ExecuteAsync(
+                        new SimpleStatement($"INSERT INTO {tableName} (id, value) VALUES (1, '1')")).ConfigureAwait(false);
+                }),
+                null).SetName("WaitForSchemaAgreementAsync_NoRequiredNode");
+        }
+
+        [TestCaseSource(nameof(WaitForSchemaAgreementCases))]
+        public void Session_WaitForSchemaAgreement(Func<ISession, ICluster, string, Task> bridgedCall, Type expectedException)
+        {
+            var localCluster = GetNewTemporaryCluster();
+            var localSession = localCluster.Connect();
+            localSession.CreateKeyspaceIfNotExists(KeyspaceName, null, false);
+            localSession.ChangeKeyspace(KeyspaceName);
+            var tableName = "table_" + Guid.NewGuid().ToString("N");
+            localSession.Execute($"CREATE TABLE {tableName} (id int PRIMARY KEY, value text)");
+
+            if (expectedException != null)
+            {
+                NUnit.Framework.Assert.ThrowsAsync(expectedException,
+                    async () => await bridgedCall(localSession, localCluster, tableName).ConfigureAwait(false));
+            }
+            else
+            {
+                NUnit.Framework.Assert.DoesNotThrowAsync(
+                    async () => await bridgedCall(localSession, localCluster, tableName).ConfigureAwait(false));
+            }
+        }
     }
 }

--- a/src/Cassandra.IntegrationTests/Core/SessionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionTests.cs
@@ -332,6 +332,32 @@ namespace Cassandra.IntegrationTests.Core
                     await session.WaitForSchemaAgreementAsync(rowSet).ConfigureAwait(false);
                 }),
                 null).SetName("WaitForSchemaAgreementAsync_WithRowSet");
+
+            yield return new TestCaseData(
+                (Func<ISession, ICluster, string, Task>)((session, cluster, tableName) =>
+                {
+                    var hostAddress = cluster.AllHosts().First().Address;
+                    session.WaitForSchemaAgreement(hostAddress);
+                    return Task.CompletedTask;
+                }),
+                null).SetName("WaitForSchemaAgreement_WithKnownHostAddress");
+
+            yield return new TestCaseData(
+                (Func<ISession, ICluster, string, Task>)(async (session, cluster, tableName) =>
+                {
+                    var hostAddress = cluster.AllHosts().First().Address;
+                    await session.WaitForSchemaAgreementAsync(hostAddress).ConfigureAwait(false);
+                }),
+                null).SetName("WaitForSchemaAgreementAsync_WithKnownHostAddress");
+
+            yield return new TestCaseData(
+                (Func<ISession, ICluster, string, Task>)((session, cluster, tableName) =>
+                {
+                    var unknownAddress = new System.Net.IPEndPoint(System.Net.IPAddress.Parse("192.0.2.1"), 9042);
+                    session.WaitForSchemaAgreement(unknownAddress);
+                    return Task.CompletedTask;
+                }),
+                typeof(ArgumentException)).SetName("WaitForSchemaAgreement_WithUnknownHostAddress_Throws");
         }
 
         [TestCaseSource(nameof(WaitForSchemaAgreementCases))]
@@ -354,6 +380,28 @@ namespace Cassandra.IntegrationTests.Core
                 NUnit.Framework.Assert.DoesNotThrowAsync(
                     async () => await bridgedCall(localSession, localCluster, tableName).ConfigureAwait(false));
             }
+        }
+
+        [Test]
+        public void Session_WaitForSchemaAgreement_WithKnownHostAddress_ResolvesHost()
+        {
+            var localCluster = GetNewTemporaryCluster();
+            var localSession = localCluster.Connect();
+
+            var hostAddress = localCluster.AllHosts().First().Address;
+
+            NUnit.Framework.Assert.DoesNotThrow(() => localSession.WaitForSchemaAgreement(hostAddress));
+        }
+
+        [Test]
+        public void Session_WaitForSchemaAgreement_WithUnknownHostAddress_Throws()
+        {
+            var localCluster = GetNewTemporaryCluster();
+            var localSession = localCluster.Connect();
+
+            var unknownAddress = new System.Net.IPEndPoint(System.Net.IPAddress.Parse("192.0.2.1"), 9042);
+
+            NUnit.Framework.Assert.Throws<ArgumentException>(() => localSession.WaitForSchemaAgreement(unknownAddress));
         }
     }
 }

--- a/src/Cassandra.IntegrationTests/Core/SessionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionTests.cs
@@ -314,6 +314,24 @@ namespace Cassandra.IntegrationTests.Core
                         new SimpleStatement($"INSERT INTO {tableName} (id, value) VALUES (1, '1')")).ConfigureAwait(false);
                 }),
                 null).SetName("WaitForSchemaAgreementAsync_NoRequiredNode");
+
+            yield return new TestCaseData(
+                (Func<ISession, ICluster, string, Task>)((session, cluster, tableName) =>
+                {
+                    var rowSet = session.Execute($"INSERT INTO {tableName} (id, value) VALUES (2, '2')");
+                    session.WaitForSchemaAgreement(rowSet);
+                    return Task.CompletedTask;
+                }),
+                null).SetName("WaitForSchemaAgreement_WithRowSet");
+
+            yield return new TestCaseData(
+                (Func<ISession, ICluster, string, Task>)(async (session, cluster, tableName) =>
+                {
+                    var rowSet = await session.ExecuteAsync(
+                        new SimpleStatement($"INSERT INTO {tableName} (id, value) VALUES (3, '3')")).ConfigureAwait(false);
+                    await session.WaitForSchemaAgreementAsync(rowSet).ConfigureAwait(false);
+                }),
+                null).SetName("WaitForSchemaAgreementAsync_WithRowSet");
         }
 
         [TestCaseSource(nameof(WaitForSchemaAgreementCases))]

--- a/src/Cassandra.IntegrationTests/Core/SessionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionTests.cs
@@ -358,6 +358,23 @@ namespace Cassandra.IntegrationTests.Core
                     return Task.CompletedTask;
                 }),
                 typeof(ArgumentException)).SetName("WaitForSchemaAgreement_WithUnknownHostAddress_Throws");
+
+            yield return new TestCaseData(
+                (Func<ISession, ICluster, string, Task>)((session, cluster, tableName) =>
+                {
+                    var hostId = cluster.AllHosts().First().HostId;
+                    session.WaitForSchemaAgreement(hostId);
+                    return Task.CompletedTask;
+                }),
+                null).SetName("WaitForSchemaAgreement_WithKnownHostId");
+
+            yield return new TestCaseData(
+                (Func<ISession, ICluster, string, Task>)(async (session, cluster, tableName) =>
+                {
+                    var hostId = cluster.AllHosts().First().HostId;
+                    await session.WaitForSchemaAgreementAsync(hostId).ConfigureAwait(false);
+                }),
+                null).SetName("WaitForSchemaAgreementAsync_WithKnownHostId");
         }
 
         [TestCaseSource(nameof(WaitForSchemaAgreementCases))]

--- a/src/Cassandra.Tests/HostIdFFIFormatTests.cs
+++ b/src/Cassandra.Tests/HostIdFFIFormatTests.cs
@@ -1,0 +1,70 @@
+//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Cassandra.Tests
+{
+    // Host ids cross the FFI boundary as 16-byte RFC 4122 / network-order UUIDs (what Rust's
+    // Uuid::as_bytes() emits and Uuid::from_slice() expects). .NET's Guid uses a mixed-endian
+    // layout, so GuidToFFIFormat / GuidFromFFIFormat must shuffle on both sides and be exact
+    // inverses. WaitForSchemaAgreement(IPEndPoint) relies on this round trip, so a mismatch would
+    // send Rust a uuid that matches no node.
+    public class HostIdFFIFormatTests : BaseUnitTest
+    {
+        // 550e8400-e29b-41d4-a716-446655440000 in canonical RFC 4122 byte order.
+        private static readonly byte[] CanonicalBytes =
+        {
+            0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4,
+            0xa7, 0x16, 0x44, 0x66, 0x55, 0x44, 0x00, 0x00
+        };
+        private static readonly Guid Uuid = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+
+        [Test]
+        public void GuidToFFIFormat_ProducesCanonicalRfc4122Bytes()
+        {
+            Span<byte> buffer = stackalloc byte[16];
+            RustBridge.GuidToFFIFormat(Uuid, buffer);
+            NUnit.Framework.Legacy.CollectionAssert.AreEqual(CanonicalBytes, buffer.ToArray());
+        }
+
+        [Test]
+        public void GuidFromFFIFormat_ParsesCanonicalRfc4122Bytes()
+        {
+            Assert.AreEqual(Uuid, RustBridge.GuidFromFFIFormat(CanonicalBytes));
+        }
+
+        [Test]
+        public void GuidFFIFormat_SerializeThenDeserialize_RoundTrips()
+        {
+            Span<byte> buffer = stackalloc byte[16];
+            RustBridge.GuidToFFIFormat(Uuid, buffer);
+            var roundTripped = RustBridge.GuidFromFFIFormat(buffer);
+            Assert.AreEqual(Uuid, roundTripped);
+        }
+
+        [Test]
+        public void GuidFFIFormat_DeserializeThenSerialize_RoundTrips()
+        {
+            var guid = RustBridge.GuidFromFFIFormat(CanonicalBytes);
+            Span<byte> buffer = stackalloc byte[16];
+            RustBridge.GuidToFFIFormat(guid, buffer);
+            NUnit.Framework.Legacy.CollectionAssert.AreEqual(CanonicalBytes, buffer.ToArray());
+        }
+    }
+}

--- a/src/Cassandra/Exceptions/SchemaAgreementException.cs
+++ b/src/Cassandra/Exceptions/SchemaAgreementException.cs
@@ -1,0 +1,16 @@
+namespace Cassandra
+{
+    /// <summary>
+    /// Base type for schema-agreement failures. Specific failures are reported as derived
+    /// exceptions (e.g. <see cref="SchemaAgreementTimeoutException"/>) so callers can
+    /// distinguish them by type, while still being able to catch any schema-agreement
+    /// failure via this type. Failures that originate from a lower-level error
+    /// (connection pool, prepare, request) are instead surfaced as the corresponding
+    /// driver exception for that error.
+    /// </summary>
+    public abstract class SchemaAgreementException : DriverException
+    {
+        protected SchemaAgreementException(string message) : base(message, null)
+        { }
+    }
+}

--- a/src/Cassandra/Exceptions/SchemaAgreementRequiredHostAbsentException.cs
+++ b/src/Cassandra/Exceptions/SchemaAgreementRequiredHostAbsentException.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using static Cassandra.RustBridge;
+
+namespace Cassandra
+{
+    /// <summary>
+    /// Thrown when a host required for schema agreement is not present in the connection pool.
+    /// </summary>
+    public class SchemaAgreementRequiredHostAbsentException : SchemaAgreementException
+    {
+        public SchemaAgreementRequiredHostAbsentException(string message) : base(message)
+        { }
+
+        [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static FFIGCHandle SchemaAgreementRequiredHostAbsentExceptionFromRust(FFIString message)
+        {
+            var exception = new SchemaAgreementRequiredHostAbsentException(message.ToManagedString());
+
+            GCHandle handle = GCHandle.Alloc(exception);
+            return new(handle);
+        }
+    }
+}

--- a/src/Cassandra/Exceptions/SchemaAgreementRowsResultException.cs
+++ b/src/Cassandra/Exceptions/SchemaAgreementRowsResultException.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using static Cassandra.RustBridge;
+
+namespace Cassandra
+{
+    /// <summary>
+    /// Thrown when the schema version query result cannot be converted into a rows result
+    /// while waiting for schema agreement.
+    /// </summary>
+    public class SchemaAgreementRowsResultException : SchemaAgreementException
+    {
+        public SchemaAgreementRowsResultException(string message) : base(message)
+        { }
+
+        [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static FFIGCHandle SchemaAgreementRowsResultExceptionFromRust(FFIString message)
+        {
+            var exception = new SchemaAgreementRowsResultException(message.ToManagedString());
+
+            GCHandle handle = GCHandle.Alloc(exception);
+            return new(handle);
+        }
+    }
+}

--- a/src/Cassandra/Exceptions/SchemaAgreementSingleRowException.cs
+++ b/src/Cassandra/Exceptions/SchemaAgreementSingleRowException.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using static Cassandra.RustBridge;
+
+namespace Cassandra
+{
+    /// <summary>
+    /// Thrown when a single row of the schema version query response cannot be deserialized
+    /// while waiting for schema agreement.
+    /// </summary>
+    public class SchemaAgreementSingleRowException : SchemaAgreementException
+    {
+        public SchemaAgreementSingleRowException(string message) : base(message)
+        { }
+
+        [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static FFIGCHandle SchemaAgreementSingleRowExceptionFromRust(FFIString message)
+        {
+            var exception = new SchemaAgreementSingleRowException(message.ToManagedString());
+
+            GCHandle handle = GCHandle.Alloc(exception);
+            return new(handle);
+        }
+    }
+}

--- a/src/Cassandra/Exceptions/SchemaAgreementTimeoutException.cs
+++ b/src/Cassandra/Exceptions/SchemaAgreementTimeoutException.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using static Cassandra.RustBridge;
+
+namespace Cassandra
+{
+    /// <summary>
+    /// Thrown when waiting for schema agreement exceeds the configured timeout.
+    /// </summary>
+    public class SchemaAgreementTimeoutException : SchemaAgreementException
+    {
+        public SchemaAgreementTimeoutException(string message) : base(message)
+        { }
+
+        [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        internal static FFIGCHandle SchemaAgreementTimeoutExceptionFromRust(FFIString message)
+        {
+            var exception = new SchemaAgreementTimeoutException(message.ToManagedString());
+
+            GCHandle handle = GCHandle.Alloc(exception);
+            return new(handle);
+        }
+    }
+}

--- a/src/Cassandra/ISession.cs
+++ b/src/Cassandra/ISession.cs
@@ -268,9 +268,70 @@ namespace Cassandra
         /// </summary>
         Task ShutdownAsync();
 
-        [Obsolete("Method deprecated. The driver internally waits for schema agreement when there is an schema change. See ProtocolOptions.MaxSchemaAgreementWaitSeconds for more info.")]
+        /// <summary>
+        /// Awaits schema agreement among all reachable nodes. Requires that the host specified by the provided RowSet
+        /// successfully returns its schema version during the agreement process.
+        /// </summary>
+        /// <param name="rs">RowSet's queried host is required to successfully return its schema version.</param>
+        /// <remarks> This is a blocking method. If you want to wait for schema agreement asynchronously, use
+        /// <see cref="WaitForSchemaAgreementAsync(RowSet)"/> instead.
+        /// When there's no requirement for a specific host to return its schema version, use
+        /// <see cref="WaitForSchemaAgreement()"/> or <see cref="WaitForSchemaAgreementAsync()"/> instead.
+        /// </remarks>
+        /// FIXME: Mention result / exception when the host does not return its schema version or is not reachable
+        /// when it's implemented.
         void WaitForSchemaAgreement(RowSet rs);
-        [Obsolete("Method deprecated. The driver internally waits for schema agreement when there is an schema change. See ProtocolOptions.MaxSchemaAgreementWaitSeconds for more info.")]
+
+        /// <summary>
+        /// Awaits schema agreement among all reachable nodes. Requires that the host specified in the parameter
+        /// successfully returns its schema version during the agreement process.
+        /// </summary>
+        /// <param name="forHost">Host required to successfully return its schema version.</param>
+        /// <remarks> This is a blocking method. If you want to wait for schema agreement asynchronously, use
+        /// <see cref="WaitForSchemaAgreementAsync(IPEndPoint)"/> instead.
+        /// When there's no requirement for a specific host to return its schema version, use
+        /// <see cref="WaitForSchemaAgreement()"/> or <see cref="WaitForSchemaAgreementAsync()"/> instead.
+        /// </remarks>
+        /// FIXME: Mention result / exception when the host does not return its schema version or is not reachable
+        /// when it's implemented.
         bool WaitForSchemaAgreement(IPEndPoint forHost);
+
+        /// <summary>
+        /// Awaits schema agreement among all reachable nodes. Requires that the host specified by the provided RowSet
+        /// successfully returns its schema version during the agreement process.
+        /// </summary>
+        /// <param name="rs">RowSet's queried host is required to successfully return its schema version.</param>
+        /// <remarks> When there's no requirement for a specific host to return its schema version, use
+        /// <see cref="WaitForSchemaAgreement()"/> or <see cref="WaitForSchemaAgreementAsync()"/> instead.
+        /// </remarks>
+        /// FIXME: Mention result / exception when the host does not return its schema version or is not reachable
+        /// when it's implemented.
+        Task WaitForSchemaAgreementAsync(RowSet rs);
+
+        /// <summary>
+        /// Awaits schema agreement among all reachable nodes. Requires that the host specified in the parameter
+        /// successfully returns its schema version during the agreement process.
+        /// </summary>
+        /// <param name="hostAddress">Host required to successfully return its schema version.</param>
+        /// <remarks> When there's no requirement for a specific host to return its schema version, use
+        /// <see cref="WaitForSchemaAgreement()"/> or <see cref="WaitForSchemaAgreementAsync()"/> instead.
+        /// </remarks>
+        /// FIXME: Mention result / exception when the host does not return its schema version or is not reachable
+        /// when it's implemented.
+        Task WaitForSchemaAgreementAsync(IPEndPoint hostAddress);
+
+        /// <summary>
+        /// Awaits schema agreement among all reachable nodes.
+        /// </summary>
+        /// <remarks> This is a blocking method. If you want to wait for schema agreement asynchronously, use
+        /// <see cref="WaitForSchemaAgreementAsync()"/> instead.
+        /// </remarks>
+        /// FIXME: Mention exception
+        void WaitForSchemaAgreement();
+        /// <summary>
+        /// Awaits schema agreement among all reachable nodes.
+        /// </summary>
+        /// FIXME: Mention exception
+        Task WaitForSchemaAgreementAsync();
     }
 }

--- a/src/Cassandra/ISession.cs
+++ b/src/Cassandra/ISession.cs
@@ -297,8 +297,9 @@ namespace Cassandra
         /// When there's no requirement for a specific host to return its schema version, use
         /// <see cref="WaitForSchemaAgreement()"/> or <see cref="WaitForSchemaAgreementAsync()"/> instead.
         /// </remarks>
-        /// FIXME: Mention result / exception when the host does not return its schema version or is not reachable
-        /// when it's implemented.
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="forHost"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="forHost"/> is not a known host in this cluster.</exception>
+        /// <exception cref="SchemaAgreementException">Thrown if schema agreement fails or times out, including when the required host does not return its schema version.</exception>
         bool WaitForSchemaAgreement(IPEndPoint forHost);
 
         /// <summary>
@@ -326,8 +327,9 @@ namespace Cassandra
         /// <remarks> When there's no requirement for a specific host to return its schema version, use
         /// <see cref="WaitForSchemaAgreement()"/> or <see cref="WaitForSchemaAgreementAsync()"/> instead.
         /// </remarks>
-        /// FIXME: Mention result / exception when the host does not return its schema version or is not reachable
-        /// when it's implemented.
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="hostAddress"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="hostAddress"/> is not a known host in this cluster.</exception>
+        /// <exception cref="SchemaAgreementException">Thrown if schema agreement fails or times out, including when the required host does not return its schema version.</exception>
         Task WaitForSchemaAgreementAsync(IPEndPoint hostAddress);
 
         /// <summary>

--- a/src/Cassandra/ISession.cs
+++ b/src/Cassandra/ISession.cs
@@ -303,6 +303,19 @@ namespace Cassandra
         bool WaitForSchemaAgreement(IPEndPoint forHost);
 
         /// <summary>
+        /// Awaits schema agreement among all reachable nodes. Requires that the host identified by the
+        /// given host id successfully returns its schema version during the agreement process.
+        /// </summary>
+        /// <param name="hostId">Host id (UUID) of the node required to successfully return its schema version.</param>
+        /// <remarks> This is a blocking method. If you want to wait for schema agreement asynchronously, use
+        /// <see cref="WaitForSchemaAgreementAsync(Guid)"/> instead.
+        /// When there's no requirement for a specific host to return its schema version, use
+        /// <see cref="WaitForSchemaAgreement()"/> or <see cref="WaitForSchemaAgreementAsync()"/> instead.
+        /// </remarks>
+        /// <exception cref="SchemaAgreementException">Thrown if schema agreement fails or times out, including when the required host does not return its schema version.</exception>
+        void WaitForSchemaAgreement(Guid hostId);
+
+        /// <summary>
         /// Awaits schema agreement among all reachable nodes. Requires that the host specified by the provided RowSet
         /// successfully returns its schema version during the agreement process.
         /// </summary>
@@ -331,6 +344,17 @@ namespace Cassandra
         /// <exception cref="ArgumentException">Thrown if <paramref name="hostAddress"/> is not a known host in this cluster.</exception>
         /// <exception cref="SchemaAgreementException">Thrown if schema agreement fails or times out, including when the required host does not return its schema version.</exception>
         Task WaitForSchemaAgreementAsync(IPEndPoint hostAddress);
+
+        /// <summary>
+        /// Awaits schema agreement among all reachable nodes. Requires that the host identified by the
+        /// given host id successfully returns its schema version during the agreement process.
+        /// </summary>
+        /// <param name="hostId">Host id (UUID) of the node required to successfully return its schema version.</param>
+        /// <remarks> When there's no requirement for a specific host to return its schema version, use
+        /// <see cref="WaitForSchemaAgreement()"/> or <see cref="WaitForSchemaAgreementAsync()"/> instead.
+        /// </remarks>
+        /// <exception cref="SchemaAgreementException">Thrown if schema agreement fails or times out, including when the required host does not return its schema version.</exception>
+        Task WaitForSchemaAgreementAsync(Guid hostId);
 
         /// <summary>
         /// Awaits schema agreement among all reachable nodes.

--- a/src/Cassandra/ISession.cs
+++ b/src/Cassandra/ISession.cs
@@ -278,8 +278,13 @@ namespace Cassandra
         /// When there's no requirement for a specific host to return its schema version, use
         /// <see cref="WaitForSchemaAgreement()"/> or <see cref="WaitForSchemaAgreementAsync()"/> instead.
         /// </remarks>
-        /// FIXME: Mention result / exception when the host does not return its schema version or is not reachable
-        /// when it's implemented.
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="rs"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if <paramref name="rs"/> does not have an 
+        /// underlying native resource.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown if <paramref name="rs"/> has already been 
+        /// disposed.</exception>
+        /// <exception cref="SchemaAgreementException">Thrown if schema agreement fails or times out, including
+        /// when the required host does not return its schema version.</exception>
         void WaitForSchemaAgreement(RowSet rs);
 
         /// <summary>
@@ -304,8 +309,13 @@ namespace Cassandra
         /// <remarks> When there's no requirement for a specific host to return its schema version, use
         /// <see cref="WaitForSchemaAgreement()"/> or <see cref="WaitForSchemaAgreementAsync()"/> instead.
         /// </remarks>
-        /// FIXME: Mention result / exception when the host does not return its schema version or is not reachable
-        /// when it's implemented.
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="rs"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if <paramref name="rs"/> does not have an 
+        /// underlying native resource.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown if <paramref name="rs"/> has already been 
+        /// disposed.</exception>
+        /// <exception cref="SchemaAgreementException">Thrown if schema agreement fails or times out, including
+        /// when the required host does not return its schema version.</exception>
         Task WaitForSchemaAgreementAsync(RowSet rs);
 
         /// <summary>
@@ -326,12 +336,13 @@ namespace Cassandra
         /// <remarks> This is a blocking method. If you want to wait for schema agreement asynchronously, use
         /// <see cref="WaitForSchemaAgreementAsync()"/> instead.
         /// </remarks>
-        /// FIXME: Mention exception
+        /// <exception cref="SchemaAgreementException">Thrown if schema agreement fails or times out.</exception>
         void WaitForSchemaAgreement();
+
         /// <summary>
         /// Awaits schema agreement among all reachable nodes.
         /// </summary>
-        /// FIXME: Mention exception
+        /// <exception cref="SchemaAgreementException">Thrown if schema agreement fails or times out.</exception>
         Task WaitForSchemaAgreementAsync();
     }
 }

--- a/src/Cassandra/RowPopulators/RowSet.cs
+++ b/src/Cassandra/RowPopulators/RowSet.cs
@@ -127,6 +127,10 @@ namespace Cassandra
             _genericSerializer = serializerManager?.GetGenericSerializer() ?? new GenericSerializer();
         }
 
+        internal BridgedRowSet BridgedRowSet =>
+            bridgedRowSet
+            ?? throw new InvalidOperationException("This RowSet does not have an underlying native resource.");
+
         /// <summary>
         /// Creates a new instance of RowSet.
         /// </summary>

--- a/src/Cassandra/RustBridge/BridgedClusterState.cs
+++ b/src/Cassandra/RustBridge/BridgedClusterState.cs
@@ -75,7 +75,7 @@ namespace Cassandra
                 // This matches the pattern used in row_set_fill_columns_metadata.
                 var context = Unsafe.AsRef<Metadata.RefreshContext>((void*)contextPtr);
 
-                var hostId = new Guid(hostData.IdBytes.As<byte>().ToSpan());
+                var hostId = GuidFromFFIFormat(hostData.IdBytes.As<byte>().ToSpan());
 
                 // Construct IPAddress directly from bytes (4 for IPv4, 16 for IPv6). ipBytes is an FFISlice<byte>
                 // and it accesses unmanaged memory that is only valid for the duration of this callback invocation.
@@ -145,7 +145,7 @@ namespace Cassandra
 
                 const int HostIdLength = 16;
                 var hostIdBytes = new ReadOnlySpan<byte>((void*)replica.HostIdBytesPtr, HostIdLength);
-                var hostId = new Guid(hostIdBytes);
+                var hostId = GuidFromFFIFormat(hostIdBytes);
 
                 if (context.HostsById.TryGetValue(hostId, out var host))
                 {

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -80,6 +80,9 @@ namespace Cassandra
         [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern void session_await_schema_agreement(Tcb<EmptyAsyncResult> tcb, IntPtr session);
 
+        [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
+        unsafe private static extern void session_await_schema_agreement_with_row_set(Tcb<EmptyAsyncResult> tcb, IntPtr session, IntPtr rowSet);
+
         /// <summary>
         /// Creates a new session connected to the specified Cassandra URI. 
         /// Checks the existence of the configured local datacenter.
@@ -268,6 +271,37 @@ namespace Cassandra
                     executionOptions));
             GC.KeepAlive(populateCtx);
             return task;
+        }
+
+        /// <summary>
+        /// Waits for schema agreement on the session, requiring agreement from the coordinator
+        /// node that served the given <paramref name="rowSet"/>. 
+        /// </summary>
+        /// <param name="rowSet">The RowSet resource whose coordinator must agree.</param>
+        internal Task WaitForSchemaAgreementWithRowSet(BridgedRowSet rowSet)
+        {
+            // Lifetime: it is sufficient to keep the RowSet referenced only until
+            // session_await_schema_agreement_with_row_set returns. The native side only
+            // borrows the RowSet synchronously.
+            return RunAsyncWithIncrement<EmptyAsyncResult>((tcb, sessionPtr) =>
+            {
+                try
+                {
+                    rowSet.RunWithIncrement(rowSetHandle =>
+                    {
+                        session_await_schema_agreement_with_row_set(tcb, sessionPtr, rowSetHandle);
+                        return FFIMaybeException.Ok();
+                    });
+                }
+                catch (Exception ex)
+                {
+                    // The native call never started (e.g. the RowSet was already disposed, so its
+                    // DangerousAddRef threw), which means the Rust-invoked completion callback that
+                    // frees the TCB's GCHandle will never run. We need to call it ourselves to finish 
+                    // the TCB and avoid a memory leak.
+                    Tcb<EmptyAsyncResult>.FailTask(tcb.tcs, FFIMaybeException.FromException(ex));
+                }
+            });
         }
 
         /// <summary>

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -83,6 +83,9 @@ namespace Cassandra
         [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern void session_await_schema_agreement_with_row_set(Tcb<EmptyAsyncResult> tcb, IntPtr session, IntPtr rowSet);
 
+        [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
+        unsafe private static extern void session_await_schema_agreement_with_required_node(Tcb<EmptyAsyncResult> tcb, IntPtr session, byte* hostId);
+
         /// <summary>
         /// Creates a new session connected to the specified Cassandra URI. 
         /// Checks the existence of the configured local datacenter.
@@ -311,6 +314,27 @@ namespace Cassandra
         {
             return RunAsyncWithIncrement<EmptyAsyncResult>(
                 (tcb, ptr) => session_await_schema_agreement(tcb, ptr));
+        }
+
+        /// <summary>
+        /// Waits for schema agreement on the session, requiring agreement from the node
+        /// identified by <paramref name="hostId"/>.
+        /// </summary>
+        /// <param name="hostId">The host ID (UUID) of the node that must agree.</param>
+        internal Task WaitForSchemaAgreementWithRequiredNode(Guid hostId)
+        {
+            Span<byte> hostIdBytes = stackalloc byte[16];
+            GuidToFFIFormat(hostId, hostIdBytes);
+
+            unsafe
+            {
+                fixed (byte* hostIdPtr = hostIdBytes)
+                {
+                    var hostIdAddr = (IntPtr)hostIdPtr; //pointer-typed variables cannot be captured in lambdas, thus this trick
+                    return RunAsyncWithIncrement<EmptyAsyncResult>(
+                        (tcb, ptr) => session_await_schema_agreement_with_required_node(tcb, ptr, (byte*)hostIdAddr));
+                }
+            }
         }
 
         /// <summary>

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -77,6 +77,9 @@ namespace Cassandra
         [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern FFIMaybeException session_get_keyspace(IntPtr session, IntPtr writeToStr, IntPtr context, IntPtr constructorsPtr);
 
+        [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
+        unsafe private static extern void session_await_schema_agreement(Tcb<EmptyAsyncResult> tcb, IntPtr session);
+
         /// <summary>
         /// Creates a new session connected to the specified Cassandra URI. 
         /// Checks the existence of the configured local datacenter.
@@ -265,6 +268,15 @@ namespace Cassandra
                     executionOptions));
             GC.KeepAlive(populateCtx);
             return task;
+        }
+
+        /// <summary>
+        /// Waits for cluster-wide schema agreement on the session.
+        /// </summary>
+        internal Task WaitForSchemaAgreement()
+        {
+            return RunAsyncWithIncrement<EmptyAsyncResult>(
+                (tcb, ptr) => session_await_schema_agreement(tcb, ptr));
         }
 
         /// <summary>

--- a/src/Cassandra/RustBridge/RustBridge.cs
+++ b/src/Cassandra/RustBridge/RustBridge.cs
@@ -889,5 +889,40 @@ namespace Cassandra
                 res.maybeException = FFIMaybeGCHandle.Empty();
             }
         }
+
+        /// <summary>
+        /// Convert a .NET <see cref="Guid"/> to the RFC 4122 / network (big-endian) byte
+        /// order used by native code (for example Rust's <c>Uuid::from_slice</c>).
+        ///
+        /// Reason: .NET's default <c>Guid.ToByteArray()</c> (and the parameterless
+        /// <c>Guid.TryWriteBytes</c>) use a mixed-endian layout on little-endian platforms (the
+        /// first three fields are written in little-endian), while RFC 4122 (and the Rust uuid
+        /// crate) expect the canonical network byte order (big-endian). Passing .NET's raw Guid
+        /// bytes directly over FFI will therefore produce the wrong UUID value on the native side
+        /// (observed as a byte-order mismatch). This helper avoids that by writing big-endian bytes.
+        ///
+        /// Use this helper wherever a Guid must be marshaled to native code as a 16-byte UUID
+        /// to ensure the bytes are ordered per RFC 4122.
+        /// </summary>
+        internal static void GuidToFFIFormat(Guid guid, Span<byte> buffer)
+        {
+            Debug.Assert(buffer.Length >= 16, "Buffer must be at least 16 bytes");
+
+            // bigEndian: true writes the canonical RFC 4122 / network byte order directly,
+            // instead of .NET's default mixed-endian layout.
+            guid.TryWriteBytes(buffer, bigEndian: true, out int bytesWritten);
+            Debug.Assert(bytesWritten == 16, $"Guid.TryWriteBytes wrote {bytesWritten} bytes instead of 16");
+        }
+
+        /// <summary>
+        /// Inverse of <see cref="GuidToFFIFormat(Guid, Span{byte})"/>: builds a <see cref="Guid"/> from a 16-byte
+        /// RFC 4122 / network-order UUID produced by native code (e.g. <c>Uuid::as_bytes()</c>).
+        /// </summary>
+        internal static Guid GuidFromFFIFormat(ReadOnlySpan<byte> bytes)
+        {
+            // bigEndian: true interprets the bytes as canonical RFC 4122 / network order,
+            // matching what GuidToFFIFormat produces.
+            return new Guid(bytes, bigEndian: true);
+        }
     }
 }

--- a/src/Cassandra/RustBridge/RustBridge.cs
+++ b/src/Cassandra/RustBridge/RustBridge.cs
@@ -662,6 +662,10 @@ namespace Cassandra
             unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFISliceRaw, FFIGCHandle> PreparedQueryNotFoundExceptionConstructorPtr = &PreparedQueryNotFoundException.PreparedQueryNotFoundExceptionFromRust;
             unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> RequestInvalidExceptionConstructorPtr = &RequestInvalidException.RequestInvalidExceptionFromRust;
             unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> RustExceptionConstructorPtr = &RustException.RustExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> SchemaAgreementRequiredHostAbsentExceptionConstructorPtr = &SchemaAgreementRequiredHostAbsentException.SchemaAgreementRequiredHostAbsentExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> SchemaAgreementRowsResultExceptionConstructorPtr = &SchemaAgreementRowsResultException.SchemaAgreementRowsResultExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> SchemaAgreementSingleRowExceptionConstructorPtr = &SchemaAgreementSingleRowException.SchemaAgreementSingleRowExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> SchemaAgreementTimeoutExceptionConstructorPtr = &SchemaAgreementTimeoutException.SchemaAgreementTimeoutExceptionFromRust;
             unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> SerializationExceptionConstructorPtr = &SerializationException.SerializationExceptionFromRust;
             unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> SyntaxErrorExceptionConstructorPtr = &SyntaxError.SyntaxErrorFromRust;
             unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> TraceRetrievalExceptionConstructorPtr = &TraceRetrievalException.TraceRetrievalExceptionFromRust;
@@ -691,6 +695,10 @@ namespace Cassandra
                 internal readonly IntPtr prepared_query_not_found_exception_constructor;
                 internal readonly IntPtr request_invalid_exception_constructor;
                 internal readonly IntPtr rust_exception_constructor;
+                internal readonly IntPtr schema_agreement_required_host_absent_exception_constructor;
+                internal readonly IntPtr schema_agreement_rows_result_exception_constructor;
+                internal readonly IntPtr schema_agreement_single_row_exception_constructor;
+                internal readonly IntPtr schema_agreement_timeout_exception_constructor;
                 internal readonly IntPtr serialization_exception_constructor;
                 internal readonly IntPtr syntax_error_exception_constructor;
                 internal readonly IntPtr trace_retrieval_exception_constructor;
@@ -712,6 +720,10 @@ namespace Cassandra
                     IntPtr preparedQueryNotFoundException,
                     IntPtr requestInvalidException,
                     IntPtr rustException,
+                    IntPtr schemaAgreementRequiredHostAbsentException,
+                    IntPtr schemaAgreementRowsResultException,
+                    IntPtr schemaAgreementSingleRowException,
+                    IntPtr schemaAgreementTimeoutException,
                     IntPtr serializationException,
                     IntPtr syntaxErrorException,
                     IntPtr traceRetrievalException,
@@ -732,6 +744,10 @@ namespace Cassandra
                     prepared_query_not_found_exception_constructor = preparedQueryNotFoundException;
                     request_invalid_exception_constructor = requestInvalidException;
                     rust_exception_constructor = rustException;
+                    schema_agreement_required_host_absent_exception_constructor = schemaAgreementRequiredHostAbsentException;
+                    schema_agreement_rows_result_exception_constructor = schemaAgreementRowsResultException;
+                    schema_agreement_single_row_exception_constructor = schemaAgreementSingleRowException;
+                    schema_agreement_timeout_exception_constructor = schemaAgreementTimeoutException;
                     serialization_exception_constructor = serializationException;
                     syntax_error_exception_constructor = syntaxErrorException;
                     trace_retrieval_exception_constructor = traceRetrievalException;
@@ -833,6 +849,10 @@ namespace Cassandra
                     (IntPtr)PreparedQueryNotFoundExceptionConstructorPtr,
                     (IntPtr)RequestInvalidExceptionConstructorPtr,
                     (IntPtr)RustExceptionConstructorPtr,
+                    (IntPtr)SchemaAgreementRequiredHostAbsentExceptionConstructorPtr,
+                    (IntPtr)SchemaAgreementRowsResultExceptionConstructorPtr,
+                    (IntPtr)SchemaAgreementSingleRowExceptionConstructorPtr,
+                    (IntPtr)SchemaAgreementTimeoutExceptionConstructorPtr,
                     (IntPtr)SerializationExceptionConstructorPtr,
                     (IntPtr)SyntaxErrorExceptionConstructorPtr,
                     (IntPtr)TraceRetrievalExceptionConstructorPtr,

--- a/src/Cassandra/RustBridge/RustBridge.cs
+++ b/src/Cassandra/RustBridge/RustBridge.cs
@@ -310,6 +310,59 @@ namespace Cassandra
         }
 
         /// <summary>
+        /// Represents a Void counterpart of an async result.
+        /// </summary>
+        /// <remarks>
+        /// This struct contains a dummy byte field to ensure consistent size (1 byte) across FFI boundary.
+        /// Empty structs have different sizes in C# (1 byte) and Rust with #[repr(C)] (0 bytes),
+        /// which would cause memory layout mismatches. The dummy field ensures both sides agree.
+        /// The Rust side must also define this struct with a u8 field.
+        /// </remarks>
+        [StructLayout(LayoutKind.Sequential)]
+        internal readonly struct EmptyAsyncResult : IBridgedTaskResult
+        {
+            // Dummy field to ensure consistent size across FFI boundary.
+            private readonly byte _dummy;
+
+            [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+            internal static void CompleteTask(FFIGCHandle tcsHandle, EmptyAsyncResult result)
+            {
+                Tcb<EmptyAsyncResult>.CompleteTask(tcsHandle, result);
+            }
+
+            [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+            internal static void FailTask(FFIGCHandle tcsHandle, FFIMaybeException ffiException)
+            {
+                Tcb<EmptyAsyncResult>.FailTask(tcsHandle, ffiException);
+            }
+
+            internal unsafe readonly static delegate* unmanaged[Cdecl]<FFIGCHandle, EmptyAsyncResult, void> completeTaskDel = &CompleteTask;
+            internal unsafe readonly static delegate* unmanaged[Cdecl]<FFIGCHandle, FFIMaybeException, void> failTaskDel = &FailTask;
+
+            static IntPtr IBridgedTaskResult.CompleteTaskDelegate
+            {
+                get
+                {
+                    unsafe
+                    {
+                        return (IntPtr)completeTaskDel;
+                    }
+                }
+            }
+
+            static IntPtr IBridgedTaskResult.FailTaskDelegate
+            {
+                get
+                {
+                    unsafe
+                    {
+                        return (IntPtr)failTaskDel;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Struct used to pass a native pointer along with its destructor function pointer.
         /// This is used to transfer ownership of Rust resources to C# code.
         /// All changes to this struct's fields must be mirrored in Rust code in the exact same order.

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -457,6 +457,8 @@ namespace Cassandra
             return true;
         }
 
+        public void WaitForSchemaAgreement(Guid hostId) => TaskHelper.WaitToComplete(WaitForSchemaAgreementAsync(hostId));
+
         public Task WaitForSchemaAgreementAsync(RowSet rs)
         {
             if (rs == null)
@@ -478,8 +480,10 @@ namespace Cassandra
                 ?? throw new ArgumentException(
                     $"No known host with address {hostAddress} was found in the cluster.", nameof(hostAddress));
 
-            return bridgedSession.WaitForSchemaAgreementWithRequiredNode(hostId);
+            return WaitForSchemaAgreementAsync(hostId);
         }
+
+        public Task WaitForSchemaAgreementAsync(Guid hostId) => bridgedSession.WaitForSchemaAgreementWithRequiredNode(hostId);
 
         public void WaitForSchemaAgreement() => TaskHelper.WaitToComplete(WaitForSchemaAgreementAsync());
 

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -460,6 +459,22 @@ namespace Cassandra
             // Deprecated and implemented as no-op.
             return false;
         }
+
+        public Task WaitForSchemaAgreementAsync(RowSet rs)
+        {
+            throw new NotImplementedException("WaitForSchemaAgreementAsync(RowSet) is not yet supported. " +
+                                              "Use WaitForSchemaAgreementAsync().");
+        }
+
+        public Task WaitForSchemaAgreementAsync(IPEndPoint hostAddress)
+        {
+            throw new NotImplementedException("WaitForSchemaAgreementAsync(IPEndPoint) is not yet supported. " +
+                                              "Use WaitForSchemaAgreementAsync().");
+        }
+
+        public void WaitForSchemaAgreement() => TaskHelper.WaitToComplete(WaitForSchemaAgreementAsync());
+
+        public Task WaitForSchemaAgreementAsync() => bridgedSession.WaitForSchemaAgreement();
 
         private IStatement GetDefaultStatement(string cqlQuery)
         {

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -449,10 +449,7 @@ namespace Cassandra
             }, TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        public void WaitForSchemaAgreement(RowSet rs)
-        {
-            // Deprecated and implemented as no-op.
-        }
+        public void WaitForSchemaAgreement(RowSet rs) => TaskHelper.WaitToComplete(WaitForSchemaAgreementAsync(rs));
 
         public bool WaitForSchemaAgreement(IPEndPoint hostAddress)
         {
@@ -462,8 +459,12 @@ namespace Cassandra
 
         public Task WaitForSchemaAgreementAsync(RowSet rs)
         {
-            throw new NotImplementedException("WaitForSchemaAgreementAsync(RowSet) is not yet supported. " +
-                                              "Use WaitForSchemaAgreementAsync().");
+            if (rs == null)
+            {
+                throw new ArgumentNullException(nameof(rs));
+            }
+
+            return bridgedSession.WaitForSchemaAgreementWithRowSet(rs.BridgedRowSet);
         }
 
         public Task WaitForSchemaAgreementAsync(IPEndPoint hostAddress)

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -453,8 +453,8 @@ namespace Cassandra
 
         public bool WaitForSchemaAgreement(IPEndPoint hostAddress)
         {
-            // Deprecated and implemented as no-op.
-            return false;
+            TaskHelper.WaitToComplete(WaitForSchemaAgreementAsync(hostAddress));
+            return true;
         }
 
         public Task WaitForSchemaAgreementAsync(RowSet rs)
@@ -469,8 +469,16 @@ namespace Cassandra
 
         public Task WaitForSchemaAgreementAsync(IPEndPoint hostAddress)
         {
-            throw new NotImplementedException("WaitForSchemaAgreementAsync(IPEndPoint) is not yet supported. " +
-                                              "Use WaitForSchemaAgreementAsync().");
+            if (hostAddress == null)
+            {
+                throw new ArgumentNullException(nameof(hostAddress));
+            }
+
+            var hostId = _cluster.Metadata.GetHostIdByIp(hostAddress)
+                ?? throw new ArgumentException(
+                    $"No known host with address {hostAddress} was found in the cluster.", nameof(hostAddress));
+
+            return bridgedSession.WaitForSchemaAgreementWithRequiredNode(hostId);
         }
 
         public void WaitForSchemaAgreement() => TaskHelper.WaitToComplete(WaitForSchemaAgreementAsync());


### PR DESCRIPTION
closes: https://github.com/scylladb-zpp-2025-csharp-rs-driver/csharp-driver/issues/66
closes: https://github.com/scylladb-zpp-2025-csharp-rs-driver/csharp-driver/issues/75

## Context

Previously `WaitForSchemaAgreement` was implemented as a no-op, motivated by the fact that DDL statements now wait for schema agreement automatically. However, in certain use cases a user may still prefer to call `WaitForSchemaAgreement` explicitly — for example when the schema modification is initiated concurrently by some external process. The Rust driver also supports manually awaiting schema agreement, so it makes sense to expose the same capability here.

 ## Solution

Bridged the C# WaitForSchemaAgreement API to the underlying Rust driver, covering both the "any node" form and the variants that require a specific node to report its schema version.

### No required node 
Mirrors the Rust driver's public API and simply awaits agreement among all reachable nodes:

```csharp
public void WaitForSchemaAgreement()
public Task WaitForSchemaAgreementAsync()
```
### Required node 
Awaits agreement while requiring a specific host to successfully return its schema version. The host can be identified by its `Guid` host id, its `IPEndPoint`, or the `RowSet` returned by a previous query:

```csharp
public void WaitForSchemaAgreement(Guid hostId)
public Task WaitForSchemaAgreementAsync(Guid hostId)

public bool WaitForSchemaAgreement(IPEndPoint forHost)
public Task WaitForSchemaAgreementAsync(IPEndPoint hostAddress)

public void WaitForSchemaAgreement(RowSet rs)
public Task WaitForSchemaAgreementAsync(RowSet rs)
```

## Additional changes:
- Added schema-agreement exception classes
- Bridged UUID between C# and Rust and introduced `EmptyAsyncResult` to support the FFI calls.