### PR TITLE
Initialize Rust logging framework on startup

### DIFF
--- a/rust/src/task.rs
+++ b/rust/src/task.rs
@@ -21,19 +21,19 @@ use crate::error_conversion::{
 use crate::ffi::{ArcFFI, BridgedOwnedSharedPtr};
 
 /// The global Tokio runtime used to execute async tasks.
-static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
-    // Logger must be initialized for the logs to be emitted. As a good
-    // heuristic to initialize it early, we do it when creating the global
-    // Tokio runtime, which happens lazily on the first use of async tasks.
-    // This has a downside that if any logs are emitted before the first
-    // async task is spawned, they will be lost.
-    // To make this more robust, we could consider initializing the logger at
-    // the driver startup, but that would require a new call from C# to Rust,
-    // issued somehow early during the C# driver part.
-    crate::logging::init_logging();
+static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| Runtime::new().unwrap());
 
-    Runtime::new().unwrap()
-});
+/// Initialize the Rust logging early.
+///
+/// This function should be called early during driver initialization to ensure
+/// that logging is set up before any operations that might emit logs.
+///
+/// Calling this function multiple times is safe; subsequent calls will be no-ops.
+#[unsafe(no_mangle)]
+pub extern "C" fn init_rust_logging() {
+    // Force initialization of logging
+    crate::logging::init_logging();
+}
 
 /// Opaque type representing a C# TaskCompletionSource<T>.
 enum Tcs {}

--- a/src/Cassandra/RustBridge/RustBridge.cs
+++ b/src/Cassandra/RustBridge/RustBridge.cs
@@ -529,8 +529,15 @@ namespace Cassandra
                     unauthorized_exception_constructor = unauthorizedException;
                 }
             }
-
+            
             internal static readonly Constructors* ConstructorsPtr;
+
+            /// <summary>
+            /// Initializes the Rust driver components.
+            /// This must be called early to ensure logging is properly initialized.
+            /// </summary>
+            [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
+            private static extern void init_rust_logging();
 
             static Globals()
             {
@@ -554,6 +561,8 @@ namespace Cassandra
                     (IntPtr)TruncateExceptionConstructorPtr,
                     (IntPtr)UnauthorizedExceptionConstructorPtr
                 );
+
+                init_rust_logging();
             }
         }
 


### PR DESCRIPTION
Rust logging is now enabled by static call to Rust on driver startup.

Fixes: #77 