### PR TITLE
Optimise Serializer: use `ReadOnlySpan` to get rid of `bytes[]` allocations upon deserialization

### DIFF
--- a/docs/source/migration-guide/index.md
+++ b/docs/source/migration-guide/index.md
@@ -58,6 +58,24 @@ With `ITypeAdapter` removed, these classes are no longer needed. The built-in `T
 
 **Migration Impact:** No action required unless you were subclassing or referencing these types directly. The built-in serializers continue to handle `decimal` and `varint` automatically.
 
+### Changed APIs
+
+#### `TypeSerializer<T>.Deserialize`
+
+```csharp
+// BEFORE
+public abstract T Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo);
+
+// AFTER
+public abstract T Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo);
+```
+
+The `Deserialize` method on `TypeSerializer<T>` — the base class for all custom type serializers — now receives a `ReadOnlySpan<byte>` that contains exactly the serialized value, instead of a `byte[]` with separate `offset` and `length` parameters.
+
+This change eliminates intermediate `byte[]` allocations on the deserialization path. The Rust driver provides row data as a contiguous memory region; previously, each column value had to be copied into a fresh `byte[]` before deserialization. With `ReadOnlySpan<byte>`, the serializer reads directly from the Rust-owned buffer without copying.
+
+**Migration Impact:** If you have a custom `TypeSerializer<T>` subclass, update your `Deserialize` override to accept `ReadOnlySpan<byte>` instead of `byte[]` with offset/length. In most cases this simplifies the implementation — remove manual offset arithmetic and replace `buffer[offset + i]` indexing with `buffer[i]`. If your implementation needs a `byte[]` (e.g. to pass to an API that does not accept spans), call `buffer.ToArray()`.
+
 ## Host API
 
 ### Deleted as no longer supported APIs

--- a/src/Cassandra.BrokenIntegrationTests/Linq/LinqMethods/Delete.cs
+++ b/src/Cassandra.BrokenIntegrationTests/Linq/LinqMethods/Delete.cs
@@ -133,7 +133,7 @@ namespace Cassandra.IntegrationTests.Linq.LinqMethods
 
             Assert.AreEqual(1, listOfExecutionParameters.Count);
             var parameter = Convert.FromBase64String((string)listOfExecutionParameters.Single().Single());
-            var actualParameter = (string)Session.Cluster.Metadata.ControlConnection.Serializer.GetCurrentSerializer().Deserialize(parameter, 0, parameter.Length, ColumnTypeCode.Text, null);
+            var actualParameter = (string)Session.Cluster.Metadata.ControlConnection.Serializer.GetCurrentSerializer().Deserialize(parameter.AsSpan(), ColumnTypeCode.Text, null);
             Assert.AreNotEqual(entityToDelete.StringType, actualParameter);
             Assert.IsTrue(actualParameter.StartsWith(entityToDelete.StringType));
             Assert.IsTrue(actualParameter.Length > entityToDelete.StringType.Length);

--- a/src/Cassandra.BrokenIntegrationTests/Policies/Tests/ColumnEncryptionPolicyTests.cs
+++ b/src/Cassandra.BrokenIntegrationTests/Policies/Tests/ColumnEncryptionPolicyTests.cs
@@ -91,7 +91,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 return null;
             }
 
-            return serializer.Deserialize(decrypted, typeCode, typeInfo);
+            return serializer.Deserialize(decrypted.AsSpan(), typeCode, typeInfo);
         }
 
         public override void OneTimeSetUp()

--- a/src/Cassandra.BrokenIntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
+++ b/src/Cassandra.BrokenIntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
@@ -57,8 +57,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
             }
         }
         /// <summary>
-        /// Validate that no hops occur when inserting into a single partition 
-        /// 
+        /// Validate that no hops occur when inserting into a single partition
+        ///
         /// @test_category load_balancing:dc_aware,round_robin
         /// @test_category replication_strategy
         /// </summary>
@@ -91,8 +91,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
         }
 
         /// <summary>
-        /// Validate that no hops occur when inserting GUID values into the key 
-        /// 
+        /// Validate that no hops occur when inserting GUID values into the key
+        ///
         /// @test_category load_balancing:dc_aware,round_robin
         /// @test_category replication_strategy
         /// </summary>
@@ -128,8 +128,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
         }
 
         /// <summary>
-        /// Validate that no hops occur when inserting into a composite key 
-        /// 
+        /// Validate that no hops occur when inserting into a composite key
+        ///
         /// @test_category load_balancing:dc_aware,round_robin
         /// @test_category replication_strategy
         /// </summary>
@@ -202,8 +202,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
         }
 
         /// <summary>
-        /// Validate that no hops occur when inserting string values via a prepared statement 
-        /// 
+        /// Validate that no hops occur when inserting string values via a prepared statement
+        ///
         /// @test_category load_balancing:dc_aware,round_robin
         /// @test_category replication_strategy
         /// @test_category prepared_statements
@@ -242,8 +242,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
         }
 
         /// <summary>
-        /// Validate that no hops occur when inserting int values via a prepared statement 
-        /// 
+        /// Validate that no hops occur when inserting int values via a prepared statement
+        ///
         /// @test_category load_balancing:dc_aware,round_robin
         /// @test_category replication_strategy
         /// @test_category prepared_statements
@@ -279,8 +279,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
         }
 
         /// <summary>
-        /// Validate that hops occur when the wrong partition is targeted 
-        /// 
+        /// Validate that hops occur when the wrong partition is targeted
+        ///
         /// @test_category load_balancing:dc_aware,round_robin
         /// @test_category replication_strategy
         /// </summary>

--- a/src/Cassandra.BrokenIntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
+++ b/src/Cassandra.BrokenIntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
@@ -112,9 +112,12 @@ namespace Cassandra.IntegrationTests.Policies.Tests
             for (var i = 0; i < 10; i++)
             {
                 var key = Guid.NewGuid();
+                var keyBytes = key.ToByteArray();
+                var shuffled = new byte[16];
+                TypeSerializer.GuidShuffle(keyBytes, shuffled);
                 var statement = new SimpleStatement(string.Format("INSERT INTO " + uniqueTableName + " (k, i) VALUES ({0}, {1})", key, i))
                     .SetRoutingKey(
-                        new RoutingKey() { RawRoutingKey = TypeSerializer.GuidShuffle(key.ToByteArray()) })
+                        new RoutingKey() { RawRoutingKey = shuffled })
                     .EnableTracing();
                 var rs = session.Execute(statement);
                 traces.Add(rs.Info.QueryTrace);

--- a/src/Cassandra.BrokenTests/AbstractResponseTest.cs
+++ b/src/Cassandra.BrokenTests/AbstractResponseTest.cs
@@ -71,7 +71,9 @@ namespace Cassandra.Tests
             var rnd = new Random();
             var buffer = new byte[16];
             rnd.NextBytes(buffer);
-            var expected = new Guid(TypeSerializer.GuidShuffle(buffer));
+            Span<byte> shuffled = stackalloc byte[16];
+            TypeSerializer.GuidShuffle(buffer, shuffled);
+            var expected = new Guid(shuffled);
             var body = new MemoryStream(buffer);
             var frame = new Frame(header, body, new SerializerManager(ProtocolVersion.V4).GetCurrentSerializer(), null);
 

--- a/src/Cassandra.BrokenTests/FrameParserTests.cs
+++ b/src/Cassandra.BrokenTests/FrameParserTests.cs
@@ -200,7 +200,6 @@ namespace Cassandra.Tests
             BinaryPrimitives.WriteUInt16BigEndian(buf, value);
             return buf;
         }
-        }
 
         private static TException IsErrorResponse<TException>(Response response) where TException : DriverException
         {

--- a/src/Cassandra.BrokenTests/SerializerTests.cs
+++ b/src/Cassandra.BrokenTests/SerializerTests.cs
@@ -639,7 +639,12 @@ namespace Cassandra.Tests
     {
         internal static object Deserialize(this ISerializer serializer, byte[] buffer, ColumnTypeCode typeCode, IColumnInfo typeInfo)
         {
-            return serializer.Deserialize(buffer, 0, buffer.Length, typeCode, typeInfo);
+            return serializer.Deserialize(buffer.AsSpan(), typeCode, typeInfo);
+        }
+
+        internal static object Deserialize(this ISerializer serializer, byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo)
+        {
+            return serializer.Deserialize(buffer.AsSpan(offset, length), typeCode, typeInfo);
         }
 
         internal static ColumnTypeCode GetCqlTypeForPrimitive(this IGenericSerializer serializer, Type type)

--- a/src/Cassandra.Tests/DurationTests.cs
+++ b/src/Cassandra.Tests/DurationTests.cs
@@ -151,7 +151,7 @@ namespace Cassandra.Tests
             foreach (var value in Values)
             {
                 var buffer = FromHex(value.Item2);
-                Assert.AreEqual(value.Item1, serializer.Deserialize(4, buffer, 0, buffer.Length, null));
+                Assert.AreEqual(value.Item1, serializer.Deserialize(4, (ReadOnlySpan<byte>)buffer, null));
             }
         }
 

--- a/src/Cassandra.Tests/Extensions/Serializers/BigDecimalSerializer.cs
+++ b/src/Cassandra.Tests/Extensions/Serializers/BigDecimalSerializer.cs
@@ -35,10 +35,10 @@ namespace Cassandra.Tests.Extensions.Serializers
             get { return ColumnTypeCode.Decimal; }
         }
 
-        public override BigDecimal Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override BigDecimal Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            var scale = BinaryPrimitives.ReadInt32BigEndian(buffer.AsSpan(offset));
-            var unscaledValue = _bigIntegerSerializer.Deserialize(protocolVersion, buffer, 4, length - 4, null);
+            var scale = BinaryPrimitives.ReadInt32BigEndian(buffer);
+            var unscaledValue = _bigIntegerSerializer.Deserialize(protocolVersion, buffer.Slice(4), null);
             return new BigDecimal(scale, unscaledValue);
         }
 

--- a/src/Cassandra.Tests/Extensions/Serializers/DummyCustomTypeSerializer.cs
+++ b/src/Cassandra.Tests/Extensions/Serializers/DummyCustomTypeSerializer.cs
@@ -14,6 +14,7 @@
 //   limitations under the License.
 //
 
+using System;
 using Cassandra.Serialization;
 
 namespace Cassandra.Tests.Extensions.Serializers
@@ -26,9 +27,9 @@ namespace Cassandra.Tests.Extensions.Serializers
 
         }
 
-        public override DummyCustomType Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override DummyCustomType Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return new DummyCustomType(Utils.SliceBuffer(buffer, offset, length));
+            return new DummyCustomType(buffer.ToArray());
         }
 
         public override byte[] Serialize(ushort protocolVersion, DummyCustomType value)

--- a/src/Cassandra.Tests/Extensions/Serializers/UdtSerializerWrapper.cs
+++ b/src/Cassandra.Tests/Extensions/Serializers/UdtSerializerWrapper.cs
@@ -14,6 +14,7 @@
 //   limitations under the License.
 //
 
+using System;
 using System.Text;
 using Cassandra.Serialization;
 
@@ -41,14 +42,14 @@ namespace Cassandra.Tests.Extensions.Serializers
             return base.Serialize(protocolVersion, value);
         }
 
-        public override object Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override object Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
             DeserializationCounter++;
             if (_fixedValue)
             {
-                return Utils.SliceBuffer(buffer, offset, length);
+                return buffer.ToArray();
             }
-            return base.Deserialize(protocolVersion, buffer, offset, length, typeInfo);
+            return base.Deserialize(protocolVersion, buffer, typeInfo);
         }
     }
 }

--- a/src/Cassandra/RustBridge/BridgedRowSet.cs
+++ b/src/Cassandra/RustBridge/BridgedRowSet.cs
@@ -328,10 +328,8 @@ namespace Cassandra
                 {
                     CqlColumn column = columns[valueIndex];
 
-                    // TODO: reuse the frameSlice buffer.
-                    var frameSlice = FFIframeSlice.As<byte>().ToSpan().ToArray();
-                    int length = frameSlice.Length;
-                    values[valueIndex] = serializer.Deserialize(ProtocolVersion.V4, frameSlice.AsSpan(0, length), column.TypeCode, column.TypeInfo);
+                    ReadOnlySpan<byte> frameSlice = FFIframeSlice.As<byte>().ToSpan();
+                    values[valueIndex] = serializer.Deserialize(ProtocolVersion.V4, frameSlice, column.TypeCode, column.TypeInfo);
                 }
                 else
                 {

--- a/src/Cassandra/RustBridge/BridgedRowSet.cs
+++ b/src/Cassandra/RustBridge/BridgedRowSet.cs
@@ -331,7 +331,7 @@ namespace Cassandra
                     // TODO: reuse the frameSlice buffer.
                     var frameSlice = FFIframeSlice.As<byte>().ToSpan().ToArray();
                     int length = frameSlice.Length;
-                    values[valueIndex] = serializer.Deserialize(ProtocolVersion.V4, frameSlice, 0, length, column.TypeCode, column.TypeInfo);
+                    values[valueIndex] = serializer.Deserialize(ProtocolVersion.V4, frameSlice.AsSpan(0, length), column.TypeCode, column.TypeInfo);
                 }
                 else
                 {

--- a/src/Cassandra/Serialization/CollectionSerializer.cs
+++ b/src/Cassandra/Serialization/CollectionSerializer.cs
@@ -31,7 +31,7 @@ namespace Cassandra.Serialization
             get { throw new NotSupportedException("CollectionSerializer does not represent to a single CQL type"); }
         }
 
-        public override IEnumerable Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override IEnumerable Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
             ColumnTypeCode? childTypeCode = null;
             IColumnInfo childTypeInfo = null;
@@ -52,13 +52,14 @@ namespace Cassandra.Serialization
                 throw new DriverInternalError(string.Format("CollectionSerializer can not deserialize CQL values of type {0}",
                     typeInfo == null ? "null" : typeInfo.GetType().FullName));
             }
-            var count = DecodeCollectionLength((ProtocolVersion)protocolVersion, buffer, ref offset);
+            var remaining = buffer;
+            var count = DecodeCollectionLength((ProtocolVersion)protocolVersion, ref remaining);
             var childType = GetClrType(childTypeCode.Value, childTypeInfo);
             var result = Array.CreateInstance(childType, count);
             bool? isNullable = null;
             for (var i = 0; i < count; i++)
             {
-                var itemLength = DecodeCollectionLength((ProtocolVersion)protocolVersion, buffer, ref offset);
+                var itemLength = DecodeCollectionLength((ProtocolVersion)protocolVersion, ref remaining);
                 if (itemLength < 0)
                 {
                     if (isNullable == null)
@@ -83,8 +84,8 @@ namespace Cassandra.Serialization
                 }
                 else
                 {
-                    result.SetValue(DeserializeChild(protocolVersion, buffer, offset, itemLength, childTypeCode.Value, childTypeInfo), i);
-                    offset += itemLength;
+                    result.SetValue(DeserializeChild(protocolVersion, remaining.Slice(0, itemLength), childTypeCode.Value, childTypeInfo), i);
+                    remaining = remaining.Slice(itemLength);
                 }
             }
             return result;

--- a/src/Cassandra/Serialization/DictionarySerializer.cs
+++ b/src/Cassandra/Serialization/DictionarySerializer.cs
@@ -27,23 +27,24 @@ namespace Cassandra.Serialization
             get { return ColumnTypeCode.Map; }
         }
 
-        public override IDictionary Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override IDictionary Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
             var mapInfo = (MapColumnInfo)typeInfo;
             var keyType = GetClrType(mapInfo.KeyTypeCode, mapInfo.KeyTypeInfo);
             var valueType = GetClrType(mapInfo.ValueTypeCode, mapInfo.ValueTypeInfo);
-            var count = DecodeCollectionLength((ProtocolVersion)protocolVersion, buffer, ref offset);
+            var remaining = buffer;
+            var count = DecodeCollectionLength((ProtocolVersion)protocolVersion, ref remaining);
             var dicType = typeof(SortedDictionary<,>).MakeGenericType(keyType, valueType);
             var result = (IDictionary)Activator.CreateInstance(dicType);
             for (var i = 0; i < count; i++)
             {
-                var keyLength = DecodeCollectionLength((ProtocolVersion)protocolVersion, buffer, ref offset);
-                var key = DeserializeChild(protocolVersion, buffer, offset, keyLength, mapInfo.KeyTypeCode, mapInfo.KeyTypeInfo);
-                offset += keyLength;
+                var keyLength = DecodeCollectionLength((ProtocolVersion)protocolVersion, ref remaining);
+                var key = DeserializeChild(protocolVersion, remaining.Slice(0, keyLength), mapInfo.KeyTypeCode, mapInfo.KeyTypeInfo);
+                remaining = remaining.Slice(keyLength);
 
-                var valueLength = DecodeCollectionLength((ProtocolVersion)protocolVersion, buffer, ref offset);
-                var value = DeserializeChild(protocolVersion, buffer, offset, valueLength, mapInfo.ValueTypeCode, mapInfo.ValueTypeInfo);
-                offset += valueLength;
+                var valueLength = DecodeCollectionLength((ProtocolVersion)protocolVersion, ref remaining);
+                var value = DeserializeChild(protocolVersion, remaining.Slice(0, valueLength), mapInfo.ValueTypeCode, mapInfo.ValueTypeInfo);
+                remaining = remaining.Slice(valueLength);
 
                 result.Add(key, value);
             }

--- a/src/Cassandra/Serialization/DurationSerializer.cs
+++ b/src/Cassandra/Serialization/DurationSerializer.cs
@@ -42,11 +42,12 @@ namespace Cassandra.Serialization
             get { return new CustomColumnInfo("org.apache.cassandra.db.marshal.DurationType"); }
         }
 
-        public override Duration Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override Duration Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            var months = (int)VintSerializer.ReadVInt(buffer, ref offset);
-            var days = (int)VintSerializer.ReadVInt(buffer, ref offset);
-            var nanoseconds = VintSerializer.ReadVInt(buffer, ref offset);
+            var remaining = buffer;
+            var months = (int)VintSerializer.ReadVInt(ref remaining);
+            var days = (int)VintSerializer.ReadVInt(ref remaining);
+            var nanoseconds = VintSerializer.ReadVInt(ref remaining);
             return new Duration(months, days, nanoseconds);
         }
 

--- a/src/Cassandra/Serialization/GenericSerializer.cs
+++ b/src/Cassandra/Serialization/GenericSerializer.cs
@@ -105,16 +105,16 @@ namespace Cassandra.Serialization
                         return typeSerializer.Deserialize((byte)version, buffer, typeInfo);
                     }
                 case ColumnTypeCode.Vector:
-                    return ((ITypeSerializer)_vectorSerializer).Deserialize((byte)version, buffer, typeInfo);
+                    return _vectorSerializer.Deserialize((byte)version, buffer, typeInfo);
                 case ColumnTypeCode.Udt:
-                    return ((ITypeSerializer)_udtSerializer).Deserialize((byte)version, buffer, typeInfo);
+                    return _udtSerializer.Deserialize((byte)version, buffer, typeInfo);
                 case ColumnTypeCode.List:
                 case ColumnTypeCode.Set:
-                    return ((ITypeSerializer)_collectionSerializer).Deserialize((byte)version, buffer, typeInfo);
+                    return _collectionSerializer.Deserialize((byte)version, buffer, typeInfo);
                 case ColumnTypeCode.Map:
-                    return ((ITypeSerializer)_dictionarySerializer).Deserialize((byte)version, buffer, typeInfo);
+                    return _dictionarySerializer.Deserialize((byte)version, buffer, typeInfo);
                 case ColumnTypeCode.Tuple:
-                    return ((ITypeSerializer)_tupleSerializer).Deserialize((byte)version, buffer, typeInfo);
+                    return _tupleSerializer.Deserialize((byte)version, buffer, typeInfo);
             }
             //Unknown type, return the byte representation
             return buffer.ToArray();

--- a/src/Cassandra/Serialization/GenericSerializer.cs
+++ b/src/Cassandra/Serialization/GenericSerializer.cs
@@ -87,11 +87,11 @@ namespace Cassandra.Serialization
             SetSpecificSerializers(typeSerializers);
         }
 
-        public object Deserialize(ProtocolVersion version, byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo)
+        public object Deserialize(ProtocolVersion version, ReadOnlySpan<byte> buffer, ColumnTypeCode typeCode, IColumnInfo typeInfo)
         {
             if (_primitiveDeserializers.TryGetValue(typeCode, out ITypeSerializer typeSerializer))
             {
-                return typeSerializer.Deserialize((byte)version, buffer, offset, length, typeInfo);
+                return typeSerializer.Deserialize((byte)version, buffer, typeInfo);
             }
             switch (typeCode)
             {
@@ -102,22 +102,22 @@ namespace Cassandra.Serialization
                             // Use byte[] by default
                             typeSerializer = TypeSerializer.PrimitiveByteArraySerializer;
                         }
-                        return typeSerializer.Deserialize((byte)version, buffer, offset, length, typeInfo);
+                        return typeSerializer.Deserialize((byte)version, buffer, typeInfo);
                     }
                 case ColumnTypeCode.Vector:
-                    return _vectorSerializer.Deserialize((byte)version, buffer, offset, length, typeInfo);
+                    return ((ITypeSerializer)_vectorSerializer).Deserialize((byte)version, buffer, typeInfo);
                 case ColumnTypeCode.Udt:
-                    return _udtSerializer.Deserialize((byte)version, buffer, offset, length, typeInfo);
+                    return ((ITypeSerializer)_udtSerializer).Deserialize((byte)version, buffer, typeInfo);
                 case ColumnTypeCode.List:
                 case ColumnTypeCode.Set:
-                    return _collectionSerializer.Deserialize((byte)version, buffer, offset, length, typeInfo);
+                    return ((ITypeSerializer)_collectionSerializer).Deserialize((byte)version, buffer, typeInfo);
                 case ColumnTypeCode.Map:
-                    return _dictionarySerializer.Deserialize((byte)version, buffer, offset, length, typeInfo);
+                    return ((ITypeSerializer)_dictionarySerializer).Deserialize((byte)version, buffer, typeInfo);
                 case ColumnTypeCode.Tuple:
-                    return _tupleSerializer.Deserialize((byte)version, buffer, offset, length, typeInfo);
+                    return ((ITypeSerializer)_tupleSerializer).Deserialize((byte)version, buffer, typeInfo);
             }
             //Unknown type, return the byte representation
-            return buffer;
+            return buffer.ToArray();
         }
 
         public Type GetClrType(ColumnTypeCode typeCode, IColumnInfo typeInfo)

--- a/src/Cassandra/Serialization/IGenericSerializer.cs
+++ b/src/Cassandra/Serialization/IGenericSerializer.cs
@@ -23,7 +23,7 @@ namespace Cassandra.Serialization
     /// </summary>
     internal interface IGenericSerializer
     {
-        object Deserialize(ProtocolVersion version, byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo);
+        object Deserialize(ProtocolVersion version, ReadOnlySpan<byte> buffer, ColumnTypeCode typeCode, IColumnInfo typeInfo);
 
         byte[] Serialize(ProtocolVersion version, object value);
 

--- a/src/Cassandra/Serialization/ISerializer.cs
+++ b/src/Cassandra/Serialization/ISerializer.cs
@@ -27,9 +27,9 @@ namespace Cassandra.Serialization
         /// </summary>
         ProtocolVersion ProtocolVersion { get; }
 
-        object Deserialize(byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo);
+        object Deserialize(ReadOnlySpan<byte> buffer, ColumnTypeCode typeCode, IColumnInfo typeInfo);
 
-        object DeserializeAndDecrypt(string ks, string table, string col, byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo);
+        object DeserializeAndDecrypt(string ks, string table, string col, ReadOnlySpan<byte> buffer, ColumnTypeCode typeCode, IColumnInfo typeInfo);
 
         byte[] Serialize(object value);
 

--- a/src/Cassandra/Serialization/ITypeSerializer.cs
+++ b/src/Cassandra/Serialization/ITypeSerializer.cs
@@ -26,7 +26,7 @@ namespace Cassandra.Serialization
 
         ColumnTypeCode CqlType { get; }
 
-        object Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo);
+        object Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo);
 
         byte[] Serialize(ushort protocolVersion, object obj);
     }

--- a/src/Cassandra/Serialization/Primitive/BigIntegerSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/BigIntegerSerializer.cs
@@ -29,12 +29,9 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Varint; }
         }
 
-        public override BigInteger Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override BigInteger Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            buffer = Utils.SliceBuffer(buffer, offset, length);
-            //Cassandra uses big endian encoding
-            Array.Reverse(buffer);
-            return new BigInteger(buffer);
+            return new BigInteger(buffer, isUnsigned: false, isBigEndian: true);
         }
 
         public override byte[] Serialize(ushort protocolVersion, BigInteger value)

--- a/src/Cassandra/Serialization/Primitive/BooleanSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/BooleanSerializer.cs
@@ -14,6 +14,8 @@
 //   limitations under the License.
 //
 
+using System;
+
 namespace Cassandra.Serialization.Primitive
 {
     internal class BooleanSerializer : TypeSerializer<bool>
@@ -23,9 +25,9 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Boolean; }
         }
 
-        public override bool Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override bool Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return buffer[offset] == 1;
+            return buffer[0] == 1;
         }
 
         public override byte[] Serialize(ushort protocolVersion, bool value)

--- a/src/Cassandra/Serialization/Primitive/ByteArraySerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/ByteArraySerializer.cs
@@ -14,6 +14,8 @@
 //   limitations under the License.
 //
 
+using System;
+
 namespace Cassandra.Serialization.Primitive
 {
     internal class ByteArraySerializer : TypeSerializer<byte[]>
@@ -23,9 +25,9 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Blob; }
         }
 
-        public override byte[] Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override byte[] Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return Utils.FromOffset(buffer, offset, length);
+            return buffer.ToArray();
         }
 
         public override byte[] Serialize(ushort protocolVersion, byte[] value)

--- a/src/Cassandra/Serialization/Primitive/DateTimeOffsetSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/DateTimeOffsetSerializer.cs
@@ -26,9 +26,9 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Timestamp; }
         }
 
-        internal static DateTimeOffset Deserialize(byte[] buffer, int offset)
+        internal static DateTimeOffset Deserialize(ReadOnlySpan<byte> buffer)
         {
-            var milliseconds = BinaryPrimitives.ReadInt64BigEndian(buffer.AsSpan(offset));
+            var milliseconds = BinaryPrimitives.ReadInt64BigEndian(buffer);
             return UnixStart.AddTicks(TimeSpan.TicksPerMillisecond * milliseconds);
         }
 
@@ -40,9 +40,9 @@ namespace Cassandra.Serialization.Primitive
             return buffer;
         }
 
-        public override DateTimeOffset Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override DateTimeOffset Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return Deserialize(buffer, offset);
+            return Deserialize(buffer);
         }
 
         public override byte[] Serialize(ushort protocolVersion, DateTimeOffset value)

--- a/src/Cassandra/Serialization/Primitive/DateTimeSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/DateTimeSerializer.cs
@@ -25,9 +25,9 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Timestamp; }
         }
 
-        public override DateTime Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override DateTime Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            var dto = DateTimeOffsetSerializer.Deserialize(buffer, offset);
+            var dto = DateTimeOffsetSerializer.Deserialize(buffer);
             return dto.DateTime;
         }
 

--- a/src/Cassandra/Serialization/Primitive/DecimalSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/DecimalSerializer.cs
@@ -30,15 +30,10 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Decimal; }
         }
 
-        public override decimal Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override decimal Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            var scale = BinaryPrimitives.ReadInt32BigEndian(buffer.AsSpan(offset));
-            var unscaledBytes = Utils.SliceBuffer(buffer, offset + 4, length - 4);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(unscaledBytes);
-            }
-            return ToDecimal(new BigInteger(unscaledBytes), scale);
+            var scale = BinaryPrimitives.ReadInt32BigEndian(buffer);
+            return ToDecimal(new BigInteger(buffer.Slice(4), isUnsigned: false, isBigEndian: true), scale);
         }
 
         internal static decimal ToDecimal(BigInteger unscaledValue, int scale)

--- a/src/Cassandra/Serialization/Primitive/DoubleSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/DoubleSerializer.cs
@@ -26,9 +26,9 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Double; }
         }
 
-        public override double Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override double Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return BinaryPrimitives.ReadDoubleBigEndian(buffer.AsSpan(offset));
+            return BinaryPrimitives.ReadDoubleBigEndian(buffer);
         }
 
         public override byte[] Serialize(ushort protocolVersion, double value)

--- a/src/Cassandra/Serialization/Primitive/FloatSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/FloatSerializer.cs
@@ -26,9 +26,9 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Float; }
         }
 
-        public override float Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override float Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return BinaryPrimitives.ReadSingleBigEndian(buffer.AsSpan(offset));
+            return BinaryPrimitives.ReadSingleBigEndian(buffer);
         }
 
         public override byte[] Serialize(ushort protocolVersion, float value)

--- a/src/Cassandra/Serialization/Primitive/GuidSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/GuidSerializer.cs
@@ -25,14 +25,18 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Uuid; }
         }
 
-        public override Guid Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override Guid Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return new Guid(GuidShuffle(buffer, offset));
+            Span<byte> shuffled = stackalloc byte[16];
+            GuidShuffle(buffer, shuffled);
+            return new Guid((ReadOnlySpan<byte>)shuffled);
         }
 
         public override byte[] Serialize(ushort protocolVersion, Guid value)
         {
-            return GuidShuffle(value.ToByteArray());
+            var result = new byte[16];
+            GuidShuffle((ReadOnlySpan<byte>)value.ToByteArray(), result);
+            return result;
         }
     }
 }

--- a/src/Cassandra/Serialization/Primitive/IntSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/IntSerializer.cs
@@ -26,9 +26,9 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Int; }
         }
 
-        public override int Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override int Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return BinaryPrimitives.ReadInt32BigEndian(buffer.AsSpan(offset));
+            return BinaryPrimitives.ReadInt32BigEndian(buffer);
         }
 
         public override byte[] Serialize(ushort protocolVersion, int value)

--- a/src/Cassandra/Serialization/Primitive/IpAddressSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/IpAddressSerializer.cs
@@ -14,6 +14,7 @@
 //   limitations under the License.
 //
 
+using System;
 using System.Net;
 
 namespace Cassandra.Serialization.Primitive
@@ -25,13 +26,13 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Inet; }
         }
 
-        public override IPAddress Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override IPAddress Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            if (length == 4 || length == 16)
+            if (buffer.Length == 4 || buffer.Length == 16)
             {
-                return new IPAddress(Utils.FromOffset(buffer, offset, length));
+                return new IPAddress(buffer);
             }
-            throw new DriverInternalError("Invalid length of Inet address: " + length);
+            throw new DriverInternalError("Invalid length of Inet address: " + buffer.Length);
         }
 
         public override byte[] Serialize(ushort protocolVersion, IPAddress value)

--- a/src/Cassandra/Serialization/Primitive/LocalDateSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/LocalDateSerializer.cs
@@ -14,6 +14,9 @@
 //   limitations under the License.
 //
 
+using System;
+using System.Buffers.Binary;
+
 namespace Cassandra.Serialization.Primitive
 {
     internal class LocalDateSerializer : TypeSerializer<LocalDate>
@@ -23,12 +26,9 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Date; }
         }
 
-        public override LocalDate Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override LocalDate Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            var days = unchecked((uint)((buffer[offset] << 24)
-                   | (buffer[offset + 1] << 16)
-                   | (buffer[offset + 2] << 8)
-                   | (buffer[offset + 3])));
+            var days = BinaryPrimitives.ReadUInt32BigEndian(buffer);
             return new LocalDate(days);
         }
 

--- a/src/Cassandra/Serialization/Primitive/LocalTimeSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/LocalTimeSerializer.cs
@@ -26,9 +26,9 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Time; }
         }
 
-        public override LocalTime Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override LocalTime Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return new LocalTime(BinaryPrimitives.ReadInt64BigEndian(buffer.AsSpan(offset)));
+            return new LocalTime(BinaryPrimitives.ReadInt64BigEndian(buffer));
         }
 
         public override byte[] Serialize(ushort protocolVersion, LocalTime value)

--- a/src/Cassandra/Serialization/Primitive/LongSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/LongSerializer.cs
@@ -29,9 +29,9 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Bigint; }
         }
 
-        public override long Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override long Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return BinaryPrimitives.ReadInt64BigEndian(buffer.AsSpan(offset));
+            return BinaryPrimitives.ReadInt64BigEndian(buffer);
         }
 
         public override byte[] Serialize(ushort protocolVersion, long value)

--- a/src/Cassandra/Serialization/Primitive/SbyteSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/SbyteSerializer.cs
@@ -14,6 +14,8 @@
 //   limitations under the License.
 //
 
+using System;
+
 namespace Cassandra.Serialization.Primitive
 {
     internal class SbyteSerializer : TypeSerializer<sbyte>
@@ -23,9 +25,9 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.TinyInt; }
         }
 
-        public override sbyte Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override sbyte Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return unchecked((sbyte)buffer[offset]);
+            return unchecked((sbyte)buffer[0]);
         }
 
         public override byte[] Serialize(ushort protocolVersion, sbyte value)

--- a/src/Cassandra/Serialization/Primitive/ShortSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/ShortSerializer.cs
@@ -26,9 +26,9 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.SmallInt; }
         }
 
-        public override short Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override short Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return BinaryPrimitives.ReadInt16BigEndian(buffer.AsSpan(offset));
+            return BinaryPrimitives.ReadInt16BigEndian(buffer);
         }
 
         public override byte[] Serialize(ushort protocolVersion, short value)

--- a/src/Cassandra/Serialization/Primitive/StringSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/StringSerializer.cs
@@ -14,6 +14,7 @@
 //   limitations under the License.
 //
 
+using System;
 using System.Text;
 
 namespace Cassandra.Serialization.Primitive
@@ -32,9 +33,9 @@ namespace Cassandra.Serialization.Primitive
             _encoding = encoding;
         }
 
-        public override string Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override string Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return _encoding.GetString(buffer, offset, length);
+            return _encoding.GetString(buffer);
         }
 
         public override byte[] Serialize(ushort protocolVersion, string value)

--- a/src/Cassandra/Serialization/Primitive/TimeUuidSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/TimeUuidSerializer.cs
@@ -25,14 +25,18 @@ namespace Cassandra.Serialization.Primitive
             get { return ColumnTypeCode.Timeuuid; }
         }
 
-        public override TimeUuid Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override TimeUuid Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return new Guid(GuidShuffle(buffer, offset));
+            Span<byte> shuffled = stackalloc byte[16];
+            GuidShuffle(buffer, shuffled);
+            return new Guid((ReadOnlySpan<byte>)shuffled);
         }
 
         public override byte[] Serialize(ushort protocolVersion, TimeUuid value)
         {
-            return GuidShuffle(value.ToByteArray());
+            var result = new byte[16];
+            GuidShuffle((ReadOnlySpan<byte>)value.ToByteArray(), result);
+            return result;
         }
     }
 }

--- a/src/Cassandra/Serialization/Serializer.cs
+++ b/src/Cassandra/Serialization/Serializer.cs
@@ -32,17 +32,17 @@ namespace Cassandra.Serialization
 
         public ProtocolVersion ProtocolVersion { get; }
 
-        public object Deserialize(byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo)
+        public object Deserialize(ReadOnlySpan<byte> buffer, ColumnTypeCode typeCode, IColumnInfo typeInfo)
         {
-            return _serializer.Deserialize(ProtocolVersion, buffer, offset, length, typeCode, typeInfo);
+            return _serializer.Deserialize(ProtocolVersion, buffer, typeCode, typeInfo);
         }
 
-        public object DeserializeAndDecrypt(string ks, string table, string column, byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo)
+        public object DeserializeAndDecrypt(string ks, string table, string column, ReadOnlySpan<byte> buffer, ColumnTypeCode typeCode, IColumnInfo typeInfo)
         {
             var columnEncryptionMetadata = _columnEncryptionPolicy.GetColumnEncryptionMetadata(ks, table, column);
             if (columnEncryptionMetadata != null)
             {
-                var encryptedData = _serializer.Deserialize(ProtocolVersion, buffer, offset, length, typeCode, typeInfo);
+                var encryptedData = _serializer.Deserialize(ProtocolVersion, buffer, typeCode, typeInfo);
                 if (encryptedData == null)
                 {
                     throw new DriverInternalError("deserialization of encrypted data returned null");
@@ -58,9 +58,9 @@ namespace Cassandra.Serialization
                 {
                     return null;
                 }
-                return _serializer.Deserialize(ProtocolVersion, decryptedDataBuf, 0, decryptedDataBuf.Length, columnEncryptionMetadata.Value.TypeCode, columnEncryptionMetadata.Value.TypeInfo);
+                return _serializer.Deserialize(ProtocolVersion, decryptedDataBuf.AsSpan(), columnEncryptionMetadata.Value.TypeCode, columnEncryptionMetadata.Value.TypeInfo);
             }
-            return _serializer.Deserialize(ProtocolVersion, buffer, offset, length, typeCode, typeInfo);
+            return _serializer.Deserialize(ProtocolVersion, buffer, typeCode, typeInfo);
         }
 
         public byte[] Serialize(object value)
@@ -154,9 +154,9 @@ namespace Cassandra.Serialization
             }
         }
 
-        public object Deserialize(ProtocolVersion version, byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo)
+        public object Deserialize(ProtocolVersion version, ReadOnlySpan<byte> buffer, ColumnTypeCode typeCode, IColumnInfo typeInfo)
         {
-            return _serializer.Deserialize(version, buffer, offset, length, typeCode, typeInfo);
+            return _serializer.Deserialize(version, buffer, typeCode, typeInfo);
         }
 
         public byte[] Serialize(ProtocolVersion version, object value)

--- a/src/Cassandra/Serialization/SerializerManager.cs
+++ b/src/Cassandra/Serialization/SerializerManager.cs
@@ -53,11 +53,6 @@ namespace Cassandra.Serialization
             return _serializer;
         }
 
-        public object Deserialize(ProtocolVersion version, byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo)
-        {
-            return _genericSerializer.Deserialize(version, buffer, offset, length, typeCode, typeInfo);
-        }
-
         public byte[] Serialize(ProtocolVersion version, object value)
         {
             return _genericSerializer.Serialize(version, value);

--- a/src/Cassandra/Serialization/TupleSerializer.cs
+++ b/src/Cassandra/Serialization/TupleSerializer.cs
@@ -30,27 +30,27 @@ namespace Cassandra.Serialization
             get { return ColumnTypeCode.Tuple; }
         }
 
-        public override IStructuralEquatable Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override IStructuralEquatable Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
             var tupleInfo = (TupleColumnInfo)typeInfo;
             var tupleType = GetClrType(ColumnTypeCode.Tuple, tupleInfo);
             var tupleValues = new object[tupleInfo.Elements.Count];
-            var maxOffset = offset + length;
+            var remaining = buffer;
             for (var i = 0; i < tupleInfo.Elements.Count; i++)
             {
                 var element = tupleInfo.Elements[i];
-                if (offset >= maxOffset)
+                if (remaining.IsEmpty)
                 {
                     break;
                 }
-                var itemLength = BinaryPrimitives.ReadInt32BigEndian(buffer.AsSpan(offset));
-                offset += 4;
+                var itemLength = BinaryPrimitives.ReadInt32BigEndian(remaining);
+                remaining = remaining.Slice(4);
                 if (itemLength < 0)
                 {
                     continue;
                 }
-                tupleValues[i] = DeserializeChild(protocolVersion, buffer, offset, itemLength, element.TypeCode, element.TypeInfo);
-                offset += itemLength;
+                tupleValues[i] = DeserializeChild(protocolVersion, remaining.Slice(0, itemLength), element.TypeCode, element.TypeInfo);
+                remaining = remaining.Slice(itemLength);
             }
 
             return (IStructuralEquatable)Activator.CreateInstance(tupleType, tupleValues);

--- a/src/Cassandra/Serialization/TypeSerializer.cs
+++ b/src/Cassandra/Serialization/TypeSerializer.cs
@@ -168,7 +168,7 @@ namespace Cassandra.Serialization
 
         object ITypeSerializer.Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return Deserialize(protocolVersion, buffer.ToArray(), 0, buffer.Length, typeInfo);
+            return Deserialize(protocolVersion, buffer, typeInfo);
         }
 
         byte[] ITypeSerializer.Serialize(ushort protocolVersion, object obj)
@@ -181,11 +181,9 @@ namespace Cassandra.Serialization
         /// data type.
         /// </summary>
         /// <param name="protocolVersion">The Cassandra native protocol version.</param>
-        /// <param name="buffer">The byte array.</param>
-        /// <param name="offset">The zero-based byte offset in buffer at which to begin storing data from the current stream.</param>
-        /// <param name="length">The maximum amount of bytes to read from buffer.</param>
+        /// <param name="buffer">The byte span containing exactly the serialized value.</param>
         /// <param name="typeInfo">Additional type information designed for non-primitive types.</param>
-        public abstract T Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo);
+        public abstract T Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo);
 
         /// <summary>
         /// When overridden from a derived class, it encodes the CLR object into the byte representation

--- a/src/Cassandra/Serialization/TypeSerializer.cs
+++ b/src/Cassandra/Serialization/TypeSerializer.cs
@@ -52,17 +52,6 @@ namespace Cassandra.Serialization
 
         internal static readonly DateTimeOffset UnixStart = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
 
-        internal static byte[] GuidShuffle(byte[] b, int offset = 0)
-        {
-            return new[]
-            {
-                b[offset + 3], b[offset + 2], b[offset + 1], b[offset + 0],
-                b[offset + 5], b[offset + 4],
-                b[offset + 7], b[offset + 6],
-                b[offset + 8], b[offset + 9], b[offset + 10], b[offset + 11], b[offset + 12], b[offset + 13], b[offset + 14], b[offset + 15]
-            };
-        }
-
         internal static void GuidShuffle(ReadOnlySpan<byte> source, Span<byte> destination)
         {
             destination[0] = source[3]; destination[1] = source[2]; destination[2] = source[1]; destination[3] = source[0];
@@ -70,16 +59,6 @@ namespace Cassandra.Serialization
             destination[6] = source[7]; destination[7] = source[6];
             destination[8] = source[8]; destination[9] = source[9]; destination[10] = source[10]; destination[11] = source[11];
             destination[12] = source[12]; destination[13] = source[13]; destination[14] = source[14]; destination[15] = source[15];
-        }
-
-        /// <summary>
-        /// Decodes length for collection types (always 4 bytes for protocol V4+).
-        /// </summary>
-        internal static int DecodeCollectionLength(ProtocolVersion protocolVersion, byte[] buffer, ref int index)
-        {
-            var result = BinaryPrimitives.ReadInt32BigEndian(buffer.AsSpan(index));
-            index += 4;
-            return result;
         }
 
         /// <summary>
@@ -200,11 +179,6 @@ namespace Cassandra.Serialization
                 throw new NullReferenceException("Child serializer can not be null");
             }
             return _serializer.Deserialize((ProtocolVersion)protocolVersion, buffer, typeCode, typeInfo);
-        }
-
-        internal object DeserializeChild(ushort protocolVersion, byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo)
-        {
-            return DeserializeChild(protocolVersion, buffer.AsSpan(offset, length), typeCode, typeInfo);
         }
 
         internal Type GetClrType(ColumnTypeCode typeCode, IColumnInfo typeInfo)

--- a/src/Cassandra/Serialization/TypeSerializer.cs
+++ b/src/Cassandra/Serialization/TypeSerializer.cs
@@ -63,6 +63,15 @@ namespace Cassandra.Serialization
             };
         }
 
+        internal static void GuidShuffle(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            destination[0] = source[3]; destination[1] = source[2]; destination[2] = source[1]; destination[3] = source[0];
+            destination[4] = source[5]; destination[5] = source[4];
+            destination[6] = source[7]; destination[7] = source[6];
+            destination[8] = source[8]; destination[9] = source[9]; destination[10] = source[10]; destination[11] = source[11];
+            destination[12] = source[12]; destination[13] = source[13]; destination[14] = source[14]; destination[15] = source[15];
+        }
+
         /// <summary>
         /// Decodes length for collection types (always 4 bytes for protocol V4+).
         /// </summary>
@@ -70,6 +79,17 @@ namespace Cassandra.Serialization
         {
             var result = BinaryPrimitives.ReadInt32BigEndian(buffer.AsSpan(index));
             index += 4;
+            return result;
+        }
+
+        /// <summary>
+        /// Decodes length for collection types (always 4 bytes for protocol V4+).
+        /// Advances the span past the consumed bytes.
+        /// </summary>
+        internal static int DecodeCollectionLength(ProtocolVersion protocolVersion, ref ReadOnlySpan<byte> buffer)
+        {
+            var result = BinaryPrimitives.ReadInt32BigEndian(buffer);
+            buffer = buffer.Slice(4);
             return result;
         }
 

--- a/src/Cassandra/Serialization/TypeSerializer.cs
+++ b/src/Cassandra/Serialization/TypeSerializer.cs
@@ -166,9 +166,9 @@ namespace Cassandra.Serialization
         /// </summary>
         public abstract ColumnTypeCode CqlType { get; }
 
-        object ITypeSerializer.Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        object ITypeSerializer.Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
-            return Deserialize(protocolVersion, buffer, offset, length, typeInfo);
+            return Deserialize(protocolVersion, buffer.ToArray(), 0, buffer.Length, typeInfo);
         }
 
         byte[] ITypeSerializer.Serialize(ushort protocolVersion, object obj)
@@ -195,13 +195,18 @@ namespace Cassandra.Serialization
         /// <param name="value">The object to encode.</param>
         public abstract byte[] Serialize(ushort protocolVersion, T value);
 
-        internal object DeserializeChild(ushort protocolVersion, byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo)
+        internal object DeserializeChild(ushort protocolVersion, ReadOnlySpan<byte> buffer, ColumnTypeCode typeCode, IColumnInfo typeInfo)
         {
             if (_serializer == null)
             {
                 throw new NullReferenceException("Child serializer can not be null");
             }
-            return _serializer.Deserialize((ProtocolVersion)protocolVersion, buffer, offset, length, typeCode, typeInfo);
+            return _serializer.Deserialize((ProtocolVersion)protocolVersion, buffer, typeCode, typeInfo);
+        }
+
+        internal object DeserializeChild(ushort protocolVersion, byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo)
+        {
+            return DeserializeChild(protocolVersion, buffer.AsSpan(offset, length), typeCode, typeInfo);
         }
 
         internal Type GetClrType(ColumnTypeCode typeCode, IColumnInfo typeInfo)

--- a/src/Cassandra/Serialization/UdtSerializer.cs
+++ b/src/Cassandra/Serialization/UdtSerializer.cs
@@ -56,31 +56,31 @@ namespace Cassandra.Serialization
             return map;
         }
 
-        public override object Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override object Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
             var udtInfo = (UdtColumnInfo)typeInfo;
             var map = GetUdtMap(udtInfo.Name);
             if (map == null)
             {
-                return buffer;
+                return buffer.ToArray();
             }
             var valuesList = new object[udtInfo.Fields.Count];
-            var maxOffset = offset + length;
+            var remaining = buffer;
             for (var i = 0; i < udtInfo.Fields.Count; i++)
             {
                 var field = udtInfo.Fields[i];
-                if (offset >= maxOffset)
+                if (remaining.IsEmpty)
                 {
                     break;
                 }
-                var itemLength = BinaryPrimitives.ReadInt32BigEndian(buffer.AsSpan(offset));
-                offset += 4;
+                var itemLength = BinaryPrimitives.ReadInt32BigEndian(remaining);
+                remaining = remaining.Slice(4);
                 if (itemLength < 0)
                 {
                     continue;
                 }
-                valuesList[i] = DeserializeChild(protocolVersion, buffer, offset, itemLength, field.TypeCode, field.TypeInfo);
-                offset += itemLength;
+                valuesList[i] = DeserializeChild(protocolVersion, remaining.Slice(0, itemLength), field.TypeCode, field.TypeInfo);
+                remaining = remaining.Slice(itemLength);
             }
             return map.ToObject(valuesList);
         }

--- a/src/Cassandra/Serialization/VectorSerializer.cs
+++ b/src/Cassandra/Serialization/VectorSerializer.cs
@@ -28,7 +28,7 @@ namespace Cassandra.Serialization
 
         public override IColumnInfo TypeInfo => new CustomColumnInfo(DataTypeParser.VectorTypeName);
 
-        public override IInternalCqlVector Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        public override IInternalCqlVector Deserialize(ushort protocolVersion, ReadOnlySpan<byte> buffer, IColumnInfo typeInfo)
         {
             var vectorTypeInfo = GetVectorColumnInfo(typeInfo);
             if (vectorTypeInfo.Dimensions == null)
@@ -39,9 +39,10 @@ namespace Cassandra.Serialization
             var childSerializer = GetChildSerializer();
             var childType = GetClrType(vectorTypeInfo.ValueTypeCode, vectorTypeInfo.ValueTypeInfo);
             var result = Array.CreateInstance(childType, vectorTypeInfo.Dimensions.Value);
+            var remaining = buffer;
             for (var i = 0; i < vectorTypeInfo.Dimensions; i++)
             {
-                if (offset >= buffer.Length)
+                if (remaining.IsEmpty)
                 {
                     throw new DriverInternalError(
                         $"No more bytes while deserializing vector with subtype {typeInfo.GetType().FullName} and dimensions {vectorTypeInfo.Dimensions}");
@@ -49,7 +50,7 @@ namespace Cassandra.Serialization
                 var itemLength = childSerializer.GetValueLengthIfFixed(vectorTypeInfo.ValueTypeCode, vectorTypeInfo.ValueTypeInfo);
                 if (itemLength < 0)
                 {
-                    var longItemLength = VintSerializer.ReadUnsignedVInt(buffer, ref offset);
+                    var longItemLength = VintSerializer.ReadUnsignedVInt(ref remaining);
                     if (longItemLength > int.MaxValue)
                     {
                         throw new DriverInternalError(
@@ -58,11 +59,11 @@ namespace Cassandra.Serialization
 
                     itemLength = Convert.ToInt32(longItemLength);
                 }
-                result.SetValue(DeserializeChild(protocolVersion, buffer, offset, itemLength, vectorTypeInfo.ValueTypeCode, vectorTypeInfo.ValueTypeInfo), i);
-                offset += itemLength;
+                result.SetValue(DeserializeChild(protocolVersion, remaining.Slice(0, itemLength), vectorTypeInfo.ValueTypeCode, vectorTypeInfo.ValueTypeInfo), i);
+                remaining = remaining.Slice(itemLength);
             }
 
-            if (offset < length - 1)
+            if (!remaining.IsEmpty)
             {
                 throw new DriverInternalError(
                     $"There are still bytes left while deserializing vector with subtype {typeInfo.GetType().FullName} and dimensions {vectorTypeInfo.Dimensions}");

--- a/src/Cassandra/Serialization/VintSerializer.cs
+++ b/src/Cassandra/Serialization/VintSerializer.cs
@@ -101,29 +101,6 @@ namespace Cassandra.Serialization
             return WriteUnsignedVInt(EncodeZigZag64(value), buffer);
         }
 
-        public static long ReadUnsignedVInt(byte[] input, ref int offset)
-        {
-            var firstByte = input[offset++];
-            if ((firstByte & 0x80) == 0)
-            {
-                return firstByte;
-            }
-            var size = NumberOfExtraBytesToRead(firstByte);
-            long result = firstByte & FirstByteValueMask(size);
-            for (var ii = 0; ii < size; ii++)
-            {
-                long b = input[offset++];
-                result <<= 8;
-                result |= b & 0xff;
-            }
-            return result;
-        }
-
-        public static long ReadVInt(byte[] buffer, ref int offset)
-        {
-            return DecodeZigZag64(ReadUnsignedVInt(buffer, ref offset));
-        }
-
         public static long ReadUnsignedVInt(ref ReadOnlySpan<byte> input)
         {
             var firstByte = input[0];

--- a/src/Cassandra/Serialization/VintSerializer.cs
+++ b/src/Cassandra/Serialization/VintSerializer.cs
@@ -1,11 +1,11 @@
 // Copyright (C) DataStax Inc.
-// 
+//
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
 //    You may obtain a copy of the License at
-// 
+//
 //       http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/Cassandra/Serialization/VintSerializer.cs
+++ b/src/Cassandra/Serialization/VintSerializer.cs
@@ -12,6 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+using System;
+
 namespace Cassandra.Serialization
 {
     internal static class VintSerializer
@@ -120,6 +122,31 @@ namespace Cassandra.Serialization
         public static long ReadVInt(byte[] buffer, ref int offset)
         {
             return DecodeZigZag64(ReadUnsignedVInt(buffer, ref offset));
+        }
+
+        public static long ReadUnsignedVInt(ref ReadOnlySpan<byte> input)
+        {
+            var firstByte = input[0];
+            input = input.Slice(1);
+            if ((firstByte & 0x80) == 0)
+            {
+                return firstByte;
+            }
+            var size = NumberOfExtraBytesToRead(firstByte);
+            long result = firstByte & FirstByteValueMask(size);
+            for (var ii = 0; ii < size; ii++)
+            {
+                long b = input[0];
+                input = input.Slice(1);
+                result <<= 8;
+                result |= b & 0xff;
+            }
+            return result;
+        }
+
+        public static long ReadVInt(ref ReadOnlySpan<byte> buffer)
+        {
+            return DecodeZigZag64(ReadUnsignedVInt(ref buffer));
         }
     }
 }


### PR DESCRIPTION
Fixes: #103

#### Created by Opus 4.6. Reviewed by me.

## Zero-copy deserialization

### Background
When reading query results, `BridgedRowSet` receives cell values from the Rust side as byte buffers and passes them through the serialization layer to produce .NET objects. Previously, every cell required a `.ToArray()` call to convert the Rust-provided memory into a byte[] before deserialization — one heap allocation per cell, per row, per query.

### What's done
This PR changes the deserialization API from `byte[]` (with offset and length) to `ReadOnlySpan<byte>` across the entire serializer stack: interfaces, dispatch layer, and all 25 concrete `TypeSerializer<T>` implementations. With this change, the Rust-provided memory flows directly into each deserializer without any intermediate allocation.
The migration is structured bottom-up: first the low-level utility helpers gain span overloads, then the interfaces and dispatch are switched over, then all concrete serializers are updated, then `BridgedRowSet` drops its `.ToArray()` calls, and finally the old `byte[]` overloads are deleted.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
