### PR TITLE
implement IAsyncEnumerable for RowSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can execute multiple statements (prepared or unprepared) in a batch to updat
 var profileStmt = session.Prepare("UPDATE user_profiles SET email=? WHERE key=?");
 var userTrackStmt = session.Prepare("INSERT INTO user_track (key, text, date) VALUES (?, ?, ?)");
 // ...you should reuse the prepared statement
-// Bind the parameters and add the statement to the batch batch
+// Bind the parameters and add the statement to the batch
 var batch = new BatchStatement()
   .Add(profileStmt.Bind(emailAddress, "hendrix"))
   .Add(userTrackStmt.Bind("hendrix", "You changed your email", DateTime.Now));
@@ -134,7 +134,7 @@ var rs = session.Execute(statement);
 foreach (var row in rs)
 {
   // The enumerator will yield all the rows from Cassandra
-  // Retrieving them in the back in blocks of 1000.
+  // Retrieving them in blocks of 1000.
 }
 ```
 

--- a/docs/source/topics/using/paging.md
+++ b/docs/source/topics/using/paging.md
@@ -17,6 +17,21 @@ foreach (var row in rs)
 }
 ```
 
+### Async API for automatic paging
+
+To avoid incurring the overhead of blocking threads while waiting for another page to be fetched, use the asynchronous API.
+```csharp
+var ps = await session.PrepareAsync("SELECT * from tbl1 WHERE key = ?");
+// Set the page size at statement level.
+var statement = ps.Bind(key).SetPageSize(1000);
+var rs = await session.ExecuteAsync(statement);
+await foreach (var row in rs)
+{
+   // The async enumerator will yield all the rows from Cassandra.
+   // Retrieving them in the back in blocks of 1000.
+}
+```
+
 ## Manual paging 
 
 If you want to retrieve the next page of results only when you ask for it (for example, in a webpager), use the

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -908,7 +908,6 @@ impl<T> FFIGCHandle<T> {
     /// Borrows the GCHandle, for use by C#.
     /// Borrow checker prevents use-after-free, ensuring that FFIGCHandle
     /// is kept alive.
-    #[expect(dead_code)] // Will be used soon.
     pub(crate) fn borrow<'gc>(&'gc self) -> GCHandlePtr<'gc, T> {
         GCHandlePtr(self.gchandle.0)
     }

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -876,6 +876,13 @@ pub(crate) unsafe fn ffi_callback_for_each<Ctx: Copy, T>(
 #[repr(transparent)]
 pub(crate) struct GCHandlePtr<'a, T>(FFINonNullPtr<'a, T>);
 
+impl<'a, T> Clone for GCHandlePtr<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<'a, T> Copy for GCHandlePtr<'a, T> {}
+
 impl<'a, T> Debug for GCHandlePtr<'a, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)

--- a/rust/src/row_set.rs
+++ b/rust/src/row_set.rs
@@ -1,3 +1,5 @@
+use std::task::Poll;
+
 use scylla::client::pager::QueryPager;
 use scylla::cluster::metadata::CollectionType;
 use scylla::deserialize::FrameSlice;
@@ -120,6 +122,9 @@ pub enum Values {}
 /// Opaque C# representation of (de)serializer.
 pub enum Serializer {}
 
+/// Callback type for deserializing a column value in C#.
+/// Used by the **async** path (`row_set_next_row`), where the pointers
+/// are `GCHandlePtr`s (i.e. pointers to GC-pinned managed objects).
 type DeserializeValue = unsafe extern "C" fn(
     columns_ptr: GCHandlePtr<'_, Columns>,
     values_ptr: GCHandlePtr<'_, Values>,
@@ -127,6 +132,30 @@ type DeserializeValue = unsafe extern "C" fn(
     serializer_ptr: GCHandlePtr<'_, Serializer>,
     frame_slice: FFISlice<'_, u8>,
 ) -> FFIMaybeException;
+
+/// Callback type for deserializing a column value in C#.
+/// Used by the **sync** path (`row_set_try_next_row_sync`), where the pointers
+/// are raw `FFINonNullPtr`s pointing to managed references on the C# caller's stack.
+type DeserializeValueDirect = unsafe extern "C" fn(
+    columns_ptr: FFINonNullPtr<'_, Columns>,
+    values_ptr: FFINonNullPtr<'_, Values>,
+    value_index: usize,
+    serializer_ptr: FFINonNullPtr<'_, Serializer>,
+    frame_slice: FFISlice<'_, u8>,
+) -> FFIMaybeException;
+
+/// Result of a synchronous attempt to read the next row.
+#[repr(u8)]
+pub enum SyncNextRowResult {
+    /// A row was successfully read and deserialized.
+    GotRow = 0,
+    /// No more rows available (the result set is exhausted).
+    Exhausted = 1,
+    /// Could not complete synchronously (e.g. the pager lock is contended,
+    /// or the next page needs to be fetched from the server).
+    /// The caller should fall back to the async path.
+    NeedAsync = 2,
+}
 
 /// Deserializes all columns of the next row from `next_column_iterator()` result,
 /// calling back into C# via `call_deserialize` for each non-null column value.
@@ -195,53 +224,81 @@ fn deserialize_next_row(
     Ok(true)
 }
 
-// Replaced by async version in row_set_next_row_async, but this will be
-// still used in some way in next commits. Stay tuned!
+/// Synchronous fast path: attempts to read and deserialize the next row
+/// without spawning a tokio task.
+///
+/// This succeeds when the pager lock is uncontended and the next row is already
+/// buffered in the current page. On page boundaries (where a network fetch is
+/// needed), `out_result` is set to `NeedAsync` and the caller should use the
+/// async `row_set_next_row` instead.
+///
+/// # Out parameters
+/// - `out_result`: set to the result of the synchronous attempt.
+///
+/// # Safety
+/// - `columns_ptr`, `values_ptr`, `serializer_ptr` must point to valid managed
+///   references on the caller's stack. They are passed through opaquely to the
+///   `deserialize_value` callback.
+/// - `out_result` must be a valid, writable pointer.
 #[unsafe(no_mangle)]
-pub extern "C" fn row_set_next_row<'row_set>(
-    row_set_ptr: BridgedBorrowedSharedPtr<'row_set, RowSet>,
-    deserialize_value: DeserializeValue,
-    columns_handle: FFIGCHandle<Columns>,
-    values_handle: FFIGCHandle<Values>,
-    serializer_handle: FFIGCHandle<Serializer>,
-    out_has_row: *mut bool,
+pub extern "C" fn row_set_try_next_row_sync(
+    row_set_ptr: BridgedBorrowedSharedPtr<'_, RowSet>,
+    deserialize_value: DeserializeValueDirect,
+    columns_ptr: FFINonNullPtr<'_, Columns>,
+    values_ptr: FFINonNullPtr<'_, Values>,
+    serializer_ptr: FFINonNullPtr<'_, Serializer>,
     constructors: &'static ExceptionConstructors,
+    out_result: &mut SyncNextRowResult,
 ) -> FFIMaybeException {
     let row_set = ArcFFI::as_ref(row_set_ptr).unwrap();
-    let deserialize_fut = async {
-        let mut pager = row_set.pager.lock().await;
-        let num_columns = pager.column_specs().len();
-        let next = pager.next_column_iterator().await;
 
-        deserialize_next_row(
-            next,
-            num_columns,
-            |value_index, frame_slice| unsafe {
-                deserialize_value(
-                    columns_handle.borrow(),
-                    values_handle.borrow(),
-                    value_index,
-                    serializer_handle.borrow(),
-                    FFISlice::new(frame_slice.as_slice()),
-                )
-            },
-            constructors,
-        )
+    let Ok(mut pager) = row_set.pager.try_lock() else {
+        *out_result = SyncNextRowResult::NeedAsync;
+        return FFIMaybeException::ok();
     };
 
-    // This is inherently inefficient, but necessary due to blocking C# API upon page boundaries.
-    // TODO: implement async C# API (IAsyncEnumerable) to avoid this.
-    let (has_row, result) = match BridgedFuture::block_on(deserialize_fut) {
-        Ok(has_row) => (has_row, FFIMaybeException::ok()),
-        Err(exception) => (false, FFIMaybeException::from_exception(exception)),
+    let num_columns = pager.column_specs().len();
+    let mut fut = std::pin::pin!(pager.next_column_iterator());
+    let noop_waker = futures::task::noop_waker();
+    let mut cx = std::task::Context::from_waker(&noop_waker);
+
+    let Poll::Ready(next) = fut.as_mut().poll(&mut cx) else {
+        *out_result = SyncNextRowResult::NeedAsync;
+        return FFIMaybeException::ok();
     };
-    unsafe {
-        *out_has_row = has_row;
+
+    let result = deserialize_next_row(
+        next,
+        num_columns,
+        |value_index, slice| unsafe {
+            deserialize_value(
+                columns_ptr,
+                values_ptr,
+                value_index,
+                serializer_ptr,
+                FFISlice::new(slice.as_slice()),
+            )
+        },
+        constructors,
+    );
+
+    match result {
+        Ok(got_row) => {
+            *out_result = if got_row {
+                SyncNextRowResult::GotRow
+            } else {
+                SyncNextRowResult::Exhausted
+            };
+            FFIMaybeException::ok()
+        }
+        Err(exception) => FFIMaybeException::from_exception(exception),
     }
-
-    result
 }
 
+/// Async path: spawns a tokio task to read and deserialize the next row.
+///
+/// This is the fallback used when `row_set_try_next_row_sync` returns `NeedAsync`
+/// (e.g. when the next page needs to be fetched from the server).
 #[unsafe(no_mangle)]
 pub extern "C" fn row_set_next_row_async<'row_set>(
     tcb: Tcb<bool>,

--- a/rust/src/row_set.rs
+++ b/rust/src/row_set.rs
@@ -9,7 +9,6 @@ use crate::ffi::{
 use crate::task::BridgedFuture;
 use crate::task::ExceptionConstructors;
 
-// TO DO: Don't use mock RowSet - remove Option<> from the pager field
 #[derive(Debug)]
 pub(crate) struct RowSet {
     // FIXME: consider if this Mutex is necessary. Perhaps BoxFFI is a better fit?

--- a/rust/src/row_set.rs
+++ b/rust/src/row_set.rs
@@ -5,7 +5,7 @@ use scylla::frame::response::result::{ColumnType, NativeType};
 use crate::error_conversion::FFIMaybeException;
 use crate::ffi::{
     ArcFFI, BridgedBorrowedSharedPtr, FFI, FFINonNullPtr, FFISlice, FFIStr, FromArc, FromRef,
-    RefFFI,
+    GCHandlePtr, RefFFI,
 };
 use crate::task::BridgedFuture;
 use crate::task::ExceptionConstructors;
@@ -121,10 +121,10 @@ pub enum Values {}
 pub enum Serializer {}
 
 type DeserializeValue = unsafe extern "C" fn(
-    columns_ptr: FFINonNullPtr<'_, Columns>,
-    values_ptr: FFINonNullPtr<'_, Values>,
+    columns_ptr: GCHandlePtr<'_, Columns>,
+    values_ptr: GCHandlePtr<'_, Values>,
     value_index: usize,
-    serializer_ptr: FFINonNullPtr<'_, Serializer>,
+    serializer_ptr: GCHandlePtr<'_, Serializer>,
     frame_slice: FFISlice<'_, u8>,
 ) -> FFIMaybeException;
 
@@ -132,9 +132,9 @@ type DeserializeValue = unsafe extern "C" fn(
 pub extern "C" fn row_set_next_row<'row_set>(
     row_set_ptr: BridgedBorrowedSharedPtr<'row_set, RowSet>,
     deserialize_value: DeserializeValue,
-    columns_ptr: FFINonNullPtr<'_, Columns>,
-    values_ptr: FFINonNullPtr<'_, Values>,
-    serializer_ptr: FFINonNullPtr<'_, Serializer>,
+    columns_ptr: GCHandlePtr<'_, Columns>,
+    values_ptr: GCHandlePtr<'_, Values>,
+    serializer_ptr: GCHandlePtr<'_, Serializer>,
     out_has_row: *mut bool,
     constructors: &'static ExceptionConstructors,
 ) -> FFIMaybeException {

--- a/rust/src/row_set.rs
+++ b/rust/src/row_set.rs
@@ -1,8 +1,9 @@
 use scylla::client::pager::QueryPager;
 use scylla::cluster::metadata::CollectionType;
+use scylla::deserialize::FrameSlice;
 use scylla::frame::response::result::{ColumnType, NativeType};
 
-use crate::error_conversion::FFIMaybeException;
+use crate::error_conversion::{ErrorToException as _, FFIException, FFIMaybeException};
 use crate::ffi::{
     ArcFFI, BridgedBorrowedSharedPtr, FFI, FFIGCHandle, FFINonNullPtr, FFISlice, FFIStr, FromArc,
     FromRef, GCHandlePtr, RefFFI,
@@ -128,6 +129,73 @@ type DeserializeValue = unsafe extern "C" fn(
     frame_slice: FFISlice<'_, u8>,
 ) -> FFIMaybeException;
 
+/// Deserializes all columns of the next row from `next_column_iterator()` result,
+/// calling back into C# via `call_deserialize` for each non-null column value.
+///
+/// Returns `Ok(true)` if a row was deserialized, `Ok(false)` if no more rows,
+/// or `Err` with an FFI exception on failure.
+fn deserialize_next_row(
+    next: Option<
+        Result<
+            (scylla::deserialize::row::ColumnIterator<'_, '_>, bool),
+            scylla::errors::NextRowError,
+        >,
+    >,
+    num_columns: usize,
+    mut deser_csharp_value: impl FnMut(usize, FrameSlice<'_>) -> FFIMaybeException,
+    constructors: &'static ExceptionConstructors,
+) -> Result<bool, FFIException> {
+    // TODO: consider how to handle possibility of the metadata to change between pages.
+    // While unlikely, it's not impossible.
+    // For now, we just assume it won't happen and ignore `_new_page_began`.
+    // The problem is that C# assumes the same metadata for the whole RowSet,
+    // and they are passed through `FFINonNullPtr<'_, Columns>`. Currently, if the metadata changes,
+    // C# code will attempt to deserialize columns with wrong types, likely leading to exceptions.
+    let Some(next) = next else {
+        tracing::trace!("[FFI] No more rows available!");
+        return Ok(false);
+    };
+
+    let (mut column_iterator, _new_page_began) = match next {
+        // Successfully obtained the next row's column iterator
+        Ok(values) => values,
+        // Error while fetching the column value
+        Err(err) => return Err(err.to_exception(constructors)),
+    };
+
+    for value_index in 0..num_columns {
+        let Some(column_res) = column_iterator.next() else {
+            // Error: fewer columns than expected
+            // TODO: Implement error type for too few columns - server provided less columns than claimed in the metadata
+            let ex = constructors
+                .rust_exception_constructor
+                .construct_from_rust(format_args!(
+                    "Row contains fewer columns ({} of {}) than metadata claims",
+                    value_index, num_columns
+                ));
+            return Err(ex);
+        };
+
+        let raw_column = match column_res {
+            Ok(rc) => rc,
+            Err(err) => return Err(err.to_exception(constructors)),
+        };
+
+        let Some(frame_slice) = raw_column.slice else {
+            // The value is null, so we skip deserialization.
+            // We can do that because `object[] values` in C# is initialized with nulls.
+            continue;
+        };
+
+        let ffi_exception = deser_csharp_value(value_index, frame_slice);
+        if let Some(e) = ffi_exception.try_into_ffi_exception() {
+            return Err(e);
+        }
+    }
+
+    Ok(true)
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn row_set_next_row<'row_set>(
     row_set_ptr: BridgedBorrowedSharedPtr<'row_set, RowSet>,
@@ -139,77 +207,32 @@ pub extern "C" fn row_set_next_row<'row_set>(
     constructors: &'static ExceptionConstructors,
 ) -> FFIMaybeException {
     let row_set = ArcFFI::as_ref(row_set_ptr).unwrap();
-    let mut pager = row_set.pager.blocking_lock();
-    let num_columns = pager.column_specs().len();
-
     let deserialize_fut = async {
-        // Returns Ok(true) when a row was read and deserialized,
-        // Ok(false) when there are no more rows,
-        // Err(FFIMaybeException) when an error occurs and should be propagated to C#.
-        // TODO: consider how to handle possibility of the metadata to change between pages.
-        // While unlikely, it's not impossible.
-        // For now, we just assume it won't happen and ignore `_new_page_began`.
-        // The problem is that C# assumes the same metadata for the whole RowSet,
-        // and they are passed through `FFINonNullPtr<'_, Columns>`. Currently, if the metadata changes,
-        // C# code will attempt to deserialize columns with wrong types, likely leading to exceptions.
-        let Some(next) = pager.next_column_iterator().await else {
-            tracing::trace!("[FFI] No more rows available!");
-            return Ok(false);
-        };
+        let mut pager = row_set.pager.lock().await;
+        let num_columns = pager.column_specs().len();
+        let next = pager.next_column_iterator().await;
 
-        let (mut column_iterator, _new_page_began) = match next {
-            // Successfully obtained the next row's column iterator
-            Ok(values) => values,
-            // Error while fetching the column value
-            Err(err) => return Err(FFIMaybeException::from_error(err, constructors)),
-        };
-
-        for value_index in 0..num_columns {
-            let Some(column_res) = column_iterator.next() else {
-                // Error: fewer columns than expected
-                // TODO: Implement error type for too few columns - server provided less columns than claimed in the metadata
-                let ex = constructors
-                    .rust_exception_constructor
-                    .construct_from_rust(format_args!(
-                        "Row contains fewer columns ({} of {}) than metadata claims",
-                        value_index, num_columns
-                    ));
-                return Err(FFIMaybeException::from_exception(ex));
-            };
-
-            let raw_column = match column_res {
-                Ok(rc) => rc,
-                Err(err) => return Err(FFIMaybeException::from_error(err, constructors)),
-            };
-
-            let Some(frame_slice) = raw_column.slice else {
-                // The value is null, so we skip deserialization.
-                // We can do that because `object[] values` in C# is initialized with nulls.
-                continue;
-            };
-
-            unsafe {
-                let ffi_exception = deserialize_value(
+        deserialize_next_row(
+            next,
+            num_columns,
+            |value_index, frame_slice| unsafe {
+                deserialize_value(
                     columns_handle.borrow(),
                     values_handle.borrow(),
                     value_index,
                     serializer_handle.borrow(),
                     FFISlice::new(frame_slice.as_slice()),
-                );
-                if ffi_exception.has_exception() {
-                    return Err(ffi_exception);
-                }
-            }
-        }
-
-        Ok(true)
+                )
+            },
+            constructors,
+        )
     };
 
     // This is inherently inefficient, but necessary due to blocking C# API upon page boundaries.
     // TODO: implement async C# API (IAsyncEnumerable) to avoid this.
     let (has_row, result) = match BridgedFuture::block_on(deserialize_fut) {
         Ok(has_row) => (has_row, FFIMaybeException::ok()),
-        Err(exception) => (false, exception),
+        Err(exception) => (false, FFIMaybeException::from_exception(exception)),
     };
     unsafe {
         *out_has_row = has_row;

--- a/rust/src/row_set.rs
+++ b/rust/src/row_set.rs
@@ -180,7 +180,7 @@ pub extern "C" fn row_set_next_row<'row_set>(
                 // TODO: Implement error type for too few columns - server provided less columns than claimed in the metadata
                 let ex = constructors
                     .rust_exception_constructor
-                    .construct_from_rust(format!(
+                    .construct_from_rust(format_args!(
                         "Row contains fewer columns ({} of {}) than metadata claims",
                         value_index, num_columns
                     ));

--- a/rust/src/row_set.rs
+++ b/rust/src/row_set.rs
@@ -8,8 +8,7 @@ use crate::ffi::{
     ArcFFI, BridgedBorrowedSharedPtr, FFI, FFIGCHandle, FFINonNullPtr, FFISlice, FFIStr, FromArc,
     FromRef, GCHandlePtr, RefFFI,
 };
-use crate::task::BridgedFuture;
-use crate::task::ExceptionConstructors;
+use crate::task::{BridgedFuture, ExceptionConstructors, Tcb};
 
 #[derive(Debug)]
 pub(crate) struct RowSet {
@@ -196,6 +195,8 @@ fn deserialize_next_row(
     Ok(true)
 }
 
+// Replaced by async version in row_set_next_row_async, but this will be
+// still used in some way in next commits. Stay tuned!
 #[unsafe(no_mangle)]
 pub extern "C" fn row_set_next_row<'row_set>(
     row_set_ptr: BridgedBorrowedSharedPtr<'row_set, RowSet>,
@@ -239,6 +240,40 @@ pub extern "C" fn row_set_next_row<'row_set>(
     }
 
     result
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn row_set_next_row_async<'row_set>(
+    tcb: Tcb<bool>,
+    row_set_ptr: BridgedBorrowedSharedPtr<'row_set, RowSet>,
+    deserialize_value: DeserializeValue,
+    columns_handle: FFIGCHandle<Columns>,
+    values_handle: FFIGCHandle<Values>,
+    serializer_handle: FFIGCHandle<Serializer>,
+    constructors: &'static ExceptionConstructors,
+) {
+    let row_set = ArcFFI::cloned_from_ptr(row_set_ptr).unwrap();
+    BridgedFuture::spawn(tcb, async move {
+        let mut pager = row_set.pager.lock().await;
+        let num_columns = pager.column_specs().len();
+
+        let next = pager.next_column_iterator().await;
+
+        deserialize_next_row(
+            next,
+            num_columns,
+            |value_index, frame_slice| unsafe {
+                deserialize_value(
+                    columns_handle.borrow(),
+                    values_handle.borrow(),
+                    value_index,
+                    serializer_handle.borrow(),
+                    FFISlice::new(frame_slice.as_slice()),
+                )
+            },
+            constructors,
+        )
+    });
 }
 
 #[unsafe(no_mangle)]

--- a/rust/src/row_set.rs
+++ b/rust/src/row_set.rs
@@ -4,8 +4,8 @@ use scylla::frame::response::result::{ColumnType, NativeType};
 
 use crate::error_conversion::FFIMaybeException;
 use crate::ffi::{
-    ArcFFI, BridgedBorrowedSharedPtr, FFI, FFINonNullPtr, FFISlice, FFIStr, FromArc, FromRef,
-    GCHandlePtr, RefFFI,
+    ArcFFI, BridgedBorrowedSharedPtr, FFI, FFIGCHandle, FFINonNullPtr, FFISlice, FFIStr, FromArc,
+    FromRef, GCHandlePtr, RefFFI,
 };
 use crate::task::BridgedFuture;
 use crate::task::ExceptionConstructors;
@@ -132,9 +132,9 @@ type DeserializeValue = unsafe extern "C" fn(
 pub extern "C" fn row_set_next_row<'row_set>(
     row_set_ptr: BridgedBorrowedSharedPtr<'row_set, RowSet>,
     deserialize_value: DeserializeValue,
-    columns_ptr: GCHandlePtr<'_, Columns>,
-    values_ptr: GCHandlePtr<'_, Values>,
-    serializer_ptr: GCHandlePtr<'_, Serializer>,
+    columns_handle: FFIGCHandle<Columns>,
+    values_handle: FFIGCHandle<Values>,
+    serializer_handle: FFIGCHandle<Serializer>,
     out_has_row: *mut bool,
     constructors: &'static ExceptionConstructors,
 ) -> FFIMaybeException {
@@ -190,10 +190,10 @@ pub extern "C" fn row_set_next_row<'row_set>(
 
             unsafe {
                 let ffi_exception = deserialize_value(
-                    columns_ptr,
-                    values_ptr,
+                    columns_handle.borrow(),
+                    values_handle.borrow(),
                     value_index,
-                    serializer_ptr,
+                    serializer_handle.borrow(),
                     FFISlice::new(frame_slice.as_slice()),
                 );
                 if ffi_exception.has_exception() {

--- a/rust/src/row_set.rs
+++ b/rust/src/row_set.rs
@@ -4,7 +4,8 @@ use scylla::frame::response::result::{ColumnType, NativeType};
 
 use crate::error_conversion::FFIMaybeException;
 use crate::ffi::{
-    ArcFFI, BridgedBorrowedSharedPtr, FFI, FFIPtr, FFISlice, FFIStr, FromArc, FromRef, RefFFI,
+    ArcFFI, BridgedBorrowedSharedPtr, FFI, FFINonNullPtr, FFISlice, FFIStr, FromArc, FromRef,
+    RefFFI,
 };
 use crate::task::BridgedFuture;
 use crate::task::ExceptionConstructors;
@@ -47,7 +48,7 @@ pub extern "C" fn row_set_get_columns_count(
 
 // Function pointer type for setting column metadata in C#.
 type SetMetadata = unsafe extern "C" fn(
-    columns_ptr: ColumnsPtr,
+    columns_ptr: FFINonNullPtr<'_, Columns>,
     value_index: usize,
     name: FFIStr<'_>,
     keyspace: FFIStr<'_>,
@@ -65,7 +66,7 @@ type SetMetadata = unsafe extern "C" fn(
 #[unsafe(no_mangle)]
 pub extern "C" fn row_set_fill_columns_metadata(
     row_set_ptr: BridgedBorrowedSharedPtr<'_, RowSet>,
-    columns_ptr: ColumnsPtr,
+    columns_ptr: FFINonNullPtr<'_, Columns>,
     set_metadata: SetMetadata,
 ) -> FFIMaybeException {
     let row_set = ArcFFI::as_ref(row_set_ptr).unwrap();
@@ -112,29 +113,18 @@ pub extern "C" fn row_set_fill_columns_metadata(
     FFIMaybeException::ok()
 }
 
-enum Columns {}
-
-#[repr(transparent)]
-#[derive(Clone, Copy)]
-pub struct ColumnsPtr(FFIPtr<'static, Columns>);
-
-enum Values {}
-
-#[derive(Clone, Copy)]
-#[repr(transparent)]
-pub struct ValuesPtr(FFIPtr<'static, Values>);
-
-enum Serializer {}
-
-#[derive(Clone, Copy)]
-#[repr(transparent)]
-pub struct SerializerPtr(FFIPtr<'static, Serializer>);
+/// Opaque C# representation of column metadata array.
+pub enum Columns {}
+/// Opaque C# representation of deserialized column values array.
+pub enum Values {}
+/// Opaque C# representation of (de)serializer.
+pub enum Serializer {}
 
 type DeserializeValue = unsafe extern "C" fn(
-    columns_ptr: ColumnsPtr,
-    values_ptr: ValuesPtr,
+    columns_ptr: FFINonNullPtr<'_, Columns>,
+    values_ptr: FFINonNullPtr<'_, Values>,
     value_index: usize,
-    serializer_ptr: SerializerPtr,
+    serializer_ptr: FFINonNullPtr<'_, Serializer>,
     frame_slice: FFISlice<'_, u8>,
 ) -> FFIMaybeException;
 
@@ -142,9 +132,9 @@ type DeserializeValue = unsafe extern "C" fn(
 pub extern "C" fn row_set_next_row<'row_set>(
     row_set_ptr: BridgedBorrowedSharedPtr<'row_set, RowSet>,
     deserialize_value: DeserializeValue,
-    columns_ptr: ColumnsPtr,
-    values_ptr: ValuesPtr,
-    serializer_ptr: SerializerPtr,
+    columns_ptr: FFINonNullPtr<'_, Columns>,
+    values_ptr: FFINonNullPtr<'_, Values>,
+    serializer_ptr: FFINonNullPtr<'_, Serializer>,
     out_has_row: *mut bool,
     constructors: &'static ExceptionConstructors,
 ) -> FFIMaybeException {
@@ -160,7 +150,7 @@ pub extern "C" fn row_set_next_row<'row_set>(
         // While unlikely, it's not impossible.
         // For now, we just assume it won't happen and ignore `_new_page_began`.
         // The problem is that C# assumes the same metadata for the whole RowSet,
-        // and they are passed through `ColumnsPtr`. Currently, if the metadata changes,
+        // and they are passed through `FFINonNullPtr<'_, Columns>`. Currently, if the metadata changes,
         // C# code will attempt to deserialize columns with wrong types, likely leading to exceptions.
         let Some(next) = pager.next_column_iterator().await else {
             tracing::trace!("[FFI] No more rows available!");

--- a/rust/src/row_set.rs
+++ b/rust/src/row_set.rs
@@ -21,7 +21,7 @@ pub(crate) struct RowSet {
     // and it's possible that C# code will call row_set_next_row concurrently,
     // because RowSet claims it supports parallel enumeration, and does not enforce any locking
     // on its own.
-    pub(crate) pager: std::sync::Mutex<QueryPager>,
+    pub(crate) pager: tokio::sync::Mutex<QueryPager>,
 }
 
 impl FFI for RowSet {
@@ -38,7 +38,7 @@ pub extern "C" fn row_set_get_columns_count(
     out_num_fields: *mut usize,
 ) -> FFIMaybeException {
     let row_set = ArcFFI::as_ref(row_set_ptr).unwrap();
-    let pager = row_set.pager.lock().unwrap();
+    let pager = row_set.pager.blocking_lock();
     unsafe {
         *out_num_fields = pager.column_specs().len();
     }
@@ -69,7 +69,7 @@ pub extern "C" fn row_set_fill_columns_metadata(
     set_metadata: SetMetadata,
 ) -> FFIMaybeException {
     let row_set = ArcFFI::as_ref(row_set_ptr).unwrap();
-    let pager = row_set.pager.lock().unwrap();
+    let pager = row_set.pager.blocking_lock();
 
     // Iterate column specs and call the metadata setter
     for (i, spec) in pager.column_specs().iter().enumerate() {
@@ -149,7 +149,7 @@ pub extern "C" fn row_set_next_row<'row_set>(
     constructors: &'static ExceptionConstructors,
 ) -> FFIMaybeException {
     let row_set = ArcFFI::as_ref(row_set_ptr).unwrap();
-    let mut pager = row_set.pager.lock().unwrap();
+    let mut pager = row_set.pager.blocking_lock();
     let num_columns = pager.column_specs().len();
 
     let deserialize_fut = async {

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -197,7 +197,7 @@ pub extern "C" fn session_query(
         tracing::trace!("[FFI] Statement executed");
 
         Ok(Arc::new(RowSet {
-            pager: std::sync::Mutex::new(query_pager),
+            pager: tokio::sync::Mutex::new(query_pager),
         }))
     });
 }
@@ -285,7 +285,7 @@ pub extern "C" fn session_query_with_values(
         tracing::trace!("[FFI] Prepared statement executed with pre-serialized values");
 
         Ok(Arc::new(RowSet {
-            pager: std::sync::Mutex::new(query_pager),
+            pager: tokio::sync::Mutex::new(query_pager),
         }))
     });
 }
@@ -412,7 +412,7 @@ pub extern "C" fn session_query_bound(
         tracing::trace!("[FFI] Prepared statement executed");
 
         Ok(Arc::new(RowSet {
-            pager: std::sync::Mutex::new(query_pager),
+            pager: tokio::sync::Mutex::new(query_pager),
         }))
     })
 }
@@ -501,7 +501,7 @@ pub extern "C" fn session_query_bound_with_values(
         tracing::trace!("[FFI] Prepared statement executed");
 
         Ok(Arc::new(RowSet {
-            pager: std::sync::Mutex::new(query_pager),
+            pager: tokio::sync::Mutex::new(query_pager),
         }))
     });
 }

--- a/rust/src/task.rs
+++ b/rust/src/task.rs
@@ -258,6 +258,7 @@ impl BridgedFuture {
     /// This suits blocking APIs of the C# Driver that need to wait for an async operation to complete.
     /// Although it's inherently inefficient, it's not our choice - the C# Driver's blocking API is what it is.
     /// Use with caution and prefer async APIs whenever possible.
+    #[expect(dead_code)] // <- currently unused
     pub(crate) fn block_on<T>(future: impl Future<Output = T>) -> T {
         RUNTIME.block_on(future)
     }

--- a/src/Cassandra.IntegrationTests/Core/MultiPageAsyncIterationTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MultiPageAsyncIterationTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Cassandra.Tests;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Cassandra.IntegrationTests.Core
+{
+    /// <summary>
+    /// Tests async (IAsyncEnumerable) and sync (IEnumerable) iteration
+    /// over result sets that span multiple pages.
+    /// </summary>
+    [Category(TestCategory.Short), Category(TestCategory.RealCluster)]
+    public class MultiPageAsyncIterationTests : SharedClusterTest
+    {
+        private const int RowCount = 1000;
+        // Page size is small enough to make it likely that the fast path of the `BridgedRowSet.NextRow()`,
+        // `row_set_try_next_row_sync()`, will sometimes return `SyncNextRowResult.NeedAsync`,
+        // so that the fallback async path (`BridgedRowSet.NextRowAsync()`) is exercised too.
+        private const int PageSize = 7;
+        private string _tableName;
+
+        public MultiPageAsyncIterationTests()
+            : base(1, createSession: true) { }
+
+        [OneTimeSetUp]
+        public override void OneTimeSetUp()
+        {
+            base.OneTimeSetUp();
+
+            _tableName = "tbl" + Guid.NewGuid().ToString("N").ToLower();
+            Session.Execute(
+                $"CREATE TABLE {KeyspaceName}.{_tableName} (" +
+                "id int PRIMARY KEY, " +
+                "value text)");
+
+            // Insert rows. Use simple statements in a loop — batches
+            // are not yet fully supported in the Rust bridge.
+            for (int i = 0; i < RowCount; i++)
+            {
+                Session.Execute(
+                    $"INSERT INTO {KeyspaceName}.{_tableName} " +
+                    $"(id, value) VALUES ({i}, 'v{i}')");
+            }
+        }
+
+        [Test]
+        public async Task AsyncIteration_ReturnsAllRows()
+        {
+            var statement = new SimpleStatement(
+                $"SELECT * FROM {KeyspaceName}.{_tableName}");
+            statement.SetPageSize(PageSize);
+
+            var rowSet = await Session.ExecuteAsync(statement);
+
+            var ids = new HashSet<int>();
+            await foreach (var row in rowSet)
+            {
+                ids.Add(row.GetValue<int>("id"));
+            }
+
+            Assert.AreEqual(RowCount, ids.Count,
+                "Async iteration should return all rows across pages");
+        }
+
+        [Test]
+        public void SyncIteration_ReturnsAllRows()
+        {
+            var statement = new SimpleStatement(
+                $"SELECT * FROM {KeyspaceName}.{_tableName}");
+            statement.SetPageSize(PageSize);
+
+            var rowSet = Session.Execute(statement);
+
+            var ids = new HashSet<int>();
+            foreach (var row in rowSet)
+            {
+                ids.Add(row.GetValue<int>("id"));
+            }
+
+            Assert.AreEqual(RowCount, ids.Count,
+                "Sync iteration should return all rows across pages");
+        }
+    }
+}

--- a/src/Cassandra.IntegrationTests/Core/SessionExecuteAsyncTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionExecuteAsyncTests.cs
@@ -94,5 +94,19 @@ namespace Cassandra.IntegrationTests.Core
             Assert.NotNull(task2.Result.First().GetValue<string>("key"));
             Assert.NotNull(task3.Result.First().GetValue<string[]>("tokens"));
         }
+
+        [Test]
+        public async Task SessionExecuteAsyncMultiPageQuery()
+        {
+            // This test is a SimulacronTest, so it can only query system tables.
+            // It tests that IAsyncEnumerable works for a simple single-page query.
+            // Multi-page async iteration is tested by MultiPageAsyncIterationTests.
+            var rowSet = await Session.ExecuteAsync(new SimpleStatement("SELECT tokens FROM system.local WHERE key='local'"));
+
+            await foreach (var row in rowSet)
+            {
+                Assert.NotNull(row.GetValue<string[]>("tokens"));
+            }
+        }
     }
 }

--- a/src/Cassandra/RowPopulators/RowSet.cs
+++ b/src/Cassandra/RowPopulators/RowSet.cs
@@ -150,7 +150,7 @@ namespace Cassandra
 
             IGenericSerializer serializer = _genericSerializer;
 
-            var hasRow = bridgedRowSet.NextRow(ref values, Columns, ref serializer);
+            var hasRow = bridgedRowSet.NextRow(values, Columns, serializer);
             if (!hasRow)
             {
                 _exhausted = true;

--- a/src/Cassandra/RowPopulators/RowSet.cs
+++ b/src/Cassandra/RowPopulators/RowSet.cs
@@ -139,7 +139,7 @@ namespace Cassandra
         }
 
 #nullable enable
-        private Row? DeserializeRow()
+        private async Task<Row?> DeserializeRow()
 #nullable disable
         {
             if (bridgedRowSet == null)
@@ -150,7 +150,7 @@ namespace Cassandra
 
             IGenericSerializer serializer = _genericSerializer;
 
-            var hasRow = bridgedRowSet.NextRow(values, Columns, serializer);
+            var hasRow = await bridgedRowSet.NextRow(values, Columns, serializer).ConfigureAwait(false);
             if (!hasRow)
             {
                 _exhausted = true;
@@ -213,7 +213,7 @@ namespace Cassandra
         {
             while (!IsExhausted())
             {
-                Row row = DeserializeRow();
+                Row row = DeserializeRow().GetAwaiter().GetResult();
                 if (row == null)
                     yield break;
 

--- a/src/Cassandra/RowPopulators/RowSet.cs
+++ b/src/Cassandra/RowPopulators/RowSet.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Cassandra.Serialization;
 
@@ -43,7 +44,7 @@ namespace Cassandra
     /// </para>
     /// </summary>
     /// <remarks>Parallel enumerations are supported and thread-safe.</remarks>
-    public class RowSet : IEnumerable<Row>, IDisposable
+    public class RowSet : IEnumerable<Row>, IDisposable, IAsyncEnumerable<Row>
     {
         private bool _exhausted = false;
 
@@ -219,13 +220,36 @@ namespace Cassandra
 
                 yield return row;
             }
-
-            yield break;
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
+        }
+
+        /// <inheritdoc />
+        public virtual async IAsyncEnumerator<Row> GetAsyncEnumerator(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            while (!IsExhausted())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                Row row = await DeserializeRow().ConfigureAwait(false);
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (row == null)
+                    yield break;
+
+                yield return row;
+            }
+        }
+
+        IAsyncEnumerator<Row> IAsyncEnumerable<Row>.GetAsyncEnumerator(CancellationToken cancellationToken)
+        {
+            return GetAsyncEnumerator(cancellationToken);
         }
 
         /// <summary>

--- a/src/Cassandra/RustBridge/BridgedRowSet.cs
+++ b/src/Cassandra/RustBridge/BridgedRowSet.cs
@@ -28,28 +28,13 @@ namespace Cassandra
         /// <returns>True if a row was retrieved; false if there are no more rows.</returns>
         internal bool NextRow(ref object[] values, CqlColumn[] Columns, ref IGenericSerializer serializer)
         {
-            var valuesHandle = GCHandle.Alloc(values);
-            IntPtr valuesPtr = GCHandle.ToIntPtr(valuesHandle);
-
-            var columnsHandle = GCHandle.Alloc(Columns);
-            IntPtr columnsPtr = GCHandle.ToIntPtr(columnsHandle);
-
-            var serializerHandle = GCHandle.Alloc(serializer);
-            IntPtr serializerPtr = GCHandle.ToIntPtr(serializerHandle);
+            var columnsHandle = new FFIGCHandle(GCHandle.Alloc(Columns));
+            var valuesHandle = new FFIGCHandle(GCHandle.Alloc(values));
+            var serializerHandle = new FFIGCHandle(GCHandle.Alloc(serializer));
             FFIBool hasRow = false;
-
-            try
+            unsafe
             {
-                unsafe
-                {
-                    RunWithIncrement(handle => row_set_next_row(handle, (IntPtr)deserializeValue, columnsPtr, valuesPtr, serializerPtr, out hasRow, (IntPtr)Globals.ConstructorsPtr));
-                }
-            }
-            finally
-            {
-                valuesHandle.Free();
-                columnsHandle.Free();
-                serializerHandle.Free();
+                RunWithIncrement(handle => row_set_next_row(handle, (IntPtr)deserializeValue, columnsHandle, valuesHandle, serializerHandle, out hasRow, (IntPtr)Globals.ConstructorsPtr));
             }
             return hasRow;
         }
@@ -149,7 +134,7 @@ namespace Cassandra
         // Private methods and P/Invoke
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIMaybeException row_set_next_row(IntPtr rowSetPtr, IntPtr deserializeValue, IntPtr columnsPtr, IntPtr valuesPtr, IntPtr serializerPtr, out FFIBool hasRow, IntPtr constructorsPtr);
+        unsafe private static extern FFIMaybeException row_set_next_row(IntPtr rowSetPtr, IntPtr deserializeValue, FFIGCHandle columnsPtr, FFIGCHandle valuesPtr, FFIGCHandle serializerPtr, out FFIBool hasRow, IntPtr constructorsPtr);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern FFIMaybeException row_set_get_columns_count(IntPtr rowSetPtr, out nuint count);

--- a/src/Cassandra/RustBridge/BridgedRowSet.cs
+++ b/src/Cassandra/RustBridge/BridgedRowSet.cs
@@ -2,6 +2,7 @@ using System;
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Cassandra.Serialization;
 using static Cassandra.RustBridge;
 
@@ -26,17 +27,18 @@ namespace Cassandra
         /// <param name="Columns">The columns metadata for the row.</param>
         /// <param name="serializer">The serializer to use for deserialization.</param>
         /// <returns>True if a row was retrieved; false if there are no more rows.</returns>
-        internal bool NextRow(object[] values, CqlColumn[] Columns, IGenericSerializer serializer)
+        internal async Task<bool> NextRow(object[] values, CqlColumn[] Columns, IGenericSerializer serializer)
         {
             var columnsHandle = new FFIGCHandle(GCHandle.Alloc(Columns));
             var valuesHandle = new FFIGCHandle(GCHandle.Alloc(values));
             var serializerHandle = new FFIGCHandle(GCHandle.Alloc(serializer));
-            FFIBool hasRow = false;
+
+            Task<FFIBool> task;
             unsafe
             {
-                RunWithIncrement(handle => row_set_next_row(handle, (IntPtr)deserializeValue, columnsHandle, valuesHandle, serializerHandle, out hasRow, (IntPtr)Globals.ConstructorsPtr));
+                task = RunAsyncWithIncrement<FFIBool>((tcb, row_set) => row_set_next_row_async(tcb, row_set, (IntPtr)deserializeValue, columnsHandle, valuesHandle, serializerHandle, (IntPtr)Globals.ConstructorsPtr));
             }
-            return hasRow;
+            return await task.ConfigureAwait(false);
         }
 
         /// <summary>
@@ -134,7 +136,7 @@ namespace Cassandra
         // Private methods and P/Invoke
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIMaybeException row_set_next_row(IntPtr rowSetPtr, IntPtr deserializeValue, FFIGCHandle columnsPtr, FFIGCHandle valuesPtr, FFIGCHandle serializerPtr, out FFIBool hasRow, IntPtr constructorsPtr);
+        unsafe private static extern void row_set_next_row_async(Tcb<FFIBool> tcb, IntPtr rowSetPtr, IntPtr deserializeValue, FFIGCHandle columnsHandle, FFIGCHandle valuesHandle, FFIGCHandle serializerHandle, IntPtr constructorsPtr);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern FFIMaybeException row_set_get_columns_count(IntPtr rowSetPtr, out nuint count);

--- a/src/Cassandra/RustBridge/BridgedRowSet.cs
+++ b/src/Cassandra/RustBridge/BridgedRowSet.cs
@@ -317,10 +317,7 @@ namespace Cassandra
 
                 if (valuesHandle.Target is object[] values && columnsHandle.Target is CqlColumn[] columns && serializerHandle.Target is IGenericSerializer serializer)
                 {
-                    CqlColumn column = columns[valueIndex];
-
-                    ReadOnlySpan<byte> frameSlice = FFIframeSlice.As<byte>().ToSpan();
-                    values[valueIndex] = serializer.Deserialize(ProtocolVersion.V4, frameSlice, column.TypeCode, column.TypeInfo);
+                    DeserializeValueInner(columns, values, valueIndex, serializer, FFIframeSlice);
                 }
                 else
                 {
@@ -333,6 +330,16 @@ namespace Cassandra
                 Console.Error.WriteLine($"[FFI] DeserializeValue threw exception: {ex}");
                 return FFIMaybeException.FromException(ex);
             }
+        }
+
+        /// <summary>
+        /// Core deserialization logic shared by deserialization callbacks.
+        /// </summary>
+        private static void DeserializeValueInner(CqlColumn[] columns, object[] values, nuint valueIndex, IGenericSerializer serializer, FFISliceRaw frameSliceRaw)
+        {
+            CqlColumn column = columns[valueIndex];
+            ReadOnlySpan<byte> frameSlice = frameSliceRaw.As<byte>().ToSpan();
+            values[valueIndex] = serializer.Deserialize(ProtocolVersion.V4, frameSlice, column.TypeCode, column.TypeInfo);
         }
 
         internal static Type MapTypeFromCode(ColumnTypeCode code)

--- a/src/Cassandra/RustBridge/BridgedRowSet.cs
+++ b/src/Cassandra/RustBridge/BridgedRowSet.cs
@@ -26,7 +26,7 @@ namespace Cassandra
         /// <param name="Columns">The columns metadata for the row.</param>
         /// <param name="serializer">The serializer to use for deserialization.</param>
         /// <returns>True if a row was retrieved; false if there are no more rows.</returns>
-        internal bool NextRow(ref object[] values, CqlColumn[] Columns, ref IGenericSerializer serializer)
+        internal bool NextRow(object[] values, CqlColumn[] Columns, IGenericSerializer serializer)
         {
             var columnsHandle = new FFIGCHandle(GCHandle.Alloc(Columns));
             var valuesHandle = new FFIGCHandle(GCHandle.Alloc(values));

--- a/src/Cassandra/RustBridge/BridgedRowSet.cs
+++ b/src/Cassandra/RustBridge/BridgedRowSet.cs
@@ -9,6 +9,20 @@ using static Cassandra.RustBridge;
 namespace Cassandra
 {
     /// <summary>
+    /// Result of a synchronous attempt to read the next row.
+    /// Must match the Rust <c>SyncNextRowResult</c> enum layout.
+    /// </summary>
+    internal enum SyncNextRowResult : byte
+    {
+        /// <summary>A row was successfully read and deserialized.</summary>
+        GotRow = 0,
+        /// <summary>No more rows available (the result set is exhausted).</summary>
+        Exhausted = 1,
+        /// <summary>Could not complete synchronously; fall back to the async path.</summary>
+        NeedAsync = 2,
+    }
+
+    /// <summary>
     /// Bridges a Rust-owned RowSet resource to C# via SafeHandle.
     /// Inherits destructor and handle management from RustResource.
     /// </summary>
@@ -27,8 +41,63 @@ namespace Cassandra
         /// <param name="Columns">The columns metadata for the row.</param>
         /// <param name="serializer">The serializer to use for deserialization.</param>
         /// <returns>True if a row was retrieved; false if there are no more rows.</returns>
-        internal async Task<bool> NextRow(object[] values, CqlColumn[] Columns, IGenericSerializer serializer)
+        internal Task<bool> NextRow(object[] values, CqlColumn[] Columns, IGenericSerializer serializer)
         {
+            // Fast path: synchronous, zero-alloc.
+            // Attempts to read the next row without spawning a tokio task.
+            // This succeeds when the pager lock is uncontended and the next row
+            // is already buffered in the current page (the common case).
+            unsafe
+            {
+                SyncNextRowResult syncResult = default;
+                IntPtr columnsPtr = (IntPtr)Unsafe.AsPointer(ref Columns);
+                IntPtr valuesPtr = (IntPtr)Unsafe.AsPointer(ref values);
+                IntPtr serializerPtr = (IntPtr)Unsafe.AsPointer(ref serializer);
+
+                RunWithIncrement(handle =>
+                    row_set_try_next_row_sync(
+                        handle,
+                        (IntPtr)deserializeValueDirect,
+                        columnsPtr,
+                        valuesPtr,
+                        serializerPtr,
+                        (IntPtr)Globals.ConstructorsPtr,
+                        out syncResult
+                    )
+                );
+
+                // Prevent the GC from collecting the managed objects before
+                // the synchronous native call has finished using their pointers.
+                GC.KeepAlive(Columns);
+                GC.KeepAlive(values);
+                GC.KeepAlive(serializer);
+
+                switch (syncResult)
+                {
+                    case SyncNextRowResult.GotRow:
+                        return Task.FromResult(true);
+                    case SyncNextRowResult.Exhausted:
+                        return Task.FromResult(false);
+                    case SyncNextRowResult.NeedAsync:
+                        // Fall through to the async path below.
+                        break;
+                }
+            }
+
+            return NextRowAsync(values, Columns, serializer);
+        }
+
+        /// <summary>
+        /// Async slow path for NextRow: spawns a tokio task to fetch the next
+        /// row when it is not immediately available (e.g. page boundary).
+        /// Split out so the fast path avoids async state machine allocation.
+        /// </summary>
+        private async Task<bool> NextRowAsync(object[] values, CqlColumn[] Columns, IGenericSerializer serializer)
+        {
+            // Slow path: the row is not immediately available (e.g. waiting for the
+            // next page to be fetched from the server).
+            // Allocate GCHandles (owned by Rust) and a TaskCompletionSource,
+            // and spawn a tokio task to complete the operation asynchronously.
             var columnsHandle = new FFIGCHandle(GCHandle.Alloc(Columns));
             var valuesHandle = new FFIGCHandle(GCHandle.Alloc(values));
             var serializerHandle = new FFIGCHandle(GCHandle.Alloc(serializer));
@@ -137,6 +206,9 @@ namespace Cassandra
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern void row_set_next_row_async(Tcb<FFIBool> tcb, IntPtr rowSetPtr, IntPtr deserializeValue, FFIGCHandle columnsHandle, FFIGCHandle valuesHandle, FFIGCHandle serializerHandle, IntPtr constructorsPtr);
+
+        [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
+        unsafe private static extern FFIMaybeException row_set_try_next_row_sync(IntPtr rowSetPtr, IntPtr deserializeValue, IntPtr columnsPtr, IntPtr valuesPtr, IntPtr serializerPtr, IntPtr constructorsPtr, out SyncNextRowResult result);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern FFIMaybeException row_set_get_columns_count(IntPtr rowSetPtr, out nuint count);
@@ -298,7 +370,15 @@ namespace Cassandra
         unsafe readonly static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, nuint, IntPtr, FFISliceRaw, FFIMaybeException> deserializeValue = &DeserializeValue;
 
         /// <summary>
-        /// This shall be called by Rust code for each column in a row.
+        /// Callback for the sync path. Same native signature as <see cref="DeserializeValue"/>,
+        /// but recovers managed objects from raw stack-slot pointers (via Unsafe.Read)
+        /// instead of GCHandles.
+        /// </summary>
+        unsafe readonly static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, nuint, IntPtr, FFISliceRaw, FFIMaybeException> deserializeValueDirect = &DeserializeValueDirect;
+
+        /// <summary>
+        /// This shall be called by Rust code for each column in a row (async path).
+        /// Recovers managed objects from GCHandles.
         /// </summary>
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
         private static FFIMaybeException DeserializeValue(
@@ -328,6 +408,39 @@ namespace Cassandra
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"[FFI] DeserializeValue threw exception: {ex}");
+                return FFIMaybeException.FromException(ex);
+            }
+        }
+
+        /// <summary>
+        /// This shall be called by Rust code for each column in a row (sync path).
+        /// Recovers managed objects from raw stack-slot pointers (via Unsafe.Read)
+        /// instead of GCHandles.
+        /// </summary>
+        [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        private static FFIMaybeException DeserializeValueDirect(
+            IntPtr columnsPtr,
+            IntPtr valuesPtr,
+            nuint valueIndex,
+            IntPtr serializerPtr,
+            FFISliceRaw FFIframeSlice
+        )
+        {
+            try
+            {
+                unsafe
+                {
+                    var columns = Unsafe.Read<CqlColumn[]>((void*)columnsPtr);
+                    var values = Unsafe.Read<object[]>((void*)valuesPtr);
+                    var serializer = Unsafe.Read<IGenericSerializer>((void*)serializerPtr);
+
+                    DeserializeValueInner(columns, values, valueIndex, serializer, FFIframeSlice);
+                }
+                return FFIMaybeException.Ok();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[FFI] DeserializeValueDirect threw exception: {ex}");
                 return FFIMaybeException.FromException(ex);
             }
         }


### PR DESCRIPTION
Fixes: #76

--------

## `RowSet` now implements `IAsyncEnumerable<Row>`
Prior to this change, iterating over a large result set in the ScyllaDB C# driver had a subtle but serious inefficiency: even though the query itself was asynchronous, the *iteration* was not. When the driver exhausted the current page and needed to fetch the next one from the server, the calling thread blocked waiting for the network round-trip. In a high-throughput application or one using a thread-pool-based async runtime (.NET's default), this meant threads stalling on I/O instead of doing useful work — exactly the problem that `async`/`await` is designed to avoid.
This was a gap in an otherwise asynchronous API, and it is now closed. `RowSet` implements `IAsyncEnumerable<Row>`, enabling fully non-blocking iteration with `await foreach`:
```csharp
var rs = await session.ExecuteAsync(statement);
await foreach (var row in rs)
{
    // Page boundaries are crossed transparently,
    // without blocking the calling thread.
}
```
The synchronous `foreach` path remains fully supported, preserving backward compatibility.
The implementation required making the native (Rust) row-fetching function genuinely async: it now runs on a Tokio executor and completes a C#-side `Task` when the row is ready, rather than blocking the calling thread. GCHandle lifetime across the async boundary is managed safely using `FFIGCHandle`, which ensures that handles allocated before the native call are freed by Rust's ownership system on completion or on error, eliminating a class of potential leaks that existed in the prior synchronous design.
Documentation has been updated to present the async iteration pattern as the recommended approach for automatic paging.

### The performance issue

Once I completed the shift from blocking `row_set_next_row` implementation to async one, I experienced massive [slowdown, as benchmarks run by @Akvear shown](https://github.com/scylladb-zpp-2025-csharp-rs-driver/csharp-driver/pull/80#issuecomment-4302407262). I came up with two optimisation ideas (Approaches with working titles **A** and **D**) and tried them out. [Benchmarks](https://github.com/scylladb-zpp-2025-csharp-rs-driver/csharp-driver/pull/80#issuecomment-4420161751) confirmed that **Approach D** is worth pursuing, so it was chosen, finally yielding acceptable performance (comparable or better than the original blocking implementation).

### Approach A (rejected)

The idea was to return early from the `row_set_next_row` async function, without spawning a tokio task, if the row is already available. This rules out the tokio task overhead, but leaves the overhead of C# GCHandles, Task, and TCS allocations. Benchmarks shown it's worse than master.

### Approach D

The idea is to have a dedicated sync FFI P/Invoke that tries to get a row synchronosly if it's already available. Otherwise, we fallback to the `row_set_next_row` async function, spawning a tokio task. The fast path rules out not only the tokio task overhead, but also avoids the overhead of C# GCHandles, Task, and TCS allocations. Benchmarks shown it's comparable or quicker than master.

## Questions to reviewers

@sylwiaszunejko Could you please think about applying this new API in code examples and tests? It's strictly better than IEnumerable in that it allows nonblocking iteration over pages, so my feeling is that we should have it nearly everywhere (and IEnumerable left only as a legacy example, in case some users really can't afford `async`).