### PR TITLE
Benchmark driver performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ rust/libcsharp_wrapper.so
 
 # Ignore rust-analyzer files
 target/rust-analyzer/
+
+# Ignore benchmarker results
+*.svg
+*.db

--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,7 @@ global.json
 
 # Claude / AI assistant metadata
 CLAUDE.md
-.claude/ 
+.claude/
 
 # Ignore Rust build files
 rust/target/
@@ -82,3 +82,8 @@ rust/libcsharp_wrapper.so
 
 # Ignore rust-analyzer files
 target/rust-analyzer/
+
+# Ignore benchmarker results
+*.svg
+*.db
+benchmark/results/

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -1,0 +1,103 @@
+# Benchmarking With SDB
+
+This directory contains backend and benchmark configuration files for
+[ScyllaDB Drivers Benchmarker (SDB)](https://github.com/scylladb-drivers-benchmarker/scylladb-drivers-benchmarker).
+
+This README only explains the local run + plot flow.
+For full explanation and advanced options, see the SDB repository docs.
+
+## Prerequisites
+
+- `scylladb-drivers-benchmarker` cloned in the same parent directory as this repo
+- A running ScyllaDB cluster reachable via `SCYLLA_URI`
+- Driver-specific runtime/build dependencies (dotnet, cargo, node, npm)
+
+## Environment Variables
+
+Benchmark binaries read configuration from environment variables.
+Some are set directly by your shell, others are injected by backend config files in
+`benchmark/runner-config/*/config.yml` via `run-command: env ...`.
+
+- `SCYLLA_URI`: ScyllaDB contact point used by benchmark code.
+  Default in code when unset: `172.47.0.2`.
+- `CNT`: Number of benchmark iterations.
+  This is set by SDB for each benchmark step and passed through `run-csharp-benchmark.sh`.
+- `N_WORKERS`: Number of concurrent workers.
+  Used by: `insert`, `select`, `ser`, `deser` (and their concurrent variants).
+  Default in code: `1`.
+- `N_ROWS`: Number of rows preinserted for select benchmarks.
+  Used by: `select`, `large_select` (and their concurrent variants).
+  Default in code: `10`.
+- `PAGE_SIZE`: Query page size.
+  Used by: `select`, `large_select`, `deser`, and `paging`.
+  Defaults in code: `5000` for `select`/`deser`, `1` for `paging`.
+
+## 1) Run Insert Benchmark Into A Fresh DB
+
+Create a new database file and run `insert` for each backend config.
+
+```bash
+export SCYLLA_URI=172.45.0.2:9042
+export REPOS_DIR="$HOME/Repos"
+export CSHARP_REPO="~/Repos/csharp-driver"
+export NODEJS_REPO="~/Repos/nodejs-rs-driver"
+export SDB_MANIFEST="~/Repos/scylladb-drivers-benchmarker/Cargo.toml"
+export DB="$CSHARP_REPO/benchmark/results/results-database.db"
+```
+
+Run from `csharp-driver`:
+
+```bash
+cd "$CSHARP_REPO"
+
+cargo run --manifest-path "$SDB_MANIFEST" -- \
+  -d "$DB" run \
+  -B benchmark/runner-config/datastax/config.yml \
+  -b benchmark/runner-config/config.yml \
+  insert time
+
+cargo run --manifest-path "$SDB_MANIFEST" -- \
+  -d "$DB" run \
+  -B benchmark/runner-config/csharp-rs/config.yml \
+  -b benchmark/runner-config/config.yml \
+  -M force-rerun insert time
+```
+
+Run from `nodejs-rs-driver` (example backend):
+
+```bash
+cd "$NODEJS_REPO"
+
+cargo run --manifest-path "$SDB_MANIFEST" -- \
+  -d "$DB" run \
+  -B benchmark/runner-config/scylladb-driver/config.yml \
+  -b benchmark/runner-config/config.yml \
+  insert time
+```
+
+Repeat the same `run` command pattern for any additional backend config.
+
+## 2) Plot Insert Comparison
+
+Use `plot insert` with one `--series` per backend name stored in the DB.
+
+```bash
+cd "$CSHARP_REPO"
+
+cargo run --manifest-path "$SDB_MANIFEST" -- \
+  -d "$DB" plot insert \
+  -b benchmark/runner-config/config.yml \
+  --series datastax@"$CSHARP_REPO":HEAD=datastax \
+  --series csharp-rs@"$CSHARP_REPO":HEAD=csharp-rs \
+  --series scylladb-driver@"$NODEJS_REPO":HEAD=scylladb-nodejs-rs \
+  -o benchmark/results/insert-compare.svg \
+  series
+```
+
+Output plot: `benchmark/results/insert-compare.svg`
+
+## Notes
+
+- `--series` backend names must match the backend names saved by each config.
+- SDB stores results with the git commit hash of the repository where `run` was executed. This is how runs from different revisions are distinguished in one DB.
+- To compare specific revisions on one chart, pass refs in `--series`, for example: `--series csharp-rs@"$CSHARP_REPO":HEAD=main --series csharp-rs@"$CSHARP_REPO":<commit-sha>=candidate`.

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -96,6 +96,80 @@ cargo run --manifest-path "$SDB_MANIFEST" -- \
 
 Output plot: `benchmark/results/insert-compare.svg`
 
+## 3) Generate Flamegraphs
+
+This requires some extra setup:
+
+- Clone [FlameGraph](https://github.com/brendangregg/FlameGraph) to a known location
+- Set `perf_event_paranoid` to `-1` to allow perf profiling:
+  ```bash
+  sudo sysctl kernel.perf_event_paranoid=-1
+  ```
+- You will need to install dotnet directly from Microsoft
+  ```bash
+mkdir -p "$HOME/dotnet-ms"
+curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version latest --channel 9.0 --install-dir "$HOME/dotnet-ms"
+curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --runtime dotnet --channel 8.0 --install-dir "$HOME/dotnet-ms"
+
+MS_RUNTIME_DIR=$(dirname $(find $HOME/dotnet-ms/ -name "libcoreclr.so" | grep "8.0"))
+
+dotnet tool install --global dotnet-symbol
+dotnet symbol --symbols --output "$MS_RUNTIME_DIR" \
+    "$MS_RUNTIME_DIR/libcoreclr.so" \
+    "$MS_RUNTIME_DIR/libclrjit.so"
+  ```
+
+You can use this example flame graph generation script:
+```bash
+#!/bin/bash
+set -euo pipefail
+
+: "${BENCH:=ParametrizedSelect}"
+: "${SCYLLA_URI=172.47.0.2:9042}"
+: "${CNT:=1000}"
+: "${N_WORKERS:=1}"
+: "${N_ROWS:=1000}"
+: "${PAGE_SIZE:=1000}"
+: "${FLAMEGRAPH_DIR:=$HOME/repos/FlameGraph}"
+
+DOTNET_BIN="$HOME/dotnet-ms/dotnet"
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+OUTPUT_DIR="$SCRIPT_DIR/results/flamegraph"
+ENTRY_POINT="${BENCH}BenchmarkEntryPoint"
+OUTPUT_NAME="flamegraph-${BENCH}"
+PROJECT_PATH="$SCRIPT_DIR/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj"
+BUILD_OUTPUT_DIR="$SCRIPT_DIR/csharp-driver/csharp-rs/bin/Release/$ENTRY_POINT/net8.0"
+
+mkdir -p "$OUTPUT_DIR"
+
+$DOTNET_BIN build "$PROJECT_PATH" -c Release \
+    -p:BenchmarkEntryPoint="$ENTRY_POINT" \
+    -p:DebugSymbols=true \
+    -p:DebugType=full
+
+sudo \
+    SCYLLA_URI="$SCYLLA_URI" \
+    CNT="$CNT" \
+    N_WORKERS="$N_WORKERS" \
+    N_ROWS="$N_ROWS" \
+    PAGE_SIZE="$PAGE_SIZE" \
+    DOTNET_PerfMapEnabled=1 \
+    DOTNET_PerfMapIgnoreSingleFileMapping=1 \
+    DOTNET_EnableWriteXorExecute=0 \
+    DOTNET_PreserveFramePointer=1 \
+    perf record -F 1000 -g -- "$DOTNET_BIN" "$BUILD_OUTPUT_DIR/ScyllaCSharpBench.dll"
+
+sudo perf script > "$OUTPUT_DIR/out.perf"
+
+"$FLAMEGRAPH_DIR/stackcollapse-perf.pl" "$OUTPUT_DIR/out.perf" > "$OUTPUT_DIR/out.folded"
+"$FLAMEGRAPH_DIR/flamegraph.pl" --width 1000 "$OUTPUT_DIR/out.folded" > "$OUTPUT_DIR/$OUTPUT_NAME.svg"
+
+cp "$OUTPUT_DIR/out.folded" "$OUTPUT_DIR/$OUTPUT_NAME.speedscope.folded"
+```
+The flamegraph is in the .svg file.
+Alternatively you can use speedscope.folded files in [Speedscope](https://www.speedscope.app/).
+This script is designed to be placed in csharp-driver/benchmark
+
 ## Notes
 
 - `--series` backend names must match the backend names saved by each config.

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -1,0 +1,103 @@
+# Benchmarking With SDB
+
+This directory contains backend and benchmark configuration files for
+[ScyllaDB Drivers Benchmarker (SDB)](https://github.com/scylladb-drivers-benchmarker/scylladb-drivers-benchmarker).
+
+This README only explains the local run + plot flow.
+For full explanation and advanced options, see the SDB repository docs.
+
+## Prerequisites
+
+- `scylladb-drivers-benchmarker` cloned in the same parent directory as this repo
+- A running ScyllaDB cluster reachable via `SCYLLA_URI`
+- Driver-specific runtime/build dependencies (dotnet, cargo, node, npm)
+
+## Environment Variables
+
+Benchmark binaries read configuration from environment variables.
+Some are set directly by your shell, others are injected by backend config files in
+`benchmark/runner-config/*/config.yml` via `run-command: env ...`.
+
+- `SCYLLA_URI`: ScyllaDB contact point used by benchmark code.
+  Default in code when unset: `172.47.0.2`.
+- `CNT`: Number of benchmark iterations.
+  This is set by SDB for each benchmark step and passed through `run-csharp-benchmark.sh`.
+- `N_WORKERS`: Number of concurrent workers.
+  Used by: `insert`, `select`, `ser`, `deser` (and their concurrent variants).
+  Default in code: `1`.
+- `N_ROWS`: Number of rows preinserted for select benchmarks.
+  Used by: `select`, `large_select` (and their concurrent variants).
+  Default in code: `10`.
+- `PAGE_SIZE`: Query page size.
+  Used by: `select`, `large_select`, `deser`, and `paging`.
+  Defaults in code: `5000` for `select`/`deser`, `1` for `paging`.
+
+## 1) Run Insert Benchmark Into A Fresh DB
+
+Create a new database file and run `insert` for each backend config.
+
+```bash
+export SCYLLA_URI=172.46.0.2:9042
+export REPOS_DIR="$HOME/repos"
+export CSHARP_REPO="$REPOS_DIR/csharp-driver"
+export NODEJS_REPO="$REPOS_DIR/nodejs-rs-driver"
+export SDB_MANIFEST="$REPOS_DIR/scylladb-drivers-benchmarker/Cargo.toml"
+export DB="$CSHARP_REPO/benchmark/results/results-database.db"
+```
+
+Run from `csharp-driver`:
+
+```bash
+cd "$CSHARP_REPO"
+
+cargo run --manifest-path "$SDB_MANIFEST" -- \
+  -d "$DB" run \
+  -B benchmark/runner-config/datastax/config.yml \
+  -b benchmark/runner-config/config.yml \
+  insert time
+
+cargo run --manifest-path "$SDB_MANIFEST" -- \
+  -d "$DB" run \
+  -B benchmark/runner-config/csharp-rs/config.yml \
+  -b benchmark/runner-config/config.yml \
+  -M force-rerun insert time
+```
+
+Run from `nodejs-rs-driver` (example backend):
+
+```bash
+cd "$NODEJS_REPO"
+
+cargo run --manifest-path "$SDB_MANIFEST" -- \
+  -d "$DB" run \
+  -B benchmark/runner-config/scylladb-driver/config.yml \
+  -b benchmark/runner-config/config.yml \
+  insert time
+```
+
+Repeat the same `run` command pattern for any additional backend config.
+
+## 2) Plot Insert Comparison
+
+Use `plot insert` with one `--series` per backend name stored in the DB.
+
+```bash
+cd "$CSHARP_REPO"
+
+cargo run --manifest-path "$SDB_MANIFEST" -- \
+  -d "$DB" plot insert \
+  -b benchmark/runner-config/config.yml \
+  --series datastax@"$CSHARP_REPO":HEAD=datastax \
+  --series csharp-rs@"$CSHARP_REPO":HEAD=csharp-rs \
+  --series scylladb-driver@"$NODEJS_REPO":HEAD=scylladb-nodejs-rs \
+  -o benchmark/results/insert-compare.svg \
+  series
+```
+
+Output plot: `benchmark/results/insert-compare.svg`
+
+## Notes
+
+- `--series` backend names must match the backend names saved by each config.
+- SDB stores results with the git commit hash of the repository where `run` was executed. This is how runs from different revisions are distinguished in one DB.
+- To compare specific revisions on one chart, pass refs in `--series`, for example: `--series csharp-rs@"$CSHARP_REPO":HEAD=main --series csharp-rs@"$CSHARP_REPO":<commit-sha>=candidate`.

--- a/benchmark/csharp-driver/Benchmarks/Batch.cs
+++ b/benchmark/csharp-driver/Benchmarks/Batch.cs
@@ -1,0 +1,46 @@
+using Cassandra;
+
+/// <summary>
+/// Executes logged batch insert operations in sequence.
+/// </summary>
+public static class BatchBenchmark
+{
+    // Empirically determined max batch size, that doesn't cause database error.
+    private const int Step = 3971;
+
+    public static async Task Run(ISession session, int iterations)
+    {
+        var prepared = await session.PrepareAsync(Common.BasicInsertQuery);
+
+        var chunks = (iterations + Step - 1) / Step;
+        for (var i = 0; i < chunks; i++)
+        {
+            var cLen = Math.Min(iterations - (i * Step), Step);
+
+            var batch = new BatchStatement()
+                .SetBatchType(BatchType.Logged);
+
+            for (var j = 0; j < cLen; j++)
+            {
+                batch.Add(prepared.Bind(Guid.NewGuid(), 1));
+            }
+
+            await session.ExecuteAsync(batch);
+        }
+
+        await Common.CheckRowCnt(session, iterations);
+    }
+}
+
+public static class BatchBenchmarkEntryPoint
+{
+    public static async Task Main()
+    {
+#if RUST_BACKED_DRIVER
+    throw new NotSupportedException("Batches are not yet supported by the csharp-rs driver.");
+#endif
+        var n = Common.GetCnt();
+        await using var context = await Common.InitSimpleTable();
+        await BatchBenchmark.Run(context.Session, n);
+    }
+}

--- a/benchmark/csharp-driver/Benchmarks/Paging.cs
+++ b/benchmark/csharp-driver/Benchmarks/Paging.cs
@@ -1,0 +1,67 @@
+using Cassandra;
+
+/// <summary>
+/// Executes paged full-table reads in sequence.
+///
+/// Configuration:
+///   PAGE_SIZE: page size for paged reads (default: 1)
+/// </summary>
+public static class PagingBenchmark
+{
+	private const int DefaultPageSize = 1;
+
+	public static async Task Run(ISession session, int iterations)
+	{
+		var pageSize = Common.GetPositiveIntEnvOrDefault("PAGE_SIZE", DefaultPageSize);
+
+		await Common.InsertDataIntoSimpleTable(session, 500);
+
+		var preparedSelect = await session.PrepareAsync(Common.BasicSelectQuery);
+
+		for (var index = 0; index < iterations; index++)
+		{
+			byte[]? pagingState = null;
+			var sum = 0;
+
+			while (true)
+			{
+				var statement = preparedSelect.Bind().SetAutoPage(false).SetPageSize(pageSize);
+				if (pagingState is { Length: > 0 })
+				{
+					statement = statement.SetPagingState(pagingState);
+				}
+
+				var result = await session.ExecuteAsync(statement);
+				foreach (var row in result)
+				{
+					sum += row.GetValue<int>("val");
+				}
+
+				if (result.PagingState == null || result.PagingState.Length == 0)
+				{
+					break;
+				}
+
+				pagingState = result.PagingState;
+			}
+
+			if (sum != 500)
+			{
+				throw new InvalidOperationException($"Expected sum 500, but found {sum}.");
+			}
+		}
+	}
+}
+
+public static class PagingBenchmarkEntryPoint
+{
+	public static async Task Main()
+	{
+#if RUST_BACKED_DRIVER
+	throw new NotSupportedException("Paging is not supported yet in the csharp-rs driver.");
+#endif
+		var n = Common.GetCnt();
+		await using var context = await Common.InitSimpleTable();
+		await PagingBenchmark.Run(context.Session, n);
+	}
+}

--- a/benchmark/csharp-driver/Benchmarks/ParametrizedDeser.cs
+++ b/benchmark/csharp-driver/Benchmarks/ParametrizedDeser.cs
@@ -1,0 +1,106 @@
+using Cassandra;
+
+/// <summary>
+/// Executes complex-row insert and full-table select operations to benchmark deserialization with configurable concurrency.
+///
+/// Configuration:
+///   N_WORKERS: number of concurrent workers for insert and select phases (default: 1)
+///   PAGE_SIZE: page size for select reads in deserialization phase (default: 5000)
+/// </summary>
+public static class ParametrizedDeserBenchmark
+{
+    private const int DefaultWorkers = 1;
+    private const int DefaultPageSize = 5000;
+
+    private static void ReadDeserRow(Row row)
+    {
+        _ = row.GetValue<Guid>("id");
+        _ = row.GetValue<int>("val");
+        _ = row.GetValue<TimeUuid>("tuuid");
+        _ = row.GetValue<System.Net.IPAddress>("ip");
+        _ = row.GetValue<LocalDate>("date");
+        _ = row.GetValue<LocalTime>("time");
+        _ = row.GetValue<Tuple<string, int>>("tuple");
+        _ = row.GetValue<DeserUdt1>("udt");
+        _ = row.GetValue<ISet<int>>("set1");
+        _ = row.GetValue<Duration>("duration");
+    }
+
+    private static async Task InsertData(ISession session, PreparedStatement prepared, int startIndex, int iterations, int workers)
+    {
+        var index = startIndex;
+        while (index < iterations)
+        {
+            await session.ExecuteAsync(prepared.Bind(Common.GetDeserData()));
+            index += workers;
+        }
+    }
+
+    private static async Task SelectData(
+        ISession session,
+        PreparedStatement prepared,
+        int startIndex,
+        int iterations,
+        int workers,
+        int pageSize)
+    {
+        var index = startIndex;
+        while (index < iterations)
+        {
+            var statement = prepared.Bind().SetPageSize(pageSize);
+            var result = await session.ExecuteAsync(statement);
+            var rowCount = 0;
+            foreach (var row in result)
+            {
+                ReadDeserRow(row);
+                rowCount++;
+            }
+
+            if (rowCount != iterations)
+            {
+                throw new InvalidOperationException(
+                    $"Expected {iterations} selected rows, but found {rowCount}.");
+            }
+
+            index += workers;
+        }
+    }
+
+    public static async Task Run(ISession session, int iterations)
+    {
+        var workers = Common.GetPositiveIntEnvOrDefault("N_WORKERS", DefaultWorkers);
+        var pageSize = Common.GetPositiveIntEnvOrDefault("PAGE_SIZE", DefaultPageSize);
+
+        Common.DefineDeserUdt(session);
+
+        var preparedInsert = await session.PrepareAsync(Common.DeserInsertQuery);
+        var insertTasks = new Task[workers];
+        for (var i = 0; i < workers; i++)
+        {
+            var startIndex = i;
+            insertTasks[i] = InsertData(session, preparedInsert, startIndex, iterations, workers);
+        }
+
+        await Task.WhenAll(insertTasks);
+
+        var preparedSelect = await session.PrepareAsync(Common.BasicSelectQuery);
+        var selectTasks = new Task[workers];
+        for (var i = 0; i < workers; i++)
+        {
+            var startIndex = i;
+            selectTasks[i] = SelectData(session, preparedSelect, startIndex, iterations, workers, pageSize);
+        }
+
+        await Task.WhenAll(selectTasks);
+    }
+}
+
+public static class ParametrizedDeserBenchmarkEntryPoint
+{
+    public static async Task Main()
+    {
+        var n = Common.GetCnt();
+        await using var context = await Common.InitDeserTable();
+        await ParametrizedDeserBenchmark.Run(context.Session, n);
+    }
+}

--- a/benchmark/csharp-driver/Benchmarks/ParametrizedInsert.cs
+++ b/benchmark/csharp-driver/Benchmarks/ParametrizedInsert.cs
@@ -1,0 +1,51 @@
+using Cassandra;
+
+/// <summary>
+/// Executes insert operations with configurable concurrency.
+///
+/// Configuration:
+///   N_WORKERS: number of concurrent insert workers (default: 1)
+///
+/// Measured operation:
+///   INSERT INTO benchmarks.basic (id, val) VALUES (?, ?)
+/// </summary>
+public static class ParametrizedInsertBenchmark
+{
+    private const int DefaultWorkers = 1;
+
+    private static async Task InsertData(ISession session, PreparedStatement prepared, int startIndex, int iterations, int workers)
+    {
+        var index = startIndex;
+        while (index < iterations)
+        {
+            await session.ExecuteAsync(prepared.Bind(Guid.NewGuid(), 100));
+            index += workers;
+        }
+    }
+
+    public static async Task Run(ISession session, int iterations)
+    {
+        var workers = Common.GetPositiveIntEnvOrDefault("N_WORKERS", DefaultWorkers);
+
+        var sharedPrepared = await session.PrepareAsync(Common.BasicInsertQuery);
+        var tasks = new Task[workers];
+        for (var i = 0; i < workers; i++)
+        {
+            var startIndex = i;
+            tasks[i] = InsertData(session, sharedPrepared, startIndex, iterations, workers);
+        }
+
+        await Task.WhenAll(tasks);
+        await Common.CheckRowCnt(session, iterations);
+    }
+}
+
+public static class ParametrizedInsertBenchmarkEntryPoint
+{
+    public static async Task Main()
+    {
+        var n = Common.GetCnt();
+        await using var context = await Common.InitSimpleTable();
+        await ParametrizedInsertBenchmark.Run(context.Session, n);
+    }
+}

--- a/benchmark/csharp-driver/Benchmarks/ParametrizedSelect.cs
+++ b/benchmark/csharp-driver/Benchmarks/ParametrizedSelect.cs
@@ -1,0 +1,81 @@
+using Cassandra;
+
+/// <summary>
+/// Executes full-table select operations with configurable table size and concurrency.
+///
+/// Configuration:
+///   N_ROWS: number of rows preinserted into benchmarks.basic (default: 10)
+///   N_WORKERS: number of concurrent select workers (default: 1)
+///   PAGE_SIZE: page size for SELECT * reads (default: 5000)
+///
+/// Measured operation:
+///   SELECT * FROM benchmarks.basic
+/// </summary>
+public static class ParametrizedSelectBenchmark
+{
+    private const int DefaultRows = 10;
+    private const int DefaultWorkers = 1;
+    private const int DefaultPageSize = 5000;
+
+    private static async Task SelectData(
+        ISession session,
+        PreparedStatement prepared,
+        int startIndex,
+        int iterations,
+        int workers,
+        int expectedRows,
+        int pageSize)
+    {
+        var index = startIndex;
+        while (index < iterations)
+        {
+            var statement = prepared.Bind().SetPageSize(pageSize);
+            var result = await session.ExecuteAsync(statement);
+            var rowCount = 0;
+            foreach (var row in result)
+            {
+                _ = row.GetValue<Guid>("id");
+                _ = row.GetValue<int>("val");
+                rowCount++;
+            }
+
+            if (rowCount != expectedRows)
+            {
+                throw new InvalidOperationException(
+                    $"Expected {expectedRows} selected rows, but found {rowCount}.");
+            }
+
+            index += workers;
+        }
+    }
+
+    public static async Task Run(ISession session, int iterations)
+    {
+        var rows = Common.GetPositiveIntEnvOrDefault("N_ROWS", DefaultRows);
+        var workers = Common.GetPositiveIntEnvOrDefault("N_WORKERS", DefaultWorkers);
+        var pageSize = Common.GetPositiveIntEnvOrDefault("PAGE_SIZE", DefaultPageSize);
+
+        await Common.InsertDataIntoSimpleTable(session, rows);
+
+        var preparedSelect = await session.PrepareAsync(Common.BasicSelectQuery);
+
+        var tasks = new Task[workers];
+        for (var i = 0; i < workers; i++)
+        {
+            var startIndex = i;
+            tasks[i] = SelectData(session, preparedSelect, startIndex, iterations, workers, rows, pageSize);
+        }
+
+        await Task.WhenAll(tasks);
+    }
+}
+
+public static class ParametrizedSelectBenchmarkEntryPoint
+{
+    public static async Task Main()
+    {
+        var n = Common.GetCnt();
+        await using var context = await Common.InitSimpleTable();
+        await ParametrizedSelectBenchmark.Run(context.Session, n);
+    }
+}

--- a/benchmark/csharp-driver/Benchmarks/ParametrizedSer.cs
+++ b/benchmark/csharp-driver/Benchmarks/ParametrizedSer.cs
@@ -1,0 +1,51 @@
+using Cassandra;
+
+/// <summary>
+/// Executes complex-row insert operations to benchmark serialization with configurable concurrency.
+///
+/// Configuration:
+///   N_WORKERS: number of concurrent insert workers (default: 1)
+/// </summary>
+public static class ParametrizedSerBenchmark
+{
+    private const int DefaultWorkers = 1;
+
+    private static async Task InsertData(ISession session, PreparedStatement prepared, int startIndex, int iterations, int workers)
+    {
+        var index = startIndex;
+        while (index < iterations)
+        {
+            await session.ExecuteAsync(prepared.Bind(Common.GetDeserData()));
+            index += workers;
+        }
+    }
+
+    public static async Task Run(ISession session, int iterations)
+    {
+        var workers = Common.GetPositiveIntEnvOrDefault("N_WORKERS", DefaultWorkers);
+        var totalInserts = iterations * iterations;
+
+        Common.DefineDeserUdt(session);
+
+        var sharedPrepared = await session.PrepareAsync(Common.DeserInsertQuery);
+        var tasks = new Task[workers];
+        for (var i = 0; i < workers; i++)
+        {
+            var startIndex = i;
+            tasks[i] = InsertData(session, sharedPrepared, startIndex, totalInserts, workers);
+        }
+
+        await Task.WhenAll(tasks);
+        await Common.CheckRowCnt(session, totalInserts);
+    }
+}
+
+public static class ParametrizedSerBenchmarkEntryPoint
+{
+    public static async Task Main()
+    {
+        var n = Common.GetCnt();
+        await using var context = await Common.InitDeserTable();
+        await ParametrizedSerBenchmark.Run(context.Session, n);
+    }
+}

--- a/benchmark/csharp-driver/Common.cs
+++ b/benchmark/csharp-driver/Common.cs
@@ -1,0 +1,241 @@
+using Cassandra;
+using System.Net;
+
+/// <summary>
+/// Holds initialized cluster and session objects used by benchmark scenarios.
+/// </summary>
+public sealed class SessionContext : IAsyncDisposable
+{
+    public SessionContext(ICluster cluster, ISession session)
+    {
+        Cluster = cluster;
+        Session = session;
+    }
+
+    public ICluster Cluster { get; }
+    public ISession Session { get; }
+
+#if RUST_BACKED_DRIVER
+    public async ValueTask DisposeAsync()
+    {
+        await Session.ShutdownAsync();
+        Cluster.Dispose();
+    }
+#else
+    public ValueTask DisposeAsync()
+    {
+        Session.Dispose();
+        Cluster.Dispose();
+        return ValueTask.CompletedTask;
+    }
+#endif
+}
+
+public sealed class DeserUdt1
+{
+    public string Field1 { get; init; } = string.Empty;
+
+    public int Field2 { get; init; }
+}
+
+public static class Common
+{
+    public const string BasicInsertQuery = "INSERT INTO benchmarks.basic (id, val) VALUES (?, ?)";
+
+    public const string BasicSelectQuery = "SELECT * FROM benchmarks.basic";
+
+    public const string DeserInsertQuery =
+        "INSERT INTO benchmarks.basic (id, val, tuuid, ip, date, time, tuple, udt, set1, duration) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+    /// <summary>
+    /// Reads the number of benchmark iterations from the CNT environment variable.
+    /// </summary>
+    /// <returns>Parsed CNT value.</returns>
+    public static int GetCnt()
+    {
+        return Environment.GetEnvironmentVariable("CNT")
+            is { } raw && int.TryParse(raw, out var cnt)
+            ? cnt
+            : throw new InvalidOperationException("CNT parameter is required.");
+    }
+
+    /// <summary>
+    /// Reads a positive integer benchmark parameter from an environment variable or returns a default value.
+    /// </summary>
+    /// <param name="name">Environment variable name.</param>
+    /// <param name="defaultValue">Fallback value when the variable is not set.</param>
+    public static int GetPositiveIntEnvOrDefault(string name, int defaultValue)
+    {
+        var raw = Environment.GetEnvironmentVariable(name);
+        if (raw is null)
+        {
+            return defaultValue;
+        }
+
+        if (int.TryParse(raw, out var value) && value > 0)
+        {
+            return value;
+        }
+
+        throw new InvalidOperationException($"{name} must be a positive integer, got '{raw}'.");
+    }
+
+    /// <summary>
+    /// Initializes the basic benchmark table.
+    /// </summary>
+    /// <returns>A ready-to-use benchmark session context.</returns>
+    public static async Task<SessionContext> InitSimpleTable()
+    {
+        return await InitCommon("CREATE TABLE benchmarks.basic (id uuid PRIMARY KEY, val int)");
+    }
+
+    /// <summary>
+    /// Initializes the complex benchmark table used by serialization and deserialization scenarios.
+    /// </summary>
+    /// <returns>A ready-to-use benchmark session context.</returns>
+    public static async Task<SessionContext> InitDeserTable()
+    {
+        var context = await InitSimpleTable();
+        var session = context.Session;
+
+        await session.ExecuteAsync(new SimpleStatement(
+            "CREATE TYPE IF NOT EXISTS benchmarks.udt1 (field1 text, field2 int)"));
+        await session.ExecuteAsync(new SimpleStatement("DROP TABLE IF EXISTS benchmarks.basic"));
+        await session.ExecuteAsync(new SimpleStatement(
+            "CREATE TABLE benchmarks.basic (" +
+            "id uuid, val int, tuuid timeuuid, ip inet, date date, time time, " +
+            "tuple frozen<tuple<text, int>>, udt frozen<udt1>, set1 set<int>, duration duration, PRIMARY KEY(id))"));
+
+        return context;
+    }
+
+    public static async Task InsertDataIntoSimpleTable(ISession session, int n)
+    {
+        var preparedInsert = await session.PrepareAsync(BasicInsertQuery);
+        for (var index = 0; index < n; index++)
+        {
+            await session.ExecuteAsync(preparedInsert.Bind(Guid.NewGuid(), 100));
+        }
+    }
+
+    /// <summary>
+    /// Registers UDT mapping used by complex benchmark rows.
+    /// </summary>
+    /// <param name="session">Session used for UDT registration.</param>
+    public static void DefineDeserUdt(ISession session)
+    {
+        session.UserDefinedTypes.Define(
+            UdtMap.For<DeserUdt1>("udt1", keyspace: "benchmarks")
+                .Map(v => v.Field1, "field1")
+                .Map(v => v.Field2, "field2"));
+    }
+
+    /// <summary>
+    /// Creates a payload row matching the complex benchmark table schema.
+    /// </summary>
+    public static object[] GetDeserData()
+    {
+        var now = DateTime.Now;
+        return
+        [
+            Guid.NewGuid(),
+            100,
+            TimeUuid.Parse("8e14e760-7fa8-11eb-bc66-000000000001"),
+            IPAddress.Parse("192.168.0.1"),
+            new LocalDate(now.Year, now.Month, now.Day),
+            new LocalTime(now.Hour, now.Minute, now.Second, now.Millisecond * 1_000_000),
+            new Tuple<string, int>(
+                "Litwo! Ojczyzno moja! ty jestes jak zdrowie: Ile cie trzeba cenic, ten tylko sie dowie, Kto cie stracil. Dzis pieknosc twa w calej ozdobie Widze i opisuje, bo tesknie po tobie.\n",
+                1),
+            new DeserUdt1
+            {
+                Field1 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis congue egestas sapien id maximus eget.",
+                Field2 = 4321
+            },
+            new HashSet<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 11 },
+            new Duration(1, 2, 3)
+        ];
+    }
+
+    /// <summary>
+    /// Verifies that the benchmark table contains exactly the expected number of rows.
+    /// </summary>
+    /// <param name="session">Session used to query row count.</param>
+    /// <param name="n">Expected number of rows.</param>
+    public static async Task CheckRowCnt(ISession session, int n)
+    {
+        var preparedSelect = await session.PrepareAsync("SELECT COUNT(1) FROM benchmarks.basic");
+        var countResult = await session.ExecuteAsync(preparedSelect.Bind());
+
+        // Result sets are enumerable; read the first row to get the aggregate value.
+        Row? countRow = null;
+        foreach (var row in countResult)
+        {
+            countRow = row;
+            break;
+        }
+
+        if (countRow == null)
+        {
+            throw new InvalidOperationException("Failed to retrieve count of rows.");
+        }
+
+        var rows = countRow.GetValue<long>(0);
+        if (rows != n)
+        {
+            throw new InvalidOperationException($"Expected {n} rows, but found {rows}.");
+        }
+    }
+
+    /// <summary>
+    /// Creates a new benchmark keyspace and table based on the provided schema.
+    /// Existing basic table data is dropped before creation.
+    /// </summary>
+    /// <param name="schema">CREATE TABLE statement for benchmarks.basic.</param>
+    /// <returns>A ready-to-use benchmark session context.</returns>
+    private static async Task<SessionContext> InitCommon(string schema)
+    {
+        var uri = Environment.GetEnvironmentVariable("SCYLLA_URI") ?? "172.47.0.2";
+        var clusterBuilder = Cluster.Builder();
+
+#if DATASTAX_DRIVER
+        var (host, port) = ParseHostAndPort(uri);
+        clusterBuilder = clusterBuilder.AddContactPoint(host).WithPort(port);
+#else
+        clusterBuilder = clusterBuilder.AddContactPoint(uri);
+#endif
+
+        var cluster = clusterBuilder.Build();
+        var session = await cluster.ConnectAsync();
+
+        await session.ExecuteAsync(new SimpleStatement(
+            "CREATE KEYSPACE IF NOT EXISTS benchmarks WITH replication = " +
+            "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}"));
+
+        await session.ExecuteAsync(new SimpleStatement("DROP TABLE IF EXISTS benchmarks.basic"));
+        await session.ExecuteAsync(new SimpleStatement(schema));
+
+        return new SessionContext(cluster, session);
+    }
+
+#if DATASTAX_DRIVER
+    /// <summary>
+    /// Parses host and optional port in the form host[:port] for the DataStax driver.
+    /// </summary>
+    /// <param name="input">Host or host:port value.</param>
+    /// <returns>Tuple containing parsed host and port.</returns>
+    private static (string Host, int Port) ParseHostAndPort(string input)
+    {
+        var host = input;
+        var port = 9042;
+        var parts = input.Split(':', 2);
+        if (parts.Length == 2 && int.TryParse(parts[1], out var parsedPort))
+        {
+            host = parts[0];
+            port = parsedPort;
+        }
+
+        return (host, port);
+    }
+#endif
+}

--- a/benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj
+++ b/benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <BenchmarkEntryPoint Condition="'$(BenchmarkEntryPoint)' == ''">ParametrizedInsertBenchmarkEntryPoint</BenchmarkEntryPoint>
+    <StartupObject>$(BenchmarkEntryPoint)</StartupObject>
+    <OutputPath>bin/$(Configuration)/$(BenchmarkEntryPoint)/</OutputPath>
+    <IntermediateOutputPath>obj/$(Configuration)/$(BenchmarkEntryPoint)/</IntermediateOutputPath>
+    <DefineConstants>$(DefineConstants);RUST_BACKED_DRIVER</DefineConstants>
+    <AssemblyName>ScyllaCSharpBench</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../Common.cs" />
+    <Compile Include="../Benchmarks/**/*.cs" />
+    <ProjectReference Include="../../../src/Cassandra/Cassandra.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.13" />
+  </ItemGroup>
+
+  <Target Name="BuildRustNativeWrapper" BeforeTargets="Build" Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true'">
+    <PropertyGroup>
+      <RustProjectDir>$(MSBuildThisFileDirectory)../../../rust</RustProjectDir>
+    </PropertyGroup>
+
+    <Exec Command="cd &quot;$(RustProjectDir)&quot; &amp;&amp; cargo build --release &amp;&amp; cd - &gt;/dev/null" />
+  </Target>
+
+  <Target Name="LinkRustNativeWrapper" AfterTargets="Build" Condition="'$(OS)' != 'Windows_NT'">
+    <PropertyGroup>
+      <RustWrapperSo>$(MSBuildThisFileDirectory)../../../rust/target/release/libcsharp_wrapper.so</RustWrapperSo>
+      <OutputWrapperSo>$(TargetDir)libcsharp_wrapper.so</OutputWrapperSo>
+    </PropertyGroup>
+
+    <Exec
+      Condition="Exists('$(RustWrapperSo)')"
+      Command="ln -sf &quot;$(RustWrapperSo)&quot; &quot;$(OutputWrapperSo)&quot;" />
+  </Target>
+
+</Project>

--- a/benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj
+++ b/benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>DatastaxCSharpBench</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <BenchmarkEntryPoint Condition="'$(BenchmarkEntryPoint)' == ''">ParametrizedInsertBenchmarkEntryPoint</BenchmarkEntryPoint>
+    <StartupObject>$(BenchmarkEntryPoint)</StartupObject>
+    <OutputPath>bin/$(Configuration)/$(BenchmarkEntryPoint)/</OutputPath>
+    <IntermediateOutputPath>obj/$(Configuration)/$(BenchmarkEntryPoint)/</IntermediateOutputPath>
+    <DefineConstants Condition="'$(DefineConstants)' != ''">$(DefineConstants);DATASTAX_DRIVER</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">DATASTAX_DRIVER</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../Common.cs" />
+    <Compile Include="../Benchmarks/**/*.cs" />
+    <PackageReference Include="ScyllaDBCSharpDriver" Version="3.22.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/benchmark/runner-config/config.yml
+++ b/benchmark/runner-config/config.yml
@@ -1,0 +1,44 @@
+defaults:
+  num-runs: 3
+  no-steps: 4
+  step-progress: 4
+  progress-type: multiplicative
+  measure: time
+  timeout: "200s"
+
+benchmarks:
+  - name: insert
+    starting-step: 6250
+
+  - name: concurrent_insert
+    starting-step: 62500
+
+  - name: select
+    starting-step: 1563
+
+  - name: concurrent_select
+    starting-step: 6250
+
+  - name: ser
+    starting-step: 15
+
+  - name: concurrent_ser
+    starting-step: 19
+
+  - name: deser
+    starting-step: 32
+
+  - name: concurrent_deser
+    starting-step: 32
+
+  - name: paging
+    starting-step: 63
+
+  - name: large_select
+    starting-step: 63
+
+  - name: concurrent_large_select
+    starting-step: 156
+
+  - name: batch
+    starting-step: 46875

--- a/benchmark/runner-config/csharp-rs/config.yml
+++ b/benchmark/runner-config/csharp-rs/config.yml
@@ -1,0 +1,51 @@
+defaults:
+  name: csharp-rs
+
+backends:
+  - benchmark-name: insert
+    build-command: dotnet build benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedInsertBenchmarkEntryPoint
+    run-command: env N_WORKERS=1 ./benchmark/runner-config/run-csharp-benchmark.sh csharp-rs ParametrizedInsertBenchmarkEntryPoint
+
+  - benchmark-name: concurrent_insert
+    build-command: dotnet build benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedInsertBenchmarkEntryPoint
+    run-command: env N_WORKERS=100 ./benchmark/runner-config/run-csharp-benchmark.sh csharp-rs ParametrizedInsertBenchmarkEntryPoint
+
+  - benchmark-name: select
+    build-command: dotnet build benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedSelectBenchmarkEntryPoint
+    run-command: env N_ROWS=10 N_WORKERS=1 ./benchmark/runner-config/run-csharp-benchmark.sh csharp-rs ParametrizedSelectBenchmarkEntryPoint
+
+  - benchmark-name: concurrent_select
+    build-command: dotnet build benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedSelectBenchmarkEntryPoint
+    run-command: env N_ROWS=10 N_WORKERS=100 ./benchmark/runner-config/run-csharp-benchmark.sh csharp-rs ParametrizedSelectBenchmarkEntryPoint
+
+  - benchmark-name: batch
+    build-command: dotnet build benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=BatchBenchmarkEntryPoint
+    run-command: ./benchmark/runner-config/run-csharp-benchmark.sh csharp-rs BatchBenchmarkEntryPoint
+
+  - benchmark-name: paging
+    build-command: dotnet build benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=PagingBenchmarkEntryPoint
+    run-command: ./benchmark/runner-config/run-csharp-benchmark.sh csharp-rs PagingBenchmarkEntryPoint
+
+  - benchmark-name: large_select
+    build-command: dotnet build benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedSelectBenchmarkEntryPoint
+    run-command: env N_ROWS=5000 N_WORKERS=1 ./benchmark/runner-config/run-csharp-benchmark.sh csharp-rs ParametrizedSelectBenchmarkEntryPoint
+
+  - benchmark-name: concurrent_large_select
+    build-command: dotnet build benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedSelectBenchmarkEntryPoint
+    run-command: env N_ROWS=5000 N_WORKERS=100 ./benchmark/runner-config/run-csharp-benchmark.sh csharp-rs ParametrizedSelectBenchmarkEntryPoint
+
+  - benchmark-name: ser
+    build-command: dotnet build benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedSerBenchmarkEntryPoint
+    run-command: env N_WORKERS=1 ./benchmark/runner-config/run-csharp-benchmark.sh csharp-rs ParametrizedSerBenchmarkEntryPoint
+
+  - benchmark-name: concurrent_ser
+    build-command: dotnet build benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedSerBenchmarkEntryPoint
+    run-command: env N_WORKERS=100 ./benchmark/runner-config/run-csharp-benchmark.sh csharp-rs ParametrizedSerBenchmarkEntryPoint
+
+  - benchmark-name: deser
+    build-command: dotnet build benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedDeserBenchmarkEntryPoint
+    run-command: env N_WORKERS=1 ./benchmark/runner-config/run-csharp-benchmark.sh csharp-rs ParametrizedDeserBenchmarkEntryPoint
+
+  - benchmark-name: concurrent_deser
+    build-command: dotnet build benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedDeserBenchmarkEntryPoint
+    run-command: env N_WORKERS=100 ./benchmark/runner-config/run-csharp-benchmark.sh csharp-rs ParametrizedDeserBenchmarkEntryPoint

--- a/benchmark/runner-config/datastax/config.yml
+++ b/benchmark/runner-config/datastax/config.yml
@@ -1,0 +1,51 @@
+defaults:
+  name: datastax
+
+backends:
+  - benchmark-name: insert
+    build-command: dotnet build benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedInsertBenchmarkEntryPoint
+    run-command: env N_WORKERS=1 ./benchmark/runner-config/run-csharp-benchmark.sh datastax ParametrizedInsertBenchmarkEntryPoint
+
+  - benchmark-name: concurrent_insert
+    build-command: dotnet build benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedInsertBenchmarkEntryPoint
+    run-command: env N_WORKERS=100 ./benchmark/runner-config/run-csharp-benchmark.sh datastax ParametrizedInsertBenchmarkEntryPoint
+
+  - benchmark-name: select
+    build-command: dotnet build benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedSelectBenchmarkEntryPoint
+    run-command: env N_ROWS=10 N_WORKERS=1 ./benchmark/runner-config/run-csharp-benchmark.sh datastax ParametrizedSelectBenchmarkEntryPoint
+
+  - benchmark-name: concurrent_select
+    build-command: dotnet build benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedSelectBenchmarkEntryPoint
+    run-command: env N_ROWS=10 N_WORKERS=100 ./benchmark/runner-config/run-csharp-benchmark.sh datastax ParametrizedSelectBenchmarkEntryPoint
+
+  - benchmark-name: batch
+    build-command: dotnet build benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=BatchBenchmarkEntryPoint
+    run-command: ./benchmark/runner-config/run-csharp-benchmark.sh datastax BatchBenchmarkEntryPoint
+
+  - benchmark-name: paging
+    build-command: dotnet build benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=PagingBenchmarkEntryPoint
+    run-command: ./benchmark/runner-config/run-csharp-benchmark.sh datastax PagingBenchmarkEntryPoint
+
+  - benchmark-name: large_select
+    build-command: dotnet build benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedSelectBenchmarkEntryPoint
+    run-command: env N_ROWS=5000 N_WORKERS=1 ./benchmark/runner-config/run-csharp-benchmark.sh datastax ParametrizedSelectBenchmarkEntryPoint
+
+  - benchmark-name: concurrent_large_select
+    build-command: dotnet build benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedSelectBenchmarkEntryPoint
+    run-command: env N_ROWS=5000 N_WORKERS=100 ./benchmark/runner-config/run-csharp-benchmark.sh datastax ParametrizedSelectBenchmarkEntryPoint
+
+  - benchmark-name: ser
+    build-command: dotnet build benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedSerBenchmarkEntryPoint
+    run-command: env N_WORKERS=1 ./benchmark/runner-config/run-csharp-benchmark.sh datastax ParametrizedSerBenchmarkEntryPoint
+
+  - benchmark-name: concurrent_ser
+    build-command: dotnet build benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedSerBenchmarkEntryPoint
+    run-command: env N_WORKERS=100 ./benchmark/runner-config/run-csharp-benchmark.sh datastax ParametrizedSerBenchmarkEntryPoint
+
+  - benchmark-name: deser
+    build-command: dotnet build benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedDeserBenchmarkEntryPoint
+    run-command: env N_WORKERS=1 ./benchmark/runner-config/run-csharp-benchmark.sh datastax ParametrizedDeserBenchmarkEntryPoint
+
+  - benchmark-name: concurrent_deser
+    build-command: dotnet build benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj -c Release -p:BenchmarkEntryPoint=ParametrizedDeserBenchmarkEntryPoint
+    run-command: env N_WORKERS=100 ./benchmark/runner-config/run-csharp-benchmark.sh datastax ParametrizedDeserBenchmarkEntryPoint

--- a/benchmark/runner-config/run-csharp-benchmark.sh
+++ b/benchmark/runner-config/run-csharp-benchmark.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Wrapper on the command for benchmark runner.
+# Usage: run-csharp-benchmark.sh <driver> <entry-point> <N>
+set -euo pipefail
+
+DRIVER="${1:-}"
+ENTRY_POINT="${2:-}"
+N="${3:-}"
+
+if [[ -z "$DRIVER" || -z "$ENTRY_POINT" || -z "$N" ]]; then
+  echo "Usage: $0 <driver> <entry-point> <N>" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/../.."
+
+case "$DRIVER" in
+  datastax)
+    PROJECT_PATH="$REPO_ROOT/benchmark/csharp-driver/datastax/DatastaxCSharpBench.csproj"
+    ;;
+  csharp-rs)
+    PROJECT_PATH="$REPO_ROOT/benchmark/csharp-driver/csharp-rs/ScyllaCSharpBench.csproj"
+    ;;
+  *)
+    echo "Unsupported driver '$DRIVER'. Expected one of: datastax, csharp-rs" >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! -f "$PROJECT_PATH" ]]; then
+  echo "Benchmark project not found at '$PROJECT_PATH'." >&2
+  exit 1
+fi
+
+CNT="$N" dotnet run --no-build -c Release --project "$PROJECT_PATH" -p:BenchmarkEntryPoint="$ENTRY_POINT"

--- a/src/Cassandra/RustBridge/RustBridge.cs
+++ b/src/Cassandra/RustBridge/RustBridge.cs
@@ -488,8 +488,6 @@ namespace Cassandra
                             // The Rust code is responsible for interpreting the pointer's contents
                             // memory is freed when the C# RustResource releases it.
                             tcs.SetResult(result);
-
-                            Console.Error.WriteLine($"[FFI] CompleteTask done.");
                         }
                         else
                         {


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- [x] I have adjusted the documentation in `./docs/source/`.
- ~~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.

Fixes: #98 

## Summary
This PR adds benchmarks to compare drivers using the ScyllaDB driver benchmarker:
- new C# driver (Rust-backed, this project)
- ScyllaDB fork of DataStax C# driver
    
 ## Benchmarks covered
- insert: sequential INSERT throughput
- select: repeated full-table SELECT throughput
- concurrent_insert: 100-worker concurrent INSERT throughput
- concurrent_select: 100-worker concurrent SELECT
- serialization (with concurrent variant)
- deserialization (with concurrent variant)
- large select
- batch - only works for datastax
- paging - only works for datastax

## How to run
- Start Scylla cluster
- Run benchmarks using the benchmarker
- Plot results using the benchmarker

Instructions for using the benchmarker can be found in:
- https://github.com/scylladb-drivers-benchmarker/scylladb-drivers-benchmarker/tree/v0.1.0
- https://github.com/scylladb/nodejs-rs-driver/blob/main/benchmark/README.md

## Output artifacts
- .db file with saved results
- .svg file with time vs input size graph

## Example plots:
All benchmarks were ran using CCM on POTWOREK.
<img width="1920" height="1080" alt="insert" src="https://github.com/user-attachments/assets/a1e12983-efda-4c48-b9a0-32353b739a81" />
<img width="1920" height="1080" alt="concurrent_insert" src="https://github.com/user-attachments/assets/2c6c411e-2d21-4cbd-a542-a708b0a59189" />
<img width="1920" height="1080" alt="select" src="https://github.com/user-attachments/assets/b9e36a8b-af05-4e64-b2e2-61c922f35842" />
<img width="1920" height="1080" alt="concurrent_select" src="https://github.com/user-attachments/assets/2f11e2cd-60c3-4040-bec1-aac75fe4d55c" />
<img width="1920" height="1080" alt="ser" src="https://github.com/user-attachments/assets/b0bc78a8-4395-4c77-90f1-8e09f72f585b" />
<img width="1920" height="1080" alt="concurrent_ser" src="https://github.com/user-attachments/assets/f1d87bc6-fead-4864-b48f-9af03587cb30" />
<img width="1920" height="1080" alt="deser" src="https://github.com/user-attachments/assets/1a9ffe58-d8ed-47ac-bba2-f1bcdf982c68" />
<img width="1920" height="1080" alt="concurrent_deser" src="https://github.com/user-attachments/assets/3a88c5eb-bba0-4b3f-8544-85ecc33be940" />
