### PR TITLE
Implement additional Prepared statement API and move tests

### DIFF
--- a/rust/src/error_conversion.rs
+++ b/rust/src/error_conversion.rs
@@ -317,6 +317,9 @@ pub(crate) enum MaybeShutdownError<E> {
 
     #[error("Session has been shut down and can no longer execute operations")]
     AlreadyShutdown,
+
+    #[error("Invalid argument: {0}")]
+    InvalidArgument(String),
 }
 
 /// Trait for converting Rust error types into pointers to C# exceptions using constructors from the TCB.
@@ -692,6 +695,9 @@ where
                 .construct_from_rust(
                     "Session has been shut down and can no longer execute operations",
                 ),
+            MaybeShutdownError::InvalidArgument(msg) => ctors
+                .invalid_argument_exception_constructor
+                .construct_from_rust(&msg),
         }
     }
 }

--- a/rust/src/prepared_statement.rs
+++ b/rust/src/prepared_statement.rs
@@ -1,5 +1,8 @@
 use crate::error_conversion::FFIMaybeException;
-use crate::ffi::{ArcFFI, BridgedBorrowedSharedPtr, FFI, FFIBool, FFIPtr, FFIStr, FromArc, RefFFI};
+use crate::ffi::{
+    ArcFFI, BridgedBorrowedSharedPtr, FFI, FFIBool, FFIPtr, FFIStr, FromArc, RefFFI,
+    ffi_callback_for_each,
+};
 use crate::row_set::column_type_to_code;
 use scylla::frame::response::result::ColumnType;
 use scylla::statement::prepared::PreparedStatement;
@@ -54,6 +57,17 @@ type SetPreparedStatementVariablesMetadata = unsafe extern "C" fn(
     is_frozen: u8,
 ) -> FFIMaybeException;
 
+enum PartitionKeyIndexesList {}
+
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct PartitionKeyIndexesListPtr<'a>(FFIPtr<'a, PartitionKeyIndexesList>);
+
+type AddPartitionKeyIndex = unsafe extern "C" fn(
+    pk_indexes_list_ptr: PartitionKeyIndexesListPtr<'_>,
+    index: u16,
+) -> FFIMaybeException;
+
 /// Calls back into C# for each column to provide column specs metadata.
 /// `metadata_setter` is a function pointer supplied by C# - it will be called synchronously for each column.
 /// SAFETY: This function assumes that `columns_ptr` is a valid pointer
@@ -64,6 +78,8 @@ pub extern "C" fn prepared_statement_fill_column_specs_metadata(
     prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
     columns_ptr: ColumnsPtr<'_>,
     set_prepared_statement_variables_metadata: SetPreparedStatementVariablesMetadata,
+    pk_indexes_list_ptr: PartitionKeyIndexesListPtr<'_>,
+    add_pk_index: AddPartitionKeyIndex,
 ) -> FFIMaybeException {
     let prepared_statement = ArcFFI::as_ref(prepared_statement_ptr)
         .expect("valid and non-null BridgedPreparedStatement pointer");
@@ -112,7 +128,17 @@ pub extern "C" fn prepared_statement_fill_column_specs_metadata(
             }
         }
     }
-    FFIMaybeException::ok()
+
+    unsafe {
+        ffi_callback_for_each(
+            pk_indexes_list_ptr,
+            add_pk_index,
+            guard
+                .get_variable_pk_indexes()
+                .iter()
+                .map(|pk_indexes| pk_indexes.index),
+        )
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/rust/src/prepared_statement.rs
+++ b/rust/src/prepared_statement.rs
@@ -1,5 +1,5 @@
 use crate::error_conversion::FFIMaybeException;
-use crate::ffi::{ArcFFI, BridgedBorrowedSharedPtr, FFI, FFIPtr, FFIStr, FromArc, RefFFI};
+use crate::ffi::{ArcFFI, BridgedBorrowedSharedPtr, FFI, FFIBool, FFIPtr, FFIStr, FromArc, RefFFI};
 use crate::row_set::column_type_to_code;
 use scylla::frame::response::result::ColumnType;
 use scylla::statement::prepared::PreparedStatement;
@@ -110,13 +110,14 @@ pub extern "C" fn prepared_statement_fill_column_specs_metadata(
 #[unsafe(no_mangle)]
 pub extern "C" fn prepared_statement_is_lwt(
     prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
-    is_lwt: *mut bool,
+    is_lwt: &mut FFIBool,
 ) -> FFIMaybeException {
-    unsafe {
-        *is_lwt = ArcFFI::as_ref(prepared_statement_ptr)
-            .unwrap()
-            .inner
-            .is_confirmed_lwt();
-    }
+    let prepared_statement = ArcFFI::as_ref(prepared_statement_ptr)
+        .expect("valid and non-null BridgedPreparedStatement pointer");
+
+    let is_lwt_value = prepared_statement.inner.is_confirmed_lwt();
+
+    *is_lwt = is_lwt_value.into();
+
     FFIMaybeException::ok()
 }

--- a/rust/src/prepared_statement.rs
+++ b/rust/src/prepared_statement.rs
@@ -13,20 +13,6 @@ impl FFI for BridgedPreparedStatement {
     type Origin = FromArc;
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn prepared_statement_is_lwt(
-    prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
-    is_lwt: *mut bool,
-) -> FFIMaybeException {
-    unsafe {
-        *is_lwt = ArcFFI::as_ref(prepared_statement_ptr)
-            .unwrap()
-            .inner
-            .is_confirmed_lwt();
-    }
-    FFIMaybeException::ok()
-}
-
 /// Gets the number of variable column specifications in the prepared statement.
 #[unsafe(no_mangle)]
 pub extern "C" fn prepared_statement_get_variables_column_specs_count(
@@ -117,6 +103,20 @@ pub extern "C" fn prepared_statement_fill_column_specs_metadata(
                 return ffi_exception;
             }
         }
+    }
+    FFIMaybeException::ok()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn prepared_statement_is_lwt(
+    prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
+    is_lwt: *mut bool,
+) -> FFIMaybeException {
+    unsafe {
+        *is_lwt = ArcFFI::as_ref(prepared_statement_ptr)
+            .unwrap()
+            .inner
+            .is_confirmed_lwt();
     }
     FFIMaybeException::ok()
 }

--- a/rust/src/prepared_statement.rs
+++ b/rust/src/prepared_statement.rs
@@ -4,6 +4,7 @@ use crate::ffi::{
     ffi_callback_for_each,
 };
 use crate::row_set::column_type_to_code;
+use crate::task::ExceptionConstructors;
 use scylla::frame::response::result::ColumnType;
 use scylla::statement::prepared::PreparedStatement;
 use std::sync::RwLock;
@@ -157,6 +158,61 @@ pub extern "C" fn prepared_statement_is_lwt(
     let is_lwt_value = guard.is_confirmed_lwt();
 
     *is_lwt = is_lwt_value.into();
+
+    FFIMaybeException::ok()
+}
+
+/// Gets consistency level of the prepared statement.
+#[unsafe(no_mangle)]
+pub extern "C" fn prepared_statement_get_consistency_level(
+    prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
+    consistency_level: Option<&mut i32>,
+) -> FFIMaybeException {
+    let prepared_statement = ArcFFI::as_ref(prepared_statement_ptr)
+        .expect("valid and non-null BridgedPreparedStatement pointer");
+
+    let guard = prepared_statement
+        .inner
+        .read()
+        .expect("poisoning impossible due to process-aborting panics");
+
+    let maybe_consistency = guard.get_consistency();
+
+    if let (Some(cl), Some(consistency_level)) = (maybe_consistency, consistency_level) {
+        *consistency_level = cl as i32;
+    }
+    FFIMaybeException::ok()
+}
+
+/// Sets consistency level of the prepared statement.
+#[unsafe(no_mangle)]
+pub extern "C" fn prepared_statement_set_consistency_level(
+    prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
+    consistency_level: u16,
+    constructors: &'static ExceptionConstructors,
+) -> FFIMaybeException {
+    let prepared_statement = ArcFFI::as_ref(prepared_statement_ptr)
+        .expect("valid and non-null BridgedPreparedStatement pointer");
+
+    let mut guard = prepared_statement
+        .inner
+        .write()
+        .expect("poisoning impossible due to process-aborting panics");
+
+    let Ok(cl) = consistency_level.try_into() else {
+        let ex = constructors
+            .invalid_argument_exception_constructor
+            .construct_from_rust(
+                format!(
+                    "Invalid consistency level value {0} passed from C#.",
+                    consistency_level
+                )
+                .as_str(),
+            );
+        return FFIMaybeException::from_exception(ex);
+    };
+
+    guard.set_consistency(cl);
 
     FFIMaybeException::ok()
 }

--- a/rust/src/prepared_statement.rs
+++ b/rust/src/prepared_statement.rs
@@ -216,3 +216,42 @@ pub extern "C" fn prepared_statement_set_consistency_level(
 
     FFIMaybeException::ok()
 }
+
+/// Gets whether the prepared statement is idempotent.
+#[unsafe(no_mangle)]
+pub extern "C" fn prepared_statement_get_is_idempotent(
+    prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
+    is_idempotent: &mut FFIBool,
+) -> FFIMaybeException {
+    let prepared_statement = ArcFFI::as_ref(prepared_statement_ptr)
+        .expect("valid and non-null BridgedPreparedStatement pointer");
+
+    let guard = prepared_statement
+        .inner
+        .read()
+        .expect("poisoning impossible due to process-aborting panics");
+    let is_idempotent_value = guard.get_is_idempotent();
+
+    *is_idempotent = is_idempotent_value.into();
+
+    FFIMaybeException::ok()
+}
+
+/// Sets whether the prepared statement is idempotent.
+#[unsafe(no_mangle)]
+pub extern "C" fn prepared_statement_set_is_idempotent(
+    prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
+    is_idempotent: FFIBool,
+) -> FFIMaybeException {
+    let prepared_statement = ArcFFI::as_ref(prepared_statement_ptr)
+        .expect("valid and non-null BridgedPreparedStatement pointer");
+
+    let mut guard = prepared_statement
+        .inner
+        .write()
+        .expect("poisoning impossible due to process-aborting panics");
+
+    guard.set_is_idempotent(is_idempotent.into());
+
+    FFIMaybeException::ok()
+}

--- a/rust/src/prepared_statement.rs
+++ b/rust/src/prepared_statement.rs
@@ -40,11 +40,11 @@ enum Columns {}
 
 #[repr(transparent)]
 #[derive(Clone, Copy)]
-pub struct ColumnsPtr(FFIPtr<'static, Columns>);
+pub struct ColumnsPtr<'a>(FFIPtr<'a, Columns>);
 
 // Function pointer type for setting column specs metadata in C#.
 type SetPreparedStatementVariablesMetadata = unsafe extern "C" fn(
-    columns_ptr: ColumnsPtr,
+    columns_ptr: ColumnsPtr<'_>,
     value_index: usize,
     name: FFIStr<'_>,
     keyspace: FFIStr<'_>,
@@ -62,7 +62,7 @@ type SetPreparedStatementVariablesMetadata = unsafe extern "C" fn(
 #[unsafe(no_mangle)]
 pub extern "C" fn prepared_statement_fill_column_specs_metadata(
     prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
-    columns_ptr: ColumnsPtr,
+    columns_ptr: ColumnsPtr<'_>,
     set_prepared_statement_variables_metadata: SetPreparedStatementVariablesMetadata,
 ) -> FFIMaybeException {
     let prepared_statement = ArcFFI::as_ref(prepared_statement_ptr)

--- a/rust/src/prepared_statement.rs
+++ b/rust/src/prepared_statement.rs
@@ -3,10 +3,11 @@ use crate::ffi::{ArcFFI, BridgedBorrowedSharedPtr, FFI, FFIBool, FFIPtr, FFIStr,
 use crate::row_set::column_type_to_code;
 use scylla::frame::response::result::ColumnType;
 use scylla::statement::prepared::PreparedStatement;
+use std::sync::RwLock;
 
 #[derive(Debug)]
 pub struct BridgedPreparedStatement {
-    pub(crate) inner: PreparedStatement,
+    pub(crate) inner: RwLock<PreparedStatement>,
 }
 
 impl FFI for BridgedPreparedStatement {
@@ -19,10 +20,16 @@ pub extern "C" fn prepared_statement_get_variables_column_specs_count(
     prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
     out_num_fields: *mut usize,
 ) -> FFIMaybeException {
-    let prepared_statement = ArcFFI::as_ref(prepared_statement_ptr).unwrap();
+    let prepared_statement = ArcFFI::as_ref(prepared_statement_ptr)
+        .expect("valid and non-null BridgedPreparedStatement pointer");
+
+    let guard = prepared_statement
+        .inner
+        .read()
+        .expect("poisoning impossible due to process-aborting panics");
 
     unsafe {
-        *out_num_fields = prepared_statement.inner.get_variable_col_specs().len();
+        *out_num_fields = guard.get_variable_col_specs().len();
     }
 
     FFIMaybeException::ok()
@@ -58,15 +65,16 @@ pub extern "C" fn prepared_statement_fill_column_specs_metadata(
     columns_ptr: ColumnsPtr,
     set_prepared_statement_variables_metadata: SetPreparedStatementVariablesMetadata,
 ) -> FFIMaybeException {
-    let prepared_statement = ArcFFI::as_ref(prepared_statement_ptr).unwrap();
+    let prepared_statement = ArcFFI::as_ref(prepared_statement_ptr)
+        .expect("valid and non-null BridgedPreparedStatement pointer");
+
+    let guard = prepared_statement
+        .inner
+        .read()
+        .expect("poisoning impossible due to process-aborting panics");
 
     // Iterate column specs and call the metadata setter
-    for (i, spec) in prepared_statement
-        .inner
-        .get_variable_col_specs()
-        .iter()
-        .enumerate()
-    {
+    for (i, spec) in guard.get_variable_col_specs().iter().enumerate() {
         let name = FFIStr::new(spec.name());
         let keyspace = FFIStr::new(spec.table_spec().ks_name());
         let table = FFIStr::new(spec.table_spec().table_name());
@@ -115,7 +123,12 @@ pub extern "C" fn prepared_statement_is_lwt(
     let prepared_statement = ArcFFI::as_ref(prepared_statement_ptr)
         .expect("valid and non-null BridgedPreparedStatement pointer");
 
-    let is_lwt_value = prepared_statement.inner.is_confirmed_lwt();
+    let guard = prepared_statement
+        .inner
+        .read()
+        .expect("poisoning impossible due to process-aborting panics");
+
+    let is_lwt_value = guard.is_confirmed_lwt();
 
     *is_lwt = is_lwt_value.into();
 

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -282,7 +282,7 @@ pub extern "C" fn session_query_bound(
     session_ptr: BridgedBorrowedSharedPtr<'_, BridgedSession>,
     prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
 ) {
-    let bridged_prepared = ArcFFI::cloned_from_ptr(prepared_statement_ptr).unwrap();
+    let bridged_prepared = ArcFFI::as_ref(prepared_statement_ptr).unwrap();
     let session_arc = ArcFFI::cloned_from_ptr(session_ptr).unwrap();
 
     tracing::trace!("[FFI] Scheduling prepared statement execution");
@@ -290,6 +290,9 @@ pub extern "C" fn session_query_bound(
     // Try to acquire an owned read lock.
     // If the operation fails, treat it as session shutting down.
     let session_guard_res = session_arc.try_read_owned();
+
+    // Clone the prepared statement to move it into the async task.
+    let prepared_statement = bridged_prepared.inner.clone();
 
     BridgedFuture::spawn::<_, _, MaybeShutdownError<PagerExecutionError>, _>(tcb, async move {
         tracing::debug!("[FFI] Executing prepared statement");
@@ -310,7 +313,7 @@ pub extern "C" fn session_query_bound(
         // Map underlying `PagerExecutionError` into `MaybeShutdownError::Inner` so
         // the BridgedFuture's error type matches.
         let query_pager = session
-            .execute_iter(bridged_prepared.inner.clone(), ())
+            .execute_iter(prepared_statement, ())
             .await
             .map_err(MaybeShutdownError::Inner)?;
 
@@ -340,7 +343,7 @@ pub extern "C" fn session_query_bound_with_values(
             }
         };
 
-    let bridged_prepared = ArcFFI::cloned_from_ptr(prepared_statement_ptr).unwrap();
+    let bridged_prepared = ArcFFI::as_ref(prepared_statement_ptr).unwrap();
     let session_arc = ArcFFI::cloned_from_ptr(session_ptr).unwrap();
 
     tracing::trace!("[FFI] Scheduling prepared statement execution");
@@ -348,6 +351,9 @@ pub extern "C" fn session_query_bound_with_values(
     // Try to acquire an owned read lock.
     // If the operation fails, treat it as session shutting down.
     let session_guard_res = session_arc.try_read_owned();
+
+    // Clone the prepared statement to move it into the async task.
+    let prepared_statement = bridged_prepared.inner.clone();
 
     BridgedFuture::spawn::<_, _, MaybeShutdownError<PagerExecutionError>, _>(tcb, async move {
         tracing::debug!("[FFI] Executing prepared statement");
@@ -367,7 +373,7 @@ pub extern "C" fn session_query_bound_with_values(
         let serialized_values: SerializedValues = psv.into_serialized_values();
 
         let query_pager = session
-            .execute_iter_preserialized(bridged_prepared.inner.clone(), serialized_values)
+            .execute_iter_preserialized(prepared_statement, serialized_values)
             .await
             .map_err(MaybeShutdownError::Inner)?;
 

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -11,7 +11,7 @@ use tokio::sync::RwLock;
 use crate::error_conversion::{FFIMaybeException, MaybeShutdownError};
 use crate::ffi::{
     ArcFFI, BridgedBorrowedSharedPtr, BridgedOwnedSharedPtr, CSharpManagedStringPtr, CSharpStr,
-    FFI, FFIStr, FromArc, WriteStringCallback,
+    FFI, FFIBool, FFIStr, FromArc, WriteStringCallback,
 };
 use crate::pre_serialized_values::{PopulateValues, PopulateValuesContext, PreSerializedValues};
 use crate::prepared_statement::BridgedPreparedStatement;
@@ -25,6 +25,15 @@ use crate::task::{BridgedFuture, ExceptionConstructors, ManuallyDestructible, Tc
 #[derive(Debug)]
 pub(crate) struct BridgedSessionInner {
     session: Option<Session>,
+}
+
+/// Execution options for bound statements mirrored with the managed FFI struct.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct BoundStatementExecutionOptions {
+    pub consistency_level: u16,
+    pub has_consistency_level: FFIBool,
+    pub is_idempotent: FFIBool,
 }
 
 /// BridgedSession is a thread-safe, asynchronously accessible session wrapper.
@@ -284,6 +293,7 @@ pub extern "C" fn session_query_bound(
     tcb: Tcb<ManuallyDestructible>,
     session_ptr: BridgedBorrowedSharedPtr<'_, BridgedSession>,
     prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
+    execution_options: BoundStatementExecutionOptions,
 ) {
     let bridged_prepared = ArcFFI::as_ref(prepared_statement_ptr).unwrap();
     let session_arc = ArcFFI::cloned_from_ptr(session_ptr).unwrap();
@@ -295,7 +305,8 @@ pub extern "C" fn session_query_bound(
     let session_guard_res = session_arc.try_read_owned();
 
     // Clone the prepared statement to move it into the async task.
-    let prepared_statement = bridged_prepared
+    // On the cloned prepared statement, set the execution options (consistency level and idempotence) before executing.
+    let mut prepared_statement = bridged_prepared
         .inner
         .read()
         .expect("poisoning impossible due to process-aborting panics")
@@ -314,6 +325,27 @@ pub extern "C" fn session_query_bound(
         let Some(session) = session_guard.session.as_ref() else {
             return Err(MaybeShutdownError::AlreadyShutdown);
         };
+
+        // If consistency level was provided, apply it to the prepared statement. Otherwise, if consistency level
+        // was not provided, ensure it's unset on the prepared statement so it uses the default (between creating
+        // this bound statement and executing it someone could set a consistency level on the prepared statement).
+        // NOTE: logic used here for applying consistency level is complicated and for now there is no tests covering it.
+        if bool::from(execution_options.has_consistency_level) {
+            let consistency = execution_options
+                .consistency_level
+                .try_into()
+                .map_err(|err| {
+                    MaybeShutdownError::InvalidArgument(format!(
+                        "Invalid consistency level value {0} passed from C# for bound query: {1}",
+                        execution_options.consistency_level, err
+                    ))
+                })?;
+            prepared_statement.set_consistency(consistency);
+        } else {
+            prepared_statement.unset_consistency();
+        }
+
+        prepared_statement.set_is_idempotent(bool::from(execution_options.is_idempotent));
 
         // Lock is held for the entire duration of the query operation,
         // preventing shutdown until this future completes
@@ -339,6 +371,7 @@ pub extern "C" fn session_query_bound_with_values(
     prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
     populate_values_context: PopulateValuesContext<'_>,
     populate_values: PopulateValues,
+    execution_options: BoundStatementExecutionOptions,
 ) {
     let psv =
         match PreSerializedValues::from_populate_callback(populate_values_context, populate_values)
@@ -360,7 +393,8 @@ pub extern "C" fn session_query_bound_with_values(
     let session_guard_res = session_arc.try_read_owned();
 
     // Clone the prepared statement to move it into the async task.
-    let prepared_statement = bridged_prepared
+    // On the cloned prepared statement, set the execution options (consistency level and idempotence) before executing.
+    let mut prepared_statement = bridged_prepared
         .inner
         .read()
         .expect("poisoning impossible due to process-aborting panics")
@@ -379,6 +413,28 @@ pub extern "C" fn session_query_bound_with_values(
         let Some(session) = session_guard.session.as_ref() else {
             return Err(MaybeShutdownError::AlreadyShutdown);
         };
+
+        // If consistency level was provided, apply it to the prepared statement. Otherwise, if consistency level
+        // was not provided, ensure it's unset on the prepared statement so it uses the default (between creating
+        // this bound statement and executing it someone could set a consistency level on the prepared statement).
+        // NOTE: logic used here for applying consistency level is complicated and for now there is no tests covering it.
+        if bool::from(execution_options.has_consistency_level) {
+            let consistency = execution_options
+                .consistency_level
+                .try_into()
+                .map_err(|err| {
+                    MaybeShutdownError::InvalidArgument(format!(
+                        "Invalid consistency level value {0} passed from C# for bound query with values: {1}",
+                        execution_options.consistency_level,
+                        err
+                    ))
+                })?;
+            prepared_statement.set_consistency(consistency);
+        } else {
+            prepared_statement.unset_consistency();
+        }
+
+        prepared_statement.set_is_idempotent(bool::from(execution_options.is_idempotent));
 
         // Convert our FFI wrapper into SerializedValues by consuming it.
         let serialized_values: SerializedValues = psv.into_serialized_values();

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -1,5 +1,6 @@
 use std::convert::Infallible;
 use std::sync::Arc;
+use std::sync::RwLock as StdRwLock;
 
 use scylla::client::session::Session;
 use scylla::cluster::ClusterState;
@@ -272,7 +273,9 @@ pub extern "C" fn session_prepare(
 
         tracing::trace!("[FFI] Statement prepared");
 
-        Ok(Arc::new(BridgedPreparedStatement { inner: ps }))
+        Ok(Arc::new(BridgedPreparedStatement {
+            inner: StdRwLock::new(ps),
+        }))
     })
 }
 
@@ -292,7 +295,11 @@ pub extern "C" fn session_query_bound(
     let session_guard_res = session_arc.try_read_owned();
 
     // Clone the prepared statement to move it into the async task.
-    let prepared_statement = bridged_prepared.inner.clone();
+    let prepared_statement = bridged_prepared
+        .inner
+        .read()
+        .expect("poisoning impossible due to process-aborting panics")
+        .clone();
 
     BridgedFuture::spawn::<_, _, MaybeShutdownError<PagerExecutionError>, _>(tcb, async move {
         tracing::debug!("[FFI] Executing prepared statement");
@@ -353,7 +360,11 @@ pub extern "C" fn session_query_bound_with_values(
     let session_guard_res = session_arc.try_read_owned();
 
     // Clone the prepared statement to move it into the async task.
-    let prepared_statement = bridged_prepared.inner.clone();
+    let prepared_statement = bridged_prepared
+        .inner
+        .read()
+        .expect("poisoning impossible due to process-aborting panics")
+        .clone();
 
     BridgedFuture::spawn::<_, _, MaybeShutdownError<PagerExecutionError>, _>(tcb, async move {
         tracing::debug!("[FFI] Executing prepared statement");

--- a/src/Cassandra.BrokenIntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.BrokenIntegrationTests/Core/PreparedStatementsTests.cs
@@ -79,71 +79,6 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         [Test]
-        public void PreparedStatement_With_Changing_Schema()
-        {
-            byte[] originalResultMetadataId = null;
-            // Use 2 different clusters as the prepared statement cache should be different
-            using (var cluster1 = GetNewTemporaryCluster())
-            using (var cluster2 = GetNewTemporaryCluster())
-            {
-                var session1 = cluster1.Connect();
-                var session2 = cluster2.Connect();
-
-                // Create schema and insert data
-                session1.Execute(
-                    "CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}");
-                session1.ChangeKeyspace("ks1");
-                session2.ChangeKeyspace("ks1");
-                session1.Execute("CREATE TABLE table1 (id int PRIMARY KEY, a text, c text)");
-                var insertPs = session1.Prepare("INSERT INTO table1 (id, a, c) VALUES (?, ?, ?)");
-                session1.Execute(insertPs.Bind(1, "a value", "c value"));
-
-                // Prepare and execute a few requests
-                var selectPs1 = session1.Prepare("SELECT * FROM table1");
-                var selectPs2 = session2.Prepare("SELECT * FROM table1");
-
-                var protocolVersion = (ProtocolVersion)session1.BinaryProtocolVersion;
-                if (protocolVersion.SupportsResultMetadataId())
-                {
-                    originalResultMetadataId = selectPs1.ResultMetadata.ResultMetadataId;
-                    Assert.That(selectPs2.ResultMetadata.ResultMetadataId, Is.EquivalentTo(selectPs1.ResultMetadata.ResultMetadataId));
-                }
-
-                for (var i = 0; i < 10; i++)
-                {
-                    var rs1 = session1.Execute(selectPs1.Bind());
-                    var rs2 = session2.Execute(selectPs2.Bind());
-                    Assert.That(rs1.Columns.Select(c => c.Name), Does.Contain("a").And.Contain("c"));
-                    Assert.That(rs2.Columns.Select(c => c.Name), Does.Contain("a").And.Contain("c"));
-                }
-
-                // Alter table, adding a new column
-                session1.Execute("ALTER TABLE table1 ADD b text");
-
-                // Execute on all nodes on a single session1, causing UNPREPARE->PREPARE flow
-                for (var i = 0; i < 10; i++)
-                {
-                    var rs1 = session1.Execute(selectPs1.Bind());
-                    Assert.That(rs1.Columns.Select(c => c.Name), Does.Contain("a").And.Contain("b").And.Contain("c"));
-                }
-
-                // Execute on a different session causing metadata change
-                for (var i = 0; i < 10; i++)
-                {
-                    var rs2 = session2.Execute(selectPs2.Bind());
-                    Assert.That(rs2.Columns.Select(c => c.Name), Does.Contain("a").And.Contain("b").And.Contain("c"));
-                }
-
-                if (protocolVersion.SupportsResultMetadataId())
-                {
-                    // The ResultMetadataId changed and it's updated on both PreparedStatement instances
-                    Assert.That(selectPs1.ResultMetadata.ResultMetadataId, Is.Not.EquivalentTo(originalResultMetadataId));
-                    Assert.That(selectPs2.ResultMetadata.ResultMetadataId, Is.EquivalentTo(selectPs1.ResultMetadata.ResultMetadataId));
-                }
-            }
-        }
-
-        [Test]
         [TestCassandraVersion(2, 1)]
         public void Prepared_SetTimestamp()
         {
@@ -153,83 +88,6 @@ namespace Cassandra.IntegrationTests.Core
             Session.Execute(insertStatement.Bind(id, "sample text").SetTimestamp(timestamp));
             var row = Session.Execute(new SimpleStatement(string.Format("SELECT id, text_sample, writetime(text_sample) FROM {0} WHERE id = ?", AllTypesTableName), id)).First();
             Assert.NotNull(row.GetValue<string>("text_sample"));
-        }
-
-        [Test]
-        [TestCassandraVersion(2, 0)]
-        public void Bound_NamedParamsOrder()
-        {
-            var query = string.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :my_id)", AllTypesTableName);
-            var preparedStatement = Session.Prepare(query);
-            if (TestClusterManager.CheckCassandraVersion(false, new Version(2, 2), Comparison.LessThan))
-            {
-                //For older versions, there is no way to determine that my_id is actually id column
-                Assert.Null(preparedStatement.RoutingIndexes);
-            }
-            Assert.AreEqual(preparedStatement.Variables.Columns.Length, 4);
-            Assert.AreEqual("my_text, my_int, my_bigint, my_id", String.Join(", ", preparedStatement.Variables.Columns.Select(c => c.Name)));
-        }
-
-        [Test]
-        [TestCassandraVersion(2, 0)]
-        public void Bound_NamedParameters()
-        {
-            var insertQuery = string.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :id)", AllTypesTableName);
-            var preparedStatement = Session.Prepare(insertQuery);
-            CollectionAssert.AreEqual(new[] { 3 }, preparedStatement.RoutingIndexes);
-            Assert.AreEqual(preparedStatement.Variables.Columns.Length, 4);
-            Assert.AreEqual("my_text, my_int, my_bigint, id", String.Join(", ", preparedStatement.Variables.Columns.Select(c => c.Name)));
-
-            var id = Guid.NewGuid();
-            Session.Execute(
-                preparedStatement.Bind(
-                    new { my_int = 100, my_bigint = -500L, id = id, my_text = "named params ftw!" }));
-
-            var row = Session.Execute(string.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
-
-            Assert.AreEqual(100, row.GetValue<int>("int_sample"));
-            Assert.AreEqual(-500L, row.GetValue<long>("bigint_sample"));
-            Assert.AreEqual("named params ftw!", row.GetValue<string>("text_sample"));
-        }
-
-        [Test]
-        [TestCassandraVersion(2, 0)]
-        public void Bound_NamedParameters_Nulls()
-        {
-            var insertQuery = string.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :my_id)", AllTypesTableName);
-            var preparedStatement = Session.Prepare(insertQuery);
-
-            var id = Guid.NewGuid();
-            Session.Execute(
-                preparedStatement.Bind(
-                    new { my_bigint = (long?)null, my_int = 100, my_id = id }));
-
-            var row = Session.Execute(string.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
-
-            Assert.AreEqual(100, row.GetValue<int>("int_sample"));
-            Assert.IsNull(row.GetValue<long?>("bigint_sample"));
-            Assert.IsNull(row.GetValue<string>("text_sample"));
-        }
-
-        [Test]
-        [TestCassandraVersion(2, 0)]
-        public void Bound_NamedParameters_CaseInsensitive()
-        {
-            var insertQuery = string.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_TeXt, :my_int, :my_bigint, :id)", AllTypesTableName);
-            var preparedStatement = Session.Prepare(insertQuery);
-            //The routing key is at position 3
-            CollectionAssert.AreEqual(new[] { 3 }, preparedStatement.RoutingIndexes);
-
-            var id = Guid.NewGuid();
-            Session.Execute(
-                preparedStatement.Bind(
-                    new { MY_int = -100, MY_BigInt = 1511L, ID = id, MY_text = "yeah!" }));
-
-            var row = Session.Execute(string.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
-
-            Assert.AreEqual(-100, row.GetValue<int>("int_sample"));
-            Assert.AreEqual(1511L, row.GetValue<long>("bigint_sample"));
-            Assert.AreEqual("yeah!", row.GetValue<string>("text_sample"));
         }
 
         [Test]
@@ -388,78 +246,6 @@ namespace Cassandra.IntegrationTests.Core
             CollectionAssert.AreEqual(calculateKey(anon2.nice_name_a, anon2.nice_name_b), statement.RoutingKey.RawRoutingKey);
         }
 
-        [Test]
-        [TestCassandraVersion(2, 2)]
-        public void Bound_Date_Tests()
-        {
-            Session.Execute("CREATE TABLE tbl_date_prep (id int PRIMARY KEY, v date)");
-            var insert = Session.Prepare("INSERT INTO tbl_date_prep (id, v) VALUES (?, ?)");
-            var select = Session.Prepare("SELECT * FROM tbl_date_prep WHERE id = ?");
-            var values = new[] { new LocalDate(2010, 4, 29), new LocalDate(0, 1, 1), new LocalDate(-1, 12, 31) };
-            var index = 0;
-            foreach (var v in values)
-            {
-                Session.Execute(insert.Bind(index, v));
-                var rs = Session.Execute(select.Bind(index)).ToList();
-                Assert.AreEqual(1, rs.Count);
-                Assert.AreEqual(v, rs[0].GetValue<LocalDate>("v"));
-                index++;
-            }
-        }
-
-        [Test]
-        [TestCassandraVersion(2, 2)]
-        public void Bound_Time_Tests()
-        {
-            Session.Execute("CREATE TABLE tbl_time_prep (id int PRIMARY KEY, v time)");
-            var insert = Session.Prepare("INSERT INTO tbl_time_prep (id, v) VALUES (?, ?)");
-            var select = Session.Prepare("SELECT * FROM tbl_time_prep WHERE id = ?");
-            var values = new[] { new LocalTime(0, 0, 0, 0), new LocalTime(12, 11, 1, 10), new LocalTime(0, 58, 31, 991809111) };
-            var index = 0;
-            foreach (var v in values)
-            {
-                Session.Execute(insert.Bind(index, v));
-                var rs = Session.Execute(select.Bind(index)).ToList();
-                Assert.AreEqual(1, rs.Count);
-                Assert.AreEqual(v, rs[0].GetValue<LocalTime>("v"));
-                index++;
-            }
-        }
-
-        [Test]
-        [TestCassandraVersion(2, 2)]
-        public void Bound_SmallInt_Tests()
-        {
-            Session.Execute("CREATE TABLE tbl_smallint_prep (id int PRIMARY KEY, v smallint)");
-            var insert = Session.Prepare("INSERT INTO tbl_smallint_prep (id, v) VALUES (?, ?)");
-            var select = Session.Prepare("SELECT * FROM tbl_smallint_prep WHERE id = ?");
-            var values = new short[] { Int16.MinValue, -31000, -1, 0, 1, 2, 0xff, 0x0101, Int16.MaxValue };
-            foreach (var v in values)
-            {
-                Session.Execute(insert.Bind(Convert.ToInt32(v), v));
-                var rs = Session.Execute(select.Bind(Convert.ToInt32(v))).ToList();
-                Assert.AreEqual(1, rs.Count);
-                Assert.AreEqual(v, rs[0].GetValue<short>("v"));
-            }
-        }
-
-        [Test]
-        [TestCassandraVersion(2, 2)]
-        public void Bound_TinyInt_Tests()
-        {
-            Session.Execute("CREATE TABLE tbl_tinyint_prep (id int PRIMARY KEY, v tinyint)");
-            var insert = Session.Prepare("INSERT INTO tbl_tinyint_prep (id, v) VALUES (?, ?)");
-            var select = Session.Prepare("SELECT * FROM tbl_tinyint_prep WHERE id = ?");
-            var values = new sbyte[] { sbyte.MinValue, -4, -1, 0, 1, 2, 126, sbyte.MaxValue };
-            foreach (var v in values)
-            {
-                Session.Execute(insert.Bind(Convert.ToInt32(v), v));
-                var rs = Session.Execute(select.Bind(Convert.ToInt32(v))).ToList();
-                Assert.AreEqual(1, rs.Count);
-                Assert.AreEqual(v, rs[0].GetValue<sbyte>("v"));
-            }
-        }
-
         [TestCase(true)]
         [TestCase(false)]
         [TestCassandraVersion(4, 0)]
@@ -603,40 +389,6 @@ namespace Cassandra.IntegrationTests.Core
             Assert.IsTrue(ps.Keyspace == null || ps.Keyspace == KeyspaceName, ps.Keyspace);
             bound = ps.Bind("a", "c", Guid.NewGuid());
             Assert.AreEqual(bound.Keyspace, KeyspaceName);
-        }
-
-        [Test]
-        public void Prepared_SelectOne()
-        {
-            var tableName = TestUtils.GetUniqueTableName();
-            try
-            {
-                QueryTools.ExecuteSyncNonQuery(Session, string.Format(@"
-                    CREATE TABLE {0}(
-                    tweet_id int PRIMARY KEY,
-                    numb double,
-                    label text);", tableName));
-                TestUtils.WaitForSchemaAgreement(Session.Cluster);
-            }
-            catch (AlreadyExistsException)
-            {
-            }
-
-            for (int i = 0; i < 10; i++)
-            {
-                Session.Execute(string.Format("INSERT INTO {0} (tweet_id, numb, label) VALUES({1}, 0.01,'{2}')", tableName, i, "row" + i));
-            }
-
-            var prepSelect = QueryTools.PrepareQuery(Session, string.Format("SELECT * FROM {0} WHERE tweet_id = ?;", tableName));
-
-            var rowId = 5;
-            var result = QueryTools.ExecutePreparedSelectQuery(Session, prepSelect, new object[] { rowId });
-            foreach (var row in result)
-            {
-                Assert.True((string)row.GetValue(typeof(int), "label") == "row" + rowId);
-            }
-            Assert.True(result.Columns != null);
-            Assert.True(result.Columns.Length == 3);
         }
 
         [Test]

--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
@@ -78,67 +78,66 @@ namespace Cassandra.IntegrationTests.Core
             CreateTable(_tableName);
         }
 
-        // // TODO: Routing index not implemented in Rust driver integration yet
-        // [Test]
-        // public void Bound_AllSingleTypesDifferentValues()
-        // {
-        //     var insertQuery = string.Format(@"
-        //         INSERT INTO {0}
-        //         (id, text_sample, int_sample, bigint_sample, float_sample, double_sample, decimal_sample,
-        //             blob_sample, boolean_sample, timestamp_sample, inet_sample)
-        //         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", AllTypesTableName);
+        [Test]
+        public void Bound_AllSingleTypesDifferentValues()
+        {
+            var insertQuery = string.Format(@"
+                INSERT INTO {0}
+                (id, text_sample, int_sample, bigint_sample, float_sample, double_sample, decimal_sample,
+                    blob_sample, boolean_sample, timestamp_sample, inet_sample)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", AllTypesTableName);
 
-        //     var preparedStatement = Session.Prepare(insertQuery);
-        //     CollectionAssert.AreEqual(new[] { 0 }, preparedStatement.RoutingIndexes);
+            var preparedStatement = Session.Prepare(insertQuery);
+            CollectionAssert.AreEqual(new[] { 0 }, preparedStatement.RoutingIndexes);
 
-        //     var firstRowValues = new object[]
-        //     {
-        //         Guid.NewGuid(), "first", 10, Int64.MaxValue - 1, 1.999F, 32.002D, 1.101010M,
-        //         new byte[] {255, 255}, true, new DateTimeOffset(new DateTime(2005, 8, 5)), new IPAddress(new byte[] {192, 168, 0, 100})
-        //     };
-        //     var secondRowValues = new object[]
-        //     {
-        //         Guid.NewGuid(), "second", 0, 0L, 0F, 0D, 0M,
-        //         new byte[] {0, 0}, true, new DateTimeOffset(new DateTime(1970, 9, 18)), new IPAddress(new byte[] {0, 0, 0, 0})
-        //     };
-        //     var thirdRowValues = new object[]
-        //     {
-        //         Guid.NewGuid(), "third", -100, Int64.MinValue + 1, -150.111F, -5.12342D, -8.101010M,
-        //         new byte[] {1, 1}, true, new DateTimeOffset(new DateTime(1543, 5, 24)), new IPAddress(new byte[] {255, 128, 12, 1, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255})
-        //     };
+            var firstRowValues = new object[]
+            {
+                Guid.NewGuid(), "first", 10, Int64.MaxValue - 1, 1.999F, 32.002D, 1.101010M,
+                new byte[] {255, 255}, true, new DateTimeOffset(new DateTime(2005, 8, 5)), new IPAddress(new byte[] {192, 168, 0, 100})
+            };
+            var secondRowValues = new object[]
+            {
+                Guid.NewGuid(), "second", 0, 0L, 0F, 0D, 0M,
+                new byte[] {0, 0}, true, new DateTimeOffset(new DateTime(1970, 9, 18)), new IPAddress(new byte[] {0, 0, 0, 0})
+            };
+            var thirdRowValues = new object[]
+            {
+                Guid.NewGuid(), "third", -100, Int64.MinValue + 1, -150.111F, -5.12342D, -8.101010M,
+                new byte[] {1, 1}, true, new DateTimeOffset(new DateTime(1543, 5, 24)), new IPAddress(new byte[] {255, 128, 12, 1, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255})
+            };
 
-        //     Session.Execute(preparedStatement.Bind(firstRowValues));
-        //     Session.Execute(preparedStatement.Bind(secondRowValues));
-        //     Session.Execute(preparedStatement.Bind(thirdRowValues));
+            Session.Execute(preparedStatement.Bind(firstRowValues));
+            Session.Execute(preparedStatement.Bind(secondRowValues));
+            Session.Execute(preparedStatement.Bind(thirdRowValues));
 
-        //     var selectQuery = string.Format(@"
-        //     SELECT
-        //         id, text_sample, int_sample, bigint_sample, float_sample, double_sample, decimal_sample,
-        //             blob_sample, boolean_sample, timestamp_sample, inet_sample
-        //     FROM {0} WHERE id IN ({1}, {2}, {3})", AllTypesTableName, firstRowValues[0], secondRowValues[0], thirdRowValues[0]);
-        //     var rowList = Session.Execute(selectQuery).ToList();
-        //     //Check that they were inserted and retrieved
-        //     Assert.AreEqual(3, rowList.Count);
+            var selectQuery = string.Format(@"
+            SELECT
+                id, text_sample, int_sample, bigint_sample, float_sample, double_sample, decimal_sample,
+                    blob_sample, boolean_sample, timestamp_sample, inet_sample
+            FROM {0} WHERE id IN ({1}, {2}, {3})", AllTypesTableName, firstRowValues[0], secondRowValues[0], thirdRowValues[0]);
+            var rowList = Session.Execute(selectQuery).ToList();
+            //Check that they were inserted and retrieved
+            Assert.AreEqual(3, rowList.Count);
 
-        //     //Create a dictionary with the inserted values to compare with the retrieved values
-        //     var insertedValues = new Dictionary<Guid, object[]>()
-        //     {
-        //         {(Guid)firstRowValues[0], firstRowValues},
-        //         {(Guid)secondRowValues[0], secondRowValues},
-        //         {(Guid)thirdRowValues[0], thirdRowValues}
-        //     };
+            //Create a dictionary with the inserted values to compare with the retrieved values
+            var insertedValues = new Dictionary<Guid, object[]>()
+            {
+                {(Guid)firstRowValues[0], firstRowValues},
+                {(Guid)secondRowValues[0], secondRowValues},
+                {(Guid)thirdRowValues[0], thirdRowValues}
+            };
 
-        //     foreach (var retrievedRow in rowList)
-        //     {
-        //         var inserted = insertedValues[retrievedRow.GetValue<Guid>("id")];
-        //         for (var i = 0; i < inserted.Length; i++)
-        //         {
-        //             var insertedValue = inserted[i];
-        //             var retrievedValue = retrievedRow[i];
-        //             Assert.AreEqual(insertedValue, retrievedValue);
-        //         }
-        //     }
-        // }
+            foreach (var retrievedRow in rowList)
+            {
+                var inserted = insertedValues[retrievedRow.GetValue<Guid>("id")];
+                for (var i = 0; i < inserted.Length; i++)
+                {
+                    var insertedValue = inserted[i];
+                    var retrievedValue = retrievedRow[i];
+                    Assert.AreEqual(insertedValue, retrievedValue);
+                }
+            }
+        }
 
         [Test]
         public void Bound_AllSingleTypesNullValues()
@@ -188,6 +187,56 @@ namespace Cassandra.IntegrationTests.Core
             var row = rs.First();
             Assert.IsNotNull(row);
             Assert.AreEqual("", row.GetValue<string>("text_sample"));
+        }
+
+        [Test]
+        public void PreparedStatement_With_Changing_Schema()
+        {
+            // Use 2 different clusters as the prepared statement cache should be different
+            using (var cluster1 = GetNewTemporaryCluster())
+            using (var cluster2 = GetNewTemporaryCluster())
+            {
+                var session1 = cluster1.Connect();
+                var session2 = cluster2.Connect();
+
+                // Create schema and insert data
+                session1.Execute(
+                    "CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}");
+                session1.ChangeKeyspace("ks1");
+                session2.ChangeKeyspace("ks1");
+                session1.Execute("CREATE TABLE table1 (id int PRIMARY KEY, a text, c text)");
+                var insertPs = session1.Prepare("INSERT INTO table1 (id, a, c) VALUES (?, ?, ?)");
+                session1.Execute(insertPs.Bind(1, "a value", "c value"));
+
+                // Prepare and execute a few requests
+                var selectPs1 = session1.Prepare("SELECT * FROM table1");
+                var selectPs2 = session2.Prepare("SELECT * FROM table1");
+
+                for (var i = 0; i < 10; i++)
+                {
+                    var rs1 = session1.Execute(selectPs1.Bind());
+                    var rs2 = session2.Execute(selectPs2.Bind());
+                    Assert.That(rs1.Columns.Select(c => c.Name), Does.Contain("a").And.Contain("c"));
+                    Assert.That(rs2.Columns.Select(c => c.Name), Does.Contain("a").And.Contain("c"));
+                }
+
+                // Alter table, adding a new column
+                session1.Execute("ALTER TABLE table1 ADD b text");
+
+                // Execute on all nodes on a single session1, causing UNPREPARE->PREPARE flow
+                for (var i = 0; i < 10; i++)
+                {
+                    var rs1 = session1.Execute(selectPs1.Bind());
+                    Assert.That(rs1.Columns.Select(c => c.Name), Does.Contain("a").And.Contain("b").And.Contain("c"));
+                }
+
+                // Execute on a different session causing metadata change
+                for (var i = 0; i < 10; i++)
+                {
+                    var rs2 = session2.Execute(selectPs2.Bind());
+                    Assert.That(rs2.Columns.Select(c => c.Name), Does.Contain("a").And.Contain("b").And.Contain("c"));
+                }
+            }
         }
 
         [Test, TestCassandraVersion(2, 2)]
@@ -296,81 +345,80 @@ namespace Cassandra.IntegrationTests.Core
             Session.Execute("DROP TABLE test_unset_values");
         }
 
-        // // TODO: Routing index not implemented in Rust driver integration yet
-        // [Test]
-        // public void Bound_CollectionTypes()
-        // {
-        //     var insertQuery = string.Format(@"
-        //         INSERT INTO {0}
-        //         (id, map_sample, list_sample, set_sample)
-        //         VALUES (?, ?, ?, ?)", AllTypesTableName);
+        [Test]
+        public void Bound_CollectionTypes()
+        {
+            var insertQuery = string.Format(@"
+                INSERT INTO {0}
+                (id, map_sample, list_sample, set_sample)
+                VALUES (?, ?, ?, ?)", AllTypesTableName);
 
-        //     var preparedStatement = Session.Prepare(insertQuery);
-        //     // CollectionAssert.AreEqual(new[] { 0 }, preparedStatement.RoutingIndexes);
+            var preparedStatement = Session.Prepare(insertQuery);
+            CollectionAssert.AreEqual(new[] { 0 }, preparedStatement.RoutingIndexes);
 
-        //     var firstRowValues = new object[]
-        //     {
-        //         Guid.NewGuid(),
-        //         new Dictionary<string, string> {{"key1", "value1"}, {"key2", "value2"}},
-        //         new List<string> (new [] {"one", "two", "three", "four", "five"}),
-        //         new List<string> (new [] {"set_1one", "set_2two", "set_3three", "set_4four", "set_5five"})
-        //     };
-        //     var secondRowValues = new object[]
-        //     {
-        //         Guid.NewGuid(),
-        //         new Dictionary<string, string>(),
-        //         new List<string>(),
-        //         new List<string>()
-        //     };
-        //     var thirdRowValues = new object[]
-        //     {
-        //         Guid.NewGuid(),
-        //         null,
-        //         null,
-        //         null
-        //     };
+            var firstRowValues = new object[]
+            {
+                Guid.NewGuid(),
+                new Dictionary<string, string> {{"key1", "value1"}, {"key2", "value2"}},
+                new List<string> (new [] {"one", "two", "three", "four", "five"}),
+                new List<string> (new [] {"set_1one", "set_2two", "set_3three", "set_4four", "set_5five"})
+            };
+            var secondRowValues = new object[]
+            {
+                Guid.NewGuid(),
+                new Dictionary<string, string>(),
+                new List<string>(),
+                new List<string>()
+            };
+            var thirdRowValues = new object[]
+            {
+                Guid.NewGuid(),
+                null,
+                null,
+                null
+            };
 
-        //     Session.Execute(preparedStatement.Bind(firstRowValues));
-        //     Session.Execute(preparedStatement.Bind(secondRowValues));
-        //     Session.Execute(preparedStatement.Bind(thirdRowValues));
+            Session.Execute(preparedStatement.Bind(firstRowValues));
+            Session.Execute(preparedStatement.Bind(secondRowValues));
+            Session.Execute(preparedStatement.Bind(thirdRowValues));
 
-        //     var selectQuery = string.Format(@"
-        //         SELECT
-        //             id, map_sample, list_sample, set_sample
-        //         FROM {0} WHERE id IN ({1}, {2}, {3})", AllTypesTableName, firstRowValues[0], secondRowValues[0], thirdRowValues[0]);
-        //     var rowList = Session.Execute(selectQuery).ToList();
-        //     //Check that they were inserted and retrieved
-        //     Assert.AreEqual(3, rowList.Count);
+            var selectQuery = string.Format(@"
+                SELECT
+                    id, map_sample, list_sample, set_sample
+                FROM {0} WHERE id IN ({1}, {2}, {3})", AllTypesTableName, firstRowValues[0], secondRowValues[0], thirdRowValues[0]);
+            var rowList = Session.Execute(selectQuery).ToList();
+            //Check that they were inserted and retrieved
+            Assert.AreEqual(3, rowList.Count);
 
-        //     //Create a dictionary with the inserted values to compare with the retrieved values
-        //     var insertedValues = new Dictionary<Guid, object[]>()
-        //     {
-        //         {(Guid)firstRowValues[0], firstRowValues},
-        //         {(Guid)secondRowValues[0], secondRowValues},
-        //         {(Guid)thirdRowValues[0], thirdRowValues}
-        //     };
+            //Create a dictionary with the inserted values to compare with the retrieved values
+            var insertedValues = new Dictionary<Guid, object[]>()
+            {
+                {(Guid)firstRowValues[0], firstRowValues},
+                {(Guid)secondRowValues[0], secondRowValues},
+                {(Guid)thirdRowValues[0], thirdRowValues}
+            };
 
-        //     foreach (var retrievedRow in rowList)
-        //     {
-        //         var inserted = insertedValues[retrievedRow.GetValue<Guid>("id")];
-        //         for (var i = 1; i < inserted.Length; i++)
-        //         {
-        //             var insertedValue = inserted[i];
-        //             var retrievedValue = retrievedRow[i];
-        //             if (retrievedValue == null)
-        //             {
-        //                 //Empty collections are retrieved as nulls
-        //                 Assert.True(insertedValue == null || ((ICollection)insertedValue).Count == 0);
-        //                 continue;
-        //             }
-        //             if (insertedValue != null)
-        //             {
-        //                 Assert.AreEqual(((ICollection)insertedValue).Count, ((ICollection)retrievedValue).Count);
-        //             }
-        //             Assert.AreEqual(insertedValue, retrievedValue);
-        //         }
-        //     }
-        // }
+            foreach (var retrievedRow in rowList)
+            {
+                var inserted = insertedValues[retrievedRow.GetValue<Guid>("id")];
+                for (var i = 1; i < inserted.Length; i++)
+                {
+                    var insertedValue = inserted[i];
+                    var retrievedValue = retrievedRow[i];
+                    if (retrievedValue == null)
+                    {
+                        //Empty collections are retrieved as nulls
+                        Assert.True(insertedValue == null || ((ICollection)insertedValue).Count == 0);
+                        continue;
+                    }
+                    if (insertedValue != null)
+                    {
+                        Assert.AreEqual(((ICollection)insertedValue).Count, ((ICollection)retrievedValue).Count);
+                    }
+                    Assert.AreEqual(insertedValue, retrievedValue);
+                }
+            }
+        }
 
         [Test]
         public void Prepared_NoParams()
@@ -383,12 +431,89 @@ namespace Cassandra.IntegrationTests.Core
             Assert.NotNull(rs);
         }
 
-        // [Test]
-        // public void Bound_With_Parameters_That_Can_Not_Be_Encoded()
-        // {
-        //     var ps = Session.Prepare("SELECT * FROM system.local WHERE key = ?");
-        //     Assert.Throws<InvalidTypeException>(() => ps.Bind(new Object()));
-        // }
+        [Test]
+        [TestCassandraVersion(2, 0)]
+        public void Bound_NamedParamsOrder()
+        {
+            var query = string.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :my_id)", AllTypesTableName);
+            var preparedStatement = Session.Prepare(query);
+            if (TestClusterManager.CheckCassandraVersion(false, new Version(2, 2), Comparison.LessThan))
+            {
+                //For older versions, there is no way to determine that my_id is actually id column
+                Assert.Null(preparedStatement.RoutingIndexes);
+            }
+            Assert.AreEqual(preparedStatement.Variables.Columns.Length, 4);
+            Assert.AreEqual("my_text, my_int, my_bigint, my_id", String.Join(", ", preparedStatement.Variables.Columns.Select(c => c.Name)));
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 0)]
+        public void Bound_NamedParameters()
+        {
+            var insertQuery = string.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :id)", AllTypesTableName);
+            var preparedStatement = Session.Prepare(insertQuery);
+            CollectionAssert.AreEqual(new[] { 3 }, preparedStatement.RoutingIndexes);
+            Assert.AreEqual(preparedStatement.Variables.Columns.Length, 4);
+            Assert.AreEqual("my_text, my_int, my_bigint, id", String.Join(", ", preparedStatement.Variables.Columns.Select(c => c.Name)));
+
+            var id = Guid.NewGuid();
+            Session.Execute(
+                preparedStatement.Bind(
+                    new { my_int = 100, my_bigint = -500L, id = id, my_text = "named params ftw!" }));
+
+            var row = Session.Execute(string.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
+
+            Assert.AreEqual(100, row.GetValue<int>("int_sample"));
+            Assert.AreEqual(-500L, row.GetValue<long>("bigint_sample"));
+            Assert.AreEqual("named params ftw!", row.GetValue<string>("text_sample"));
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 0)]
+        public void Bound_NamedParameters_Nulls()
+        {
+            var insertQuery = string.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_text, :my_int, :my_bigint, :my_id)", AllTypesTableName);
+            var preparedStatement = Session.Prepare(insertQuery);
+
+            var id = Guid.NewGuid();
+            Session.Execute(
+                preparedStatement.Bind(
+                    new { my_bigint = (long?)null, my_int = 100, my_id = id }));
+
+            var row = Session.Execute(string.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
+
+            Assert.AreEqual(100, row.GetValue<int>("int_sample"));
+            Assert.IsNull(row.GetValue<long?>("bigint_sample"));
+            Assert.IsNull(row.GetValue<string>("text_sample"));
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 0)]
+        public void Bound_NamedParameters_CaseInsensitive()
+        {
+            var insertQuery = string.Format("INSERT INTO {0} (text_sample, int_sample, bigint_sample, id) VALUES (:my_TeXt, :my_int, :my_bigint, :id)", AllTypesTableName);
+            var preparedStatement = Session.Prepare(insertQuery);
+            //The routing key is at position 3
+            CollectionAssert.AreEqual(new[] { 3 }, preparedStatement.RoutingIndexes);
+
+            var id = Guid.NewGuid();
+            Session.Execute(
+                preparedStatement.Bind(
+                    new { MY_int = -100, MY_BigInt = 1511L, ID = id, MY_text = "yeah!" }));
+
+            var row = Session.Execute(string.Format("SELECT int_sample, bigint_sample, text_sample FROM {0} WHERE id = {1:D}", AllTypesTableName, id)).First();
+
+            Assert.AreEqual(-100, row.GetValue<int>("int_sample"));
+            Assert.AreEqual(1511L, row.GetValue<long>("bigint_sample"));
+            Assert.AreEqual("yeah!", row.GetValue<string>("text_sample"));
+        }
+
+        [Test]
+        public void Bound_With_Parameters_That_Can_Not_Be_Encoded()
+        {
+            var ps = Session.Prepare("SELECT * FROM system.local WHERE key = ?");
+            Assert.Throws<InvalidTypeException>(() => ps.Bind(new Object()));
+        }
 
         [Test]
         public void Bound_Int_Valids()
@@ -472,6 +597,170 @@ namespace Cassandra.IntegrationTests.Core
                 session.ChangeKeyspace("bound_changeks_test");
                 Assert.DoesNotThrow(() => TestHelper.Invoke(() => session.Execute(ps.Bind()), 10));
             }
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 2)]
+        public void Bound_Date_Tests()
+        {
+            Session.Execute("CREATE TABLE tbl_date_prep (id int PRIMARY KEY, v date)");
+            var insert = Session.Prepare("INSERT INTO tbl_date_prep (id, v) VALUES (?, ?)");
+            var select = Session.Prepare("SELECT * FROM tbl_date_prep WHERE id = ?");
+            var values = new[] { new LocalDate(2010, 4, 29), new LocalDate(0, 1, 1), new LocalDate(-1, 12, 31) };
+            var index = 0;
+            foreach (var v in values)
+            {
+                Session.Execute(insert.Bind(index, v));
+                var rs = Session.Execute(select.Bind(index)).ToList();
+                Assert.AreEqual(1, rs.Count);
+                Assert.AreEqual(v, rs[0].GetValue<LocalDate>("v"));
+                index++;
+            }
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 2)]
+        public void Bound_Time_Tests()
+        {
+            Session.Execute("CREATE TABLE tbl_time_prep (id int PRIMARY KEY, v time)");
+            var insert = Session.Prepare("INSERT INTO tbl_time_prep (id, v) VALUES (?, ?)");
+            var select = Session.Prepare("SELECT * FROM tbl_time_prep WHERE id = ?");
+            var values = new[] { new LocalTime(0, 0, 0, 0), new LocalTime(12, 11, 1, 10), new LocalTime(0, 58, 31, 991809111) };
+            var index = 0;
+            foreach (var v in values)
+            {
+                Session.Execute(insert.Bind(index, v));
+                var rs = Session.Execute(select.Bind(index)).ToList();
+                Assert.AreEqual(1, rs.Count);
+                Assert.AreEqual(v, rs[0].GetValue<LocalTime>("v"));
+                index++;
+            }
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 2)]
+        public void Bound_SmallInt_Tests()
+        {
+            Session.Execute("CREATE TABLE tbl_smallint_prep (id int PRIMARY KEY, v smallint)");
+            var insert = Session.Prepare("INSERT INTO tbl_smallint_prep (id, v) VALUES (?, ?)");
+            var select = Session.Prepare("SELECT * FROM tbl_smallint_prep WHERE id = ?");
+            var values = new short[] { Int16.MinValue, -31000, -1, 0, 1, 2, 0xff, 0x0101, Int16.MaxValue };
+            foreach (var v in values)
+            {
+                Session.Execute(insert.Bind(Convert.ToInt32(v), v));
+                var rs = Session.Execute(select.Bind(Convert.ToInt32(v))).ToList();
+                Assert.AreEqual(1, rs.Count);
+                Assert.AreEqual(v, rs[0].GetValue<short>("v"));
+            }
+        }
+
+        [Test]
+        [TestCassandraVersion(2, 2)]
+        public void Bound_TinyInt_Tests()
+        {
+            Session.Execute("CREATE TABLE tbl_tinyint_prep (id int PRIMARY KEY, v tinyint)");
+            var insert = Session.Prepare("INSERT INTO tbl_tinyint_prep (id, v) VALUES (?, ?)");
+            var select = Session.Prepare("SELECT * FROM tbl_tinyint_prep WHERE id = ?");
+            var values = new sbyte[] { sbyte.MinValue, -4, -1, 0, 1, 2, 126, sbyte.MaxValue };
+            foreach (var v in values)
+            {
+                Session.Execute(insert.Bind(Convert.ToInt32(v), v));
+                var rs = Session.Execute(select.Bind(Convert.ToInt32(v))).ToList();
+                Assert.AreEqual(1, rs.Count);
+                Assert.AreEqual(v, rs[0].GetValue<sbyte>("v"));
+            }
+        }
+
+        [Test]
+        public void Prepared_SelectOne()
+        {
+            var tableName = TestUtils.GetUniqueTableName();
+            try
+            {
+                Session.Execute(string.Format("CREATE TABLE {0} (tweet_id int PRIMARY KEY, numb double, label text);", tableName));
+            }
+            catch (AlreadyExistsException)
+            {
+            }
+
+            for (int i = 0; i < 10; i++)
+            {
+                Session.Execute(string.Format("INSERT INTO {0} (tweet_id, numb, label) VALUES({1}, 0.01,'{2}')", tableName, i, "row" + i));
+            }
+
+            var prepSelect = Session.Prepare(string.Format("SELECT * FROM {0} WHERE tweet_id = ?;", tableName));
+
+            var rowId = 5;
+            var result = Session.Execute(prepSelect.Bind(rowId));
+            foreach (var row in result)
+            {
+                Assert.True((string)row.GetValue(typeof(int), "label") == "row" + rowId);
+            }
+            Assert.True(result.Columns != null);
+            Assert.True(result.Columns.Length == 3);
+        }
+
+        [Test]
+        public void Prepared_Bound_Overrides_Are_Local()
+        {
+            var preparedStatement = Session.Prepare("SELECT key FROM system.local WHERE key = ?");
+
+            preparedStatement.SetConsistencyLevel(ConsistencyLevel.One);
+            preparedStatement.SetIdempotence(false);
+
+            var boundWithOverrides = preparedStatement.Bind("local")
+                                                    .SetConsistencyLevel(ConsistencyLevel.LocalQuorum)
+                                                    .SetIdempotence(true);
+            Session.Execute(boundWithOverrides);
+
+            Assert.AreEqual(ConsistencyLevel.One, preparedStatement.ConsistencyLevel);
+            Assert.AreEqual(false, preparedStatement.IsIdempotent);
+
+            var nextBound = preparedStatement.Bind("local");
+            Assert.AreEqual(ConsistencyLevel.One, nextBound.ConsistencyLevel);
+            Assert.AreEqual(false, nextBound.IsIdempotent);
+        }
+
+        [Test]
+        public void Prepared_Bind_Snapshots_Prepared_Options()
+        {
+            var preparedStatement = Session.Prepare("SELECT key FROM system.local WHERE key = ?");
+
+            preparedStatement.SetConsistencyLevel(ConsistencyLevel.LocalQuorum);
+            preparedStatement.SetIdempotence(true);
+            var firstBound = preparedStatement.Bind("local");
+
+            preparedStatement.SetConsistencyLevel(ConsistencyLevel.EachQuorum);
+            preparedStatement.SetIdempotence(false);
+            var secondBound = preparedStatement.Bind("local");
+
+            Assert.AreEqual(ConsistencyLevel.LocalQuorum, firstBound.ConsistencyLevel);
+            Assert.AreEqual(true, firstBound.IsIdempotent);
+
+            Assert.AreEqual(ConsistencyLevel.EachQuorum, secondBound.ConsistencyLevel);
+            Assert.AreEqual(false, secondBound.IsIdempotent);
+        }
+
+        [Test]
+        public void Prepared_Nullability_Preserved()
+        {
+            var preparedStatement = Session.Prepare("SELECT key FROM system.local WHERE key = ?");
+
+            Assert.IsNull(preparedStatement.ConsistencyLevel);
+            Assert.IsNull(preparedStatement.IsIdempotent);
+
+            var bound = preparedStatement.Bind("local");
+            Assert.IsNull(bound.ConsistencyLevel);
+            Assert.IsNull(bound.IsIdempotent);
+        }
+
+        [Test]
+        public void Prepared_Bound_Invalid_ConsistencyLevel()
+        {
+            var preparedStatement = Session.Prepare("SELECT key FROM system.local WHERE key = ?");
+            var bound = preparedStatement.Bind("local").SetConsistencyLevel((ConsistencyLevel)999);
+
+            Assert.Throws<InvalidArgumentException>(() => Session.Execute(bound));
         }
 
         //////////////////////////////

--- a/src/Cassandra/BatchStatement.cs
+++ b/src/Cassandra/BatchStatement.cs
@@ -31,7 +31,6 @@ namespace Cassandra
         private BatchType _batchType = BatchType.Logged;
         private RoutingKey _routingKey;
         private object[] _routingValues;
-        private string _keyspace;
 
         /// <summary>
         /// Gets the batch type
@@ -91,26 +90,11 @@ namespace Cassandra
             }
         }
 
+        /// The current implementation supports protocol v4 exclusively. This protocol version does not support
+        /// per-statement keyspace, so this method will throw a <see cref="NotImplementedException"/> if called.
         public override string Keyspace
         {
-            get
-            {
-                if (_keyspace != null)
-                {
-                    return _keyspace;
-                }
-
-                var serializer = Serializer;
-                if (serializer == null)
-                {
-                    serializer = SerializerManager.Default.GetCurrentSerializer();
-                    BatchStatement.Logger.Warning(
-                        "Calculating keyspace key before executing is not supported for BatchStatement instances, " +
-                        "using default serializer.");
-                }
-
-                return GetRoutingStatement(serializer)?.Keyspace;
-            }
+            get => throw new NotImplementedException("Protocol version 4 does not support per-statement keyspace.");
         }
 
         private IStatement GetRoutingStatement(ISerializer serializer)
@@ -198,12 +182,13 @@ namespace Cassandra
         /// <summary>
         /// Sets the keyspace this batch operates on. The keyspace should only be set when the statements in this
         /// batch apply to a different keyspace to the logged keyspace of the <see cref="ISession"/>.
+        /// The current implementation supports protocol v4 exclusively. This protocol version does not support
+        /// per-statement keyspace, so this method will throw a <see cref="NotImplementedException"/> if called.
         /// </summary>
         /// <param name="name">The keyspace name.</param>
         public BatchStatement SetKeyspace(string name)
         {
-            _keyspace = name;
-            return this;
+            throw new NotImplementedException("Protocol version 4 does not support per-statement keyspace.");
         }
 
         /// <summary>

--- a/src/Cassandra/BoundStatement.cs
+++ b/src/Cassandra/BoundStatement.cs
@@ -63,13 +63,15 @@ namespace Cassandra
 
         /// <summary>
         /// Returns the keyspace this query operates on, based on the <see cref="PreparedStatement"/> metadata.
+        /// The current implementation supports protocol v4 exclusively. This protocol version does not support
+        /// per-statement keyspace, so this method will throw a <see cref="NotImplementedException"/> if called.
         /// <para>
         /// The keyspace returned is used as a hint for token-aware routing.
         /// </para>
         /// </summary>
         public override string Keyspace
         {
-            get { return _keyspace; }
+            get => throw new NotImplementedException("Protocol version 4 does not support per-statement keyspace.");
         }
 
         public override string TableName
@@ -99,7 +101,7 @@ namespace Cassandra
         {
             _preparedStatement = statement;
             _routingKey = statement.RoutingKey;
-            _keyspace = statement.Keyspace ?? statement.Variables?.Keyspace;
+            _keyspace = statement.Variables?.Keyspace;
             _table = statement.Variables?.Table;
 
             SetConsistencyLevel(statement.ConsistencyLevel);
@@ -161,7 +163,7 @@ namespace Cassandra
                 string failureMsg;
                 if (serializer.IsEncryptionEnabled)
                 {
-                    var tuple = serializer.IsAssignableFromEncrypted(p.Keyspace ?? Keyspace, p.Table, p.Name, p.TypeCode, p.TypeInfo, value, out failureMsg);
+                    var tuple = serializer.IsAssignableFromEncrypted(p.Keyspace, p.Table, p.Name, p.TypeCode, p.TypeInfo, value, out failureMsg);
                     assignable = tuple.Item1;
                 }
                 else
@@ -219,7 +221,7 @@ namespace Cassandra
                 for (var i = 0; i < routingIndexes.Length; i++)
                 {
                     var index = routingIndexes[i];
-                    byte[] key = serializer.SerializeAndEncrypt(PreparedStatement.Keyspace, parametersMetadata, index, valuesByPosition, index);
+                    byte[] key = serializer.SerializeAndEncrypt(_keyspace, parametersMetadata, index, valuesByPosition, index);
                     if (key == null)
                     {
                         //The partition key can not be null
@@ -269,7 +271,7 @@ namespace Cassandra
                         }
                         else
                         {
-                            key = serializer.SerializeAndEncrypt(PreparedStatement.Keyspace, parametersMetadata, colIndex, routingValues, i);
+                            key = serializer.SerializeAndEncrypt(_keyspace, parametersMetadata, colIndex, routingValues, i);
                         }
                     }
                     else

--- a/src/Cassandra/PreparedStatement.cs
+++ b/src/Cassandra/PreparedStatement.cs
@@ -107,10 +107,9 @@ namespace Cassandra
         internal PreparedStatement(RustBridge.ManuallyDestructible mdPreparedStatement, string cql, ISerializerManager serializerManager)
         {
             bridgedPreparedStatement = new BridgedPreparedStatement(mdPreparedStatement);
-            bool isLwt = bridgedPreparedStatement.IsLwt();
             _variablesMetadata = bridgedPreparedStatement.ExtractVariablesMetadataFromRust();
             Cql = cql;
-            _isLwt = isLwt;
+            _isLwt = bridgedPreparedStatement.IsLwt();
             _serializerManager = serializerManager;
         }
 

--- a/src/Cassandra/PreparedStatement.cs
+++ b/src/Cassandra/PreparedStatement.cs
@@ -50,11 +50,6 @@ namespace Cassandra
         internal byte[] Id { get; private set; }
 
         /// <summary>
-        /// The keyspace were the prepared statement was first executed
-        /// </summary>
-        internal string Keyspace { get; private set; }
-
-        /// <summary>
         /// Gets the the incoming payload, that is, the payload that the server
         /// sent back with its prepared response, or null if the server did not include any custom payload.
         /// </summary>

--- a/src/Cassandra/PreparedStatement.cs
+++ b/src/Cassandra/PreparedStatement.cs
@@ -93,6 +93,8 @@ namespace Cassandra
             get => bridgedPreparedStatement.GetConsistencyLevel();
         }
 
+        private volatile bool _hasIdempotence = false;
+
         /// <summary>
         /// Determines if the query is idempotent, i.e. whether it can be applied multiple times without 
         /// changing the result beyond the initial application.
@@ -102,7 +104,17 @@ namespace Cassandra
         /// </para>
         /// When the property is null, the driver will use the default value from the <see cref="QueryOptions.GetDefaultIdempotence()"/>.
         /// </summary>
-        public bool? IsIdempotent { get; private set; }
+        public bool? IsIdempotent
+        {
+            get
+            {
+                if (!_hasIdempotence)
+                {
+                    return null;
+                }
+                return bridgedPreparedStatement.IsIdempotent();
+            }
+        }
 
         public bool IsLwt => _isLwt;
 
@@ -271,7 +283,8 @@ namespace Cassandra
         /// </summary>
         public PreparedStatement SetIdempotence(bool value)
         {
-            IsIdempotent = value;
+            _hasIdempotence = true;
+            bridgedPreparedStatement.SetIsIdempotent(value);
             return this;
         }
 

--- a/src/Cassandra/PreparedStatement.cs
+++ b/src/Cassandra/PreparedStatement.cs
@@ -108,17 +108,6 @@ namespace Cassandra
 
         public bool IsLwt => _isLwt;
 
-        internal PreparedStatement(RowSetMetadata variablesMetadata, byte[] id, string cql,
-                                   string keyspace, ISerializerManager serializer, bool isLwt)
-        {
-            _variablesMetadata = variablesMetadata;
-            Id = id;
-            Cql = cql;
-            Keyspace = keyspace;
-            _serializerManager = serializer;
-            _isLwt = isLwt;
-        }
-
         // For use by the Rust interop code.
         internal PreparedStatement(RustBridge.ManuallyDestructible mdPreparedStatement, string cql, ISerializerManager serializerManager)
         {

--- a/src/Cassandra/PreparedStatement.cs
+++ b/src/Cassandra/PreparedStatement.cs
@@ -111,6 +111,18 @@ namespace Cassandra
             Cql = cql;
             _isLwt = bridgedPreparedStatement.IsLwt();
             _serializerManager = serializerManager;
+
+            // If the partition keys were parsed, set the routing indexes to them by default.
+            if (_variablesMetadata.PartitionKeys != null)
+            {
+                if (_variablesMetadata.PartitionKeys.Length == 0)
+                {
+                    // zero-length partition keys means that none of the parameters are partition keys
+                    // the partition key is hard-coded.
+                    return;
+                }
+                _routingIndexes = _variablesMetadata.PartitionKeys;
+            }
         }
 
         /// <summary>

--- a/src/Cassandra/PreparedStatement.cs
+++ b/src/Cassandra/PreparedStatement.cs
@@ -88,7 +88,10 @@ namespace Cassandra
         /// <summary>
         /// Gets the default consistency level for all executions using this instance
         /// </summary>
-        public ConsistencyLevel? ConsistencyLevel { get; private set; }
+        public ConsistencyLevel? ConsistencyLevel
+        {
+            get => bridgedPreparedStatement.GetConsistencyLevel();
+        }
 
         /// <summary>
         /// Determines if the query is idempotent, i.e. whether it can be applied multiple times without 
@@ -186,7 +189,7 @@ namespace Cassandra
         /// <returns>this <c>PreparedStatement</c> object.</returns>
         public PreparedStatement SetConsistencyLevel(ConsistencyLevel consistency)
         {
-            ConsistencyLevel = consistency;
+            bridgedPreparedStatement.SetConsistencyLevel(consistency);
             return this;
         }
 

--- a/src/Cassandra/RowPopulators/RowSetMetadata.cs
+++ b/src/Cassandra/RowPopulators/RowSetMetadata.cs
@@ -299,11 +299,6 @@ namespace Cassandra
         /// </summary>
         internal bool HasNewResultMetadataId() => NewResultMetadataId != null;
 
-        // for testing
-        internal RowSetMetadata()
-        {
-        }
-
         /// Initializes a new instance of the RowSetMetadata class with the provided columns, partition keys,
         /// keyspace and table information, and builds the column index mapping.
         /// Used by the Rust bridge when extracting metadata from prepared statements, allowing for more detailed metadata information to be included.

--- a/src/Cassandra/RowPopulators/RowSetMetadata.cs
+++ b/src/Cassandra/RowPopulators/RowSetMetadata.cs
@@ -303,5 +303,32 @@ namespace Cassandra
         internal RowSetMetadata()
         {
         }
+
+        /// Initializes a new instance of the RowSetMetadata class with the provided columns, partition keys,
+        /// keyspace and table information, and builds the column index mapping.
+        /// Used by the Rust bridge when extracting metadata from prepared statements, allowing for more detailed metadata information to be included.
+        internal RowSetMetadata(CqlColumn[] columns, int[] partitionKeys = null, string keyspace = null, string table = null)
+        {
+            var columnLength = columns?.Length ?? 0;
+
+            Columns = columns;
+            ColumnIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
+            PartitionKeys = partitionKeys;
+            if (columns != null)
+            {
+                for (var i = 0; i < columnLength; i++)
+                {
+                    var columnName = columns[i].Name;
+                    if (string.IsNullOrEmpty(columnName) || ColumnIndexes.ContainsKey(columnName))
+                    {
+                        continue;
+                    }
+                    ColumnIndexes.Add(columnName, i);
+                }
+            }
+
+            Keyspace = keyspace ?? (columnLength > 0 ? Columns[0].Keyspace : null);
+            Table = table ?? (columnLength > 0 ? Columns[0].Table : null);
+        }
     }
 }

--- a/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
+++ b/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
@@ -60,6 +60,38 @@ namespace Cassandra
             return isLwt;
         }
 
+        internal ConsistencyLevel? GetConsistencyLevel()
+        {
+            int clInt = -1;
+            unsafe
+            {
+                RunWithIncrement(handle => prepared_statement_get_consistency_level(
+                    handle,
+                    out clInt));
+            }
+
+            if (clInt < 0)
+            {
+                return null;
+            }
+
+            return (ConsistencyLevel)clInt;
+        }
+
+        internal void SetConsistencyLevel(ConsistencyLevel consistencyLevel)
+        {
+            unsafe
+            {
+                RunWithIncrement(handle =>
+                    prepared_statement_set_consistency_level(
+                        handle,
+                        (ushort)consistencyLevel,
+                        (IntPtr)Globals.ConstructorsPtr)
+                    );
+            }
+        }
+
+
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern FFIMaybeException prepared_statement_get_variables_column_specs_count(IntPtr prepared_statement, out nuint count);
 
@@ -68,6 +100,12 @@ namespace Cassandra
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern FFIMaybeException prepared_statement_is_lwt(IntPtr prepared_statement, out FFIBool isLwt);
+
+        [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
+        unsafe private static extern FFIMaybeException prepared_statement_get_consistency_level(IntPtr prepared_statement, out int consistency_level);
+
+        [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
+        unsafe private static extern FFIMaybeException prepared_statement_set_consistency_level(IntPtr prepared_statement, ushort consistency_level, IntPtr constructors);
 
         private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, ushort, FFIMaybeException> AddPkIndexPtr = &AddPkIndex;
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]

--- a/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
+++ b/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
@@ -16,13 +16,6 @@ namespace Cassandra
         {
         }
 
-        internal bool IsLwt()
-        {
-            FFIBool isLwt = false;
-            RunWithIncrement(handle => prepared_statement_is_lwt(handle, out isLwt));
-            return isLwt;
-        }
-
         internal RowSetMetadata ExtractVariablesMetadataFromRust()
         {
             // Query Rust for the number of variable column specs
@@ -57,14 +50,21 @@ namespace Cassandra
             return metadata;
         }
 
-        [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIMaybeException prepared_statement_is_lwt(IntPtr prepared_statement, out FFIBool isLwt);
+        internal bool IsLwt()
+        {
+            FFIBool isLwt = false;
+            RunWithIncrement(handle => prepared_statement_is_lwt(handle, out isLwt));
+            return isLwt;
+        }
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern FFIMaybeException prepared_statement_get_variables_column_specs_count(IntPtr prepared_statement, out nuint count);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern FFIMaybeException prepared_statement_fill_column_specs_metadata(IntPtr prepared_statement, IntPtr columnsPtr, IntPtr metadataSetter);
+
+        [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
+        unsafe private static extern FFIMaybeException prepared_statement_is_lwt(IntPtr prepared_statement, out FFIBool isLwt);
 
         private nuint GetVariablesColumnSpecsCount()
         {

--- a/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
+++ b/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
@@ -20,9 +20,9 @@ namespace Cassandra
         {
             // Query Rust for the number of variable column specs
             var count = GetVariablesColumnSpecsCount();
-            if (count <= 0)
+            if (count == 0)
             {
-                return new RowSetMetadata();
+                return new RowSetMetadata(Array.Empty<CqlColumn>());
             }
 
             var columns = new CqlColumn[count];
@@ -42,10 +42,7 @@ namespace Cassandra
                 );
             }
 
-            var metadata = new RowSetMetadata
-            {
-                Columns = columns
-            };
+            var metadata = new RowSetMetadata(columns);
 
             return metadata;
         }

--- a/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
+++ b/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
@@ -40,8 +40,13 @@ namespace Cassandra
 
             unsafe
             {
-                void* columnsPtr = Unsafe.AsPointer(ref columns);
-                FillVariablesMetadata((IntPtr)columnsPtr, (IntPtr)setColumnMetaPtr);
+                RunWithIncrement(handle =>
+                    prepared_statement_fill_column_specs_metadata(
+                        handle,
+                        (IntPtr)Unsafe.AsPointer(ref columns),
+                        (IntPtr)setColumnMetaPtr
+                    )
+                );
             }
 
             var metadata = new RowSetMetadata
@@ -66,11 +71,6 @@ namespace Cassandra
             nuint count = 0;
             RunWithIncrement(handle => prepared_statement_get_variables_column_specs_count(handle, out count));
             return count;
-        }
-
-        private void FillVariablesMetadata(IntPtr columnsPtr, IntPtr metadataSetter)
-        {
-            RunWithIncrement(handle => prepared_statement_fill_column_specs_metadata(handle, columnsPtr, metadataSetter));
         }
 
         unsafe static readonly delegate* unmanaged[Cdecl]<IntPtr, nuint, FFIString, FFIString, FFIString, byte, IntPtr, byte, FFIMaybeException> setColumnMetaPtr = &BridgedRowSet.SetColumnMeta;

--- a/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
+++ b/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
@@ -91,6 +91,24 @@ namespace Cassandra
             }
         }
 
+        internal bool IsIdempotent()
+        {
+            FFIBool isIdempotent = false;
+            unsafe
+            {
+                RunWithIncrement(handle => prepared_statement_get_is_idempotent(handle, out isIdempotent));
+            }
+            return isIdempotent;
+        }
+
+        internal void SetIsIdempotent(bool isIdempotent)
+        {
+            FFIBool ffiIsIdempotent = isIdempotent;
+            unsafe
+            {
+                RunWithIncrement(handle => prepared_statement_set_is_idempotent(handle, ffiIsIdempotent));
+            }
+        }
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern FFIMaybeException prepared_statement_get_variables_column_specs_count(IntPtr prepared_statement, out nuint count);
@@ -106,6 +124,12 @@ namespace Cassandra
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern FFIMaybeException prepared_statement_set_consistency_level(IntPtr prepared_statement, ushort consistency_level, IntPtr constructors);
+
+        [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
+        unsafe private static extern FFIMaybeException prepared_statement_get_is_idempotent(IntPtr prepared_statement, out FFIBool isIdempotent);
+
+        [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
+        unsafe private static extern FFIMaybeException prepared_statement_set_is_idempotent(IntPtr prepared_statement, FFIBool isIdempotent);
 
         private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, ushort, FFIMaybeException> AddPkIndexPtr = &AddPkIndex;
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]

--- a/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
+++ b/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
@@ -53,7 +53,10 @@ namespace Cassandra
         internal bool IsLwt()
         {
             FFIBool isLwt = false;
-            RunWithIncrement(handle => prepared_statement_is_lwt(handle, out isLwt));
+            unsafe
+            {
+                RunWithIncrement(handle => prepared_statement_is_lwt(handle, out isLwt));
+            }
             return isLwt;
         }
 
@@ -69,7 +72,10 @@ namespace Cassandra
         private nuint GetVariablesColumnSpecsCount()
         {
             nuint count = 0;
-            RunWithIncrement(handle => prepared_statement_get_variables_column_specs_count(handle, out count));
+            unsafe
+            {
+                RunWithIncrement(handle => prepared_statement_get_variables_column_specs_count(handle, out count));
+            }
             return count;
         }
 

--- a/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
+++ b/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
@@ -3,6 +3,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using static Cassandra.RustBridge;
+using System.Collections.Generic;
 
 namespace Cassandra
 {
@@ -31,19 +32,21 @@ namespace Cassandra
                 columns[i] = new CqlColumn();
             }
 
+            var pkIndexes = new List<int>();
             unsafe
             {
                 RunWithIncrement(handle =>
                     prepared_statement_fill_column_specs_metadata(
                         handle,
                         (IntPtr)Unsafe.AsPointer(ref columns),
-                        (IntPtr)setColumnMetaPtr
+                        (IntPtr)setColumnMetaPtr,
+                        (IntPtr)Unsafe.AsPointer(ref pkIndexes),
+                        (IntPtr)AddPkIndexPtr
                     )
                 );
             }
 
-            var metadata = new RowSetMetadata(columns);
-
+            var metadata = new RowSetMetadata(columns, pkIndexes.ToArray());
             return metadata;
         }
 
@@ -61,10 +64,29 @@ namespace Cassandra
         unsafe private static extern FFIMaybeException prepared_statement_get_variables_column_specs_count(IntPtr prepared_statement, out nuint count);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIMaybeException prepared_statement_fill_column_specs_metadata(IntPtr prepared_statement, IntPtr columnsPtr, IntPtr metadataSetter);
+        unsafe private static extern FFIMaybeException prepared_statement_fill_column_specs_metadata(IntPtr prepared_statement, IntPtr columnsPtr, IntPtr metadataSetter, IntPtr pkIndexesPtr, IntPtr addPkIndex);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern FFIMaybeException prepared_statement_is_lwt(IntPtr prepared_statement, out FFIBool isLwt);
+
+        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, ushort, FFIMaybeException> AddPkIndexPtr = &AddPkIndex;
+        [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        private static unsafe FFIMaybeException AddPkIndex(
+            IntPtr pkIndexesListPtr,
+            ushort pkIndex)
+        {
+            try
+            {
+                var pkIndexesList = Unsafe.AsRef<List<int>>((void*)pkIndexesListPtr);
+                pkIndexesList.Add(pkIndex);
+            }
+            catch (Exception ex)
+            {
+                return FFIMaybeException.FromException(ex);
+            }
+
+            return FFIMaybeException.Ok();
+        }
 
         private nuint GetVariablesColumnSpecsCount()
         {

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -55,10 +55,19 @@ namespace Cassandra
         unsafe private static extern void session_prepare(Tcb<ManuallyDestructible> tcb, IntPtr session, [MarshalAs(UnmanagedType.LPUTF8Str)] string statement);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern void session_query_bound(Tcb<ManuallyDestructible> tcb, IntPtr session, IntPtr preparedStatement);
+        unsafe private static extern void session_query_bound(
+            Tcb<ManuallyDestructible> tcb,
+            IntPtr session,
+            IntPtr preparedStatement,
+            PreparedStatementExecutionOptions executionOptions);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern void session_query_bound_with_values(Tcb<ManuallyDestructible> tcb, IntPtr session, IntPtr preparedStatement, IntPtr populateValuesContext, IntPtr populateValuesCallback);
+        unsafe private static extern void session_query_bound_with_values(
+            Tcb<ManuallyDestructible> tcb,
+            IntPtr session,
+            IntPtr preparedStatement,
+            IntPtr populateValuesContext, IntPtr populateValuesCallback,
+            PreparedStatementExecutionOptions executionOptions);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern FFIMaybeException session_get_keyspace(IntPtr session, IntPtr writeToStr, IntPtr context, IntPtr constructorsPtr);
@@ -142,9 +151,25 @@ namespace Cassandra
         /// Executes a prepared statement with bound values.
         /// </summary>
         /// <param name="preparedStatement">Pointer to the prepared statement handle.</param>
-        internal Task<ManuallyDestructible> QueryBound(IntPtr preparedStatement)
+        /// <param name="hasConsistencyLevel">Whether a consistency level override was specified.</param>
+        /// <param name="consistencyLevel">Consistency level to use for the query.</param>
+        /// <param name="isIdempotent">Indicates whether the query is idempotent.</param>
+        internal Task<ManuallyDestructible> QueryBound(
+            IntPtr preparedStatement,
+            bool hasConsistencyLevel,
+            ushort consistencyLevel,
+            bool isIdempotent)
         {
-            return RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) => session_query_bound(tcb, ptr, preparedStatement));
+            var executionOptions = new PreparedStatementExecutionOptions(
+                hasConsistencyLevel,
+                consistencyLevel,
+                isIdempotent);
+
+            return RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) => session_query_bound(
+                tcb,
+                ptr,
+                preparedStatement,
+                executionOptions));
         }
 
         /// <summary>
@@ -153,15 +178,31 @@ namespace Cassandra
         /// <param name="preparedStatement">Pointer to the prepared statement handle.</param>
         /// <param name="queryValues">Values to be serialized on demand and bound to the prepared statement.</param>
         /// <param name="serializer">Serializer to use for converting CLR values to CQL bytes.</param>
-        internal unsafe Task<ManuallyDestructible> QueryBoundWithValues(IntPtr preparedStatement, object[] queryValues, ISerializer serializer)
+        /// <param name="hasConsistencyLevel">Whether a consistency level override was specified.</param>
+        /// <param name="consistencyLevel">Consistency level to use for the query.</param>
+        /// <param name="isIdempotent">Indicates whether the query is idempotent.</param>
+        internal unsafe Task<ManuallyDestructible> QueryBoundWithValues(
+            IntPtr preparedStatement,
+            object[] queryValues,
+            ISerializer serializer,
+            bool hasConsistencyLevel,
+            ushort consistencyLevel,
+            bool isIdempotent)
         {
             var populateCtx = SerializationHandler.CreateContext(queryValues, serializer);
             var ctxIntPtr = (IntPtr)Unsafe.AsPointer(ref populateCtx);
+
+            var executionOptions = new PreparedStatementExecutionOptions(
+                hasConsistencyLevel,
+                consistencyLevel,
+                isIdempotent);
+
             var task = RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) =>
                 session_query_bound_with_values(
                     tcb, ptr, preparedStatement,
                     ctxIntPtr,
-                    (IntPtr)SerializationHandler.PopulateValuesPtr));
+                    (IntPtr)SerializationHandler.PopulateValuesPtr,
+                    executionOptions));
             GC.KeepAlive(populateCtx);
             return task;
         }
@@ -257,6 +298,28 @@ namespace Cassandra
                     connectTimeoutMillis = socketOptions?.ConnectTimeoutMillis ?? SocketOptions.DefaultConnectTimeoutMillis,
                     tcp = BridgedTcpConfig.BuildFrom(socketOptions),
                 };
+            }
+        }
+
+        /// <summary>
+        /// Execution options passed alongside a prepared statement.
+        /// Any changes to this struct must be mirrored in the Rust FFI definition.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct PreparedStatementExecutionOptions
+        {
+            internal readonly ushort ConsistencyLevel;
+            internal readonly FFIBool HasConsistencyLevel;
+            internal readonly FFIBool IsIdempotent;
+
+            internal PreparedStatementExecutionOptions(
+                bool hasConsistencyLevel,
+                ushort consistencyLevel,
+                bool isIdempotent)
+            {
+                HasConsistencyLevel = hasConsistencyLevel;
+                ConsistencyLevel = consistencyLevel;
+                IsIdempotent = isIdempotent;
             }
         }
     }

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -284,7 +284,14 @@ namespace Cassandra
                     }, TaskContinuationOptions.ExecuteSynchronously);
 
                 case BoundStatement bs:
-                    // Only support bound statements without values for now.
+                    // Extract consistency level and idempotence overrides from the BoundStatement, if provided.
+                    // If no consistency level override is provided, we pass false and an arbitrary consistency level (999).
+                    // When the Rust driver sees hasConsistencyLevel=false, it ignores the consistency level value.
+                    bool hasConsistencyLevel = bs.ConsistencyLevel.HasValue;
+                    ushort consistencyLevel = bs.ConsistencyLevel.HasValue ? (ushort)bs.ConsistencyLevel.Value : (ushort)999;
+
+                    // When the idempotence property is null, the driver will use the default value from QueryOptions.GetDefaultIdempotence().
+                    bool isIdempotent = bs.IsIdempotent ?? Configuration.QueryOptions.GetDefaultIdempotence();
 
                     // The managed PreparedStatement object (and the BoundStatement that
                     // references it) is rooted here by the local variable `bs`. Because there's an
@@ -297,14 +304,21 @@ namespace Cassandra
                     Task<RustBridge.ManuallyDestructible> boundTask;
                     if (queryValuesBound.Length == 0)
                     {
-                        boundTask = bridgedSession.QueryBound(queryPrepared);
+                        boundTask = bridgedSession.QueryBound(
+                            queryPrepared,
+                            hasConsistencyLevel,
+                            consistencyLevel,
+                            isIdempotent);
                     }
                     else
                     {
                         boundTask = bridgedSession.QueryBoundWithValues(
                             queryPrepared,
                             queryValuesBound,
-                            _serializerManager.GetCurrentSerializer()
+                            _serializerManager.GetCurrentSerializer(),
+                            hasConsistencyLevel,
+                            consistencyLevel,
+                            isIdempotent
                         );
                     }
 

--- a/src/Cassandra/SimpleStatement.cs
+++ b/src/Cassandra/SimpleStatement.cs
@@ -30,7 +30,6 @@ namespace Cassandra
         private string _query;
         private volatile RoutingKey _routingKey;
         private object[] _routingValues;
-        private string _keyspace;
 
         /// <summary>
         ///  Gets the query string.
@@ -77,6 +76,8 @@ namespace Cassandra
 
         /// <summary>
         /// Returns the keyspace this query operates on, as set using <see cref="SetKeyspace(string)"/>
+        /// The current implementation supports protocol v4 exclusively. This protocol version does not support
+        /// per-statement keyspace, so this method will throw a <see cref="NotImplementedException"/> if called.
         /// <para>
         /// The keyspace returned is used as a hint for token-aware routing.
         /// </para>
@@ -87,7 +88,7 @@ namespace Cassandra
         /// </remarks>
         public override string Keyspace
         {
-            get { return _keyspace; }
+            get => throw new NotImplementedException("Protocol version 4 does not support per-statement keyspace.");
         }
 
         /// <summary>
@@ -207,12 +208,13 @@ namespace Cassandra
         /// Sets the keyspace this Statement operates on. The keyspace should only be set when the
         /// <see cref="IStatement"/> applies to a different keyspace to the logged keyspace of the
         /// <see cref="ISession"/>.
+        /// The current implementation supports protocol v4 exclusively. This protocol version does not support
+        /// per-statement keyspace, so this method will throw a <see cref="NotImplementedException"/> if called.
         /// </summary>
         /// <param name="name">The keyspace name.</param>
         public SimpleStatement SetKeyspace(string name)
         {
-            _keyspace = name;
-            return this;
+            throw new NotImplementedException("Protocol version 4 does not support per-statement keyspace.");
         }
 
         internal override void SetValues(object[] values, ISerializer serializer)


### PR DESCRIPTION
## Keyspace and LWT properties

`PreparedStatement.cs` public API
 - removed `SetLwt(bool isLwt)` as we don't want to support setting this property
 - removed old internal constructor (we should always use the bridged constructor)
 - removed `Keyspace` property (internal)

`BoundStatement.cs` public API
 - removed `SetLwt(bool isLwt)` as we don't want to support setting this property
 - throws `NotImplementedException` on Keyspace property access
 - Keyspace needed for routing key calculation accessed from `Variables`

`SimpleStatement.cs` public API
 - throws `NotImplementedException` on Keyspace property access

## Routing Info

When creating a prepared statement, during variables retrival set Keyspace and Table properties for `RowSetMetadata` (added new internal constructor). After all metadata is bridged `PrepareAsync` calls `FillRoutingInfo` and sets partition keys / routing indexes on the prepared statement. This is required to initialize the `_routingIndexes` field in PreparedStatement, which is necessary for some tests to pass.

## Idempotence and ConsistencyLevel properties

Introduced RwLock for Rust side `prepared_statements` to ensure thread safety when accessing and modifying them. Implemented briding for `Idempotence` and `ConsistencyLevel` properties in `Statements`. Added a test that checks the behavior of statements with different consistency levels and idempotence settings.

## Tests
Moved more tests to the `PreparedStatementsTests.cs`:
- `PreparedStatement_With_Changing_Schema()`
- `Prepared_SetTimestamp`
- `Bound_NamedParamsOrder`
- `Bound_NamedParameters`
- `Bound_NamedParameters_Nulls`
- `Bound_NamedParameters_CaseInsensitive`
- `Bound_Date_Tests`
- `Bound_Time_Tests`
- `Bound_SmallInt_Tests`
- `Bound_TinyInt_Tests`
- `Prepared_SelectOne`

Fixes: #85 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.
- [x] I added appropriate `Fixes:` annotations to PR description.
