### PR TITLE
bridge: implement `FFIGCHandle` - Rust-freeable GCHandle

### DIFF
--- a/rust/src/error_conversion.rs
+++ b/rust/src/error_conversion.rs
@@ -17,7 +17,7 @@ enum Exception {}
 
 /// A pointer to a C# Exception.
 /// This is used across the FFI boundary to represent exceptions created on the C# side.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 #[repr(transparent)]
 pub struct ExceptionPtr(NonNull<Exception>);
 
@@ -332,20 +332,20 @@ pub(crate) enum MaybeShutdownError<E> {
 /// that any pointers passed to the constructors are valid for the duration of the call.
 /// The handle must be freed on the C# side when no longer needed.
 pub trait ErrorToException {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr;
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr;
 }
 
 // This allows returning Infallible as an error type in functions that cannot fail.
 impl ErrorToException for std::convert::Infallible {
-    fn to_exception(&self, _ctors: &ExceptionConstructors) -> ExceptionPtr {
-        match *self {}
+    fn to_exception(self, _ctors: &ExceptionConstructors) -> ExceptionPtr {
+        match self {}
     }
 }
 
 // This allows returning ExceptionPtr directly as an error type in functions that already produce C# exceptions.
 impl ErrorToException for ExceptionPtr {
-    fn to_exception(&self, _ctors: &ExceptionConstructors) -> ExceptionPtr {
-        *self
+    fn to_exception(self, _ctors: &ExceptionConstructors) -> ExceptionPtr {
+        self
     }
 }
 
@@ -353,7 +353,7 @@ impl ErrorToException for ExceptionPtr {
 // For now it only maps specific connection-related error kinds (ConnectionRefused, TimedOut, NotConnected) to a C# NoHostAvailableException.
 // This mapping doesn't deny wildcard matches to ensure all other IO errors are still converted to Rust exceptions without needing to list them all.
 impl ErrorToException for Arc<std::io::Error> {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         match self.kind() {
             std::io::ErrorKind::ConnectionRefused
             | std::io::ErrorKind::TimedOut
@@ -361,7 +361,7 @@ impl ErrorToException for Arc<std::io::Error> {
                 .no_host_available_exception_constructor
                 .construct_from_rust(self.to_string().as_str()),
 
-            _ => ctors.rust_exception_constructor.construct_from_rust(self),
+            _ => ctors.rust_exception_constructor.construct_from_rust(&self),
         }
     }
 }
@@ -369,7 +369,7 @@ impl ErrorToException for Arc<std::io::Error> {
 // Specific mapping for PagerExecutionError.
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for PagerExecutionError {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         match self {
             PagerExecutionError::PrepareError(e) => e.to_exception(ctors),
 
@@ -380,12 +380,12 @@ impl ErrorToException for PagerExecutionError {
             PagerExecutionError::UseKeyspaceError(e) => e.to_exception(ctors),
 
             PagerExecutionError::SchemaAgreementError(_) => {
-                ctors.rust_exception_constructor.construct_from_rust(self)
+                ctors.rust_exception_constructor.construct_from_rust(&self)
             }
 
             PagerExecutionError::MetadataError(e) => e.to_exception(ctors),
 
-            _ => ctors.rust_exception_constructor.construct_from_rust(self),
+            _ => ctors.rust_exception_constructor.construct_from_rust(&self),
         }
     }
 }
@@ -393,17 +393,17 @@ impl ErrorToException for PagerExecutionError {
 // Specific mapping for NextPageError.
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for NextPageError {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         match self {
             NextPageError::RequestFailure(e) => e.to_exception(ctors),
 
             NextPageError::TypeCheckError(e) => e.to_exception(ctors),
 
             NextPageError::PartitionKeyError(_) | NextPageError::ResultMetadataParseError(_) => {
-                ctors.rust_exception_constructor.construct_from_rust(self)
+                ctors.rust_exception_constructor.construct_from_rust(&self)
             }
 
-            _ => ctors.rust_exception_constructor.construct_from_rust(self),
+            _ => ctors.rust_exception_constructor.construct_from_rust(&self),
         }
     }
 }
@@ -411,7 +411,7 @@ impl ErrorToException for NextPageError {
 // Specific mapping for RequestError.
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for RequestError {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         match self {
             RequestError::ConnectionPoolError(e) => e.to_exception(ctors),
 
@@ -421,9 +421,9 @@ impl ErrorToException for RequestError {
 
             RequestError::LastAttemptError(e) => e.to_exception(ctors),
 
-            RequestError::EmptyPlan => ctors.rust_exception_constructor.construct_from_rust(self),
+            RequestError::EmptyPlan => ctors.rust_exception_constructor.construct_from_rust(&self),
 
-            _ => ctors.rust_exception_constructor.construct_from_rust(self),
+            _ => ctors.rust_exception_constructor.construct_from_rust(&self),
         }
     }
 }
@@ -431,12 +431,12 @@ impl ErrorToException for RequestError {
 // Specific mapping for RequestAttemptError.
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for RequestAttemptError {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         match self {
             RequestAttemptError::SerializationError(e) => e.to_exception(ctors),
 
             RequestAttemptError::DbError(db_error, message) => {
-                (db_error, message.as_str()).to_exception(ctors)
+                (&db_error, message.as_str()).to_exception(ctors)
             }
 
             RequestAttemptError::CqlRequestSerialization(_)
@@ -449,10 +449,10 @@ impl ErrorToException for RequestAttemptError {
             | RequestAttemptError::RepreparedIdChanged { .. }
             | RequestAttemptError::RepreparedIdMissingInBatch
             | RequestAttemptError::NonfinishedPagingState => {
-                ctors.rust_exception_constructor.construct_from_rust(self)
+                ctors.rust_exception_constructor.construct_from_rust(&self)
             }
 
-            _ => ctors.rust_exception_constructor.construct_from_rust(self),
+            _ => ctors.rust_exception_constructor.construct_from_rust(&self),
         }
     }
 }
@@ -460,17 +460,17 @@ impl ErrorToException for RequestAttemptError {
 // Specific mapping for PrepareError
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for PrepareError {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         match self {
             PrepareError::ConnectionPoolError(e) => e.to_exception(ctors),
 
             PrepareError::AllAttemptsFailed { first_attempt } => first_attempt.to_exception(ctors),
 
             PrepareError::PreparedStatementIdsMismatch => {
-                ctors.rust_exception_constructor.construct_from_rust(self)
+                ctors.rust_exception_constructor.construct_from_rust(&self)
             }
 
-            _ => ctors.rust_exception_constructor.construct_from_rust(self),
+            _ => ctors.rust_exception_constructor.construct_from_rust(&self),
         }
     }
 }
@@ -478,7 +478,7 @@ impl ErrorToException for PrepareError {
 // Specific mapping for NewSessionError
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for NewSessionError {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         match self {
             NewSessionError::MetadataError(e) => e.to_exception(ctors),
 
@@ -486,17 +486,17 @@ impl ErrorToException for NewSessionError {
 
             NewSessionError::FailedToResolveAnyHostname(_)
             | NewSessionError::EmptyKnownNodesList => {
-                ctors.rust_exception_constructor.construct_from_rust(self)
+                ctors.rust_exception_constructor.construct_from_rust(&self)
             }
 
-            _ => ctors.rust_exception_constructor.construct_from_rust(self),
+            _ => ctors.rust_exception_constructor.construct_from_rust(&self),
         }
     }
 }
 
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for MetadataError {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         match self {
             MetadataError::ConnectionPoolError(e) => e.to_exception(ctors),
 
@@ -505,38 +505,38 @@ impl ErrorToException for MetadataError {
             | MetadataError::Keyspaces(_)
             | MetadataError::Udts(_)
             | MetadataError::Tables(_) => {
-                ctors.rust_exception_constructor.construct_from_rust(self)
+                ctors.rust_exception_constructor.construct_from_rust(&self)
             }
 
-            _ => ctors.rust_exception_constructor.construct_from_rust(self),
+            _ => ctors.rust_exception_constructor.construct_from_rust(&self),
         }
     }
 }
 
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for UseKeyspaceError {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         match self {
             UseKeyspaceError::BadKeyspaceName(e) => e.to_exception(ctors),
 
             UseKeyspaceError::RequestError(e) => e.to_exception(ctors),
 
             UseKeyspaceError::KeyspaceNameMismatch { .. } => {
-                ctors.rust_exception_constructor.construct_from_rust(self)
+                ctors.rust_exception_constructor.construct_from_rust(&self)
             }
 
             UseKeyspaceError::RequestTimeout(duration) => ctors
                 .operation_timed_out_exception_constructor
                 .construct_from_rust(duration.as_millis().clamp(0, i32::MAX as u128) as i32),
 
-            _ => ctors.rust_exception_constructor.construct_from_rust(self),
+            _ => ctors.rust_exception_constructor.construct_from_rust(&self),
         }
     }
 }
 
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for BadKeyspaceName {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         match self {
             // Rust considers an empty keyspace name invalid, but the C# wrapper should never allow this to be passed in.
             // (At least for the case of setting a keyspace on Connect().)
@@ -552,7 +552,7 @@ impl ErrorToException for BadKeyspaceName {
                 .invalid_query_constructor
                 .construct_from_rust(self.to_string().as_str()),
 
-            _ => ctors.rust_exception_constructor.construct_from_rust(self),
+            _ => ctors.rust_exception_constructor.construct_from_rust(&self),
         }
     }
 }
@@ -560,7 +560,7 @@ impl ErrorToException for BadKeyspaceName {
 // Tuple-based mapping to include the server-provided message alongside DbError
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for (&DbError, &str) {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         let (db_error, message) = self;
         match db_error {
             DbError::AlreadyExists { keyspace, table } => ctors
@@ -617,7 +617,7 @@ impl ErrorToException for (&DbError, &str) {
 
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for ConnectionPoolError {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         match self {
             ConnectionPoolError::Broken {
                 last_connection_error: ConnectionError::IoError(io_err),
@@ -632,29 +632,29 @@ impl ErrorToException for ConnectionPoolError {
             ConnectionPoolError::Broken { .. }
             | ConnectionPoolError::NodeDisabledByHostFilter
             | ConnectionPoolError::Initializing => {
-                ctors.rust_exception_constructor.construct_from_rust(self)
+                ctors.rust_exception_constructor.construct_from_rust(&self)
             }
 
-            _ => ctors.rust_exception_constructor.construct_from_rust(self),
+            _ => ctors.rust_exception_constructor.construct_from_rust(&self),
         }
     }
 }
 
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for NextRowError {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         match self {
             NextRowError::NextPageError(e) => e.to_exception(ctors),
 
             NextRowError::RowDeserializationError(e) => e.to_exception(ctors),
 
-            _ => ctors.rust_exception_constructor.construct_from_rust(self),
+            _ => ctors.rust_exception_constructor.construct_from_rust(&self),
         }
     }
 }
 
 impl ErrorToException for DeserializationError {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         ctors
             .deserialization_exception_constructor
             .construct_from_rust(&self.to_string())
@@ -662,7 +662,7 @@ impl ErrorToException for DeserializationError {
 }
 
 impl ErrorToException for SerializationError {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         ctors
             .serialization_exception_constructor
             .construct_from_rust(&self.to_string())
@@ -670,7 +670,7 @@ impl ErrorToException for SerializationError {
 }
 
 impl ErrorToException for TypeCheckError {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         ctors
             .invalid_type_exception_constructor
             .construct_from_rust(&self.to_string())
@@ -681,7 +681,7 @@ impl<E> ErrorToException for MaybeShutdownError<E>
 where
     E: ErrorToException,
 {
-    fn to_exception(&self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
         match self {
             MaybeShutdownError::Inner(e) => e.to_exception(ctors),
             MaybeShutdownError::AlreadyShutdown => ctors

--- a/rust/src/error_conversion.rs
+++ b/rust/src/error_conversion.rs
@@ -19,7 +19,7 @@ enum Exception {}
 /// This is used across the FFI boundary to represent exceptions created on the C# side.
 #[derive(Debug)]
 #[repr(transparent)]
-pub struct ExceptionPtr(NonNull<Exception>);
+pub struct FFIException(NonNull<Exception>);
 
 /// Wrapper struct for returning exceptions over FFI.
 ///
@@ -30,7 +30,7 @@ pub struct ExceptionPtr(NonNull<Exception>);
 #[repr(transparent)]
 #[must_use]
 pub struct FFIMaybeException {
-    pub exception: Option<ExceptionPtr>,
+    pub exception: Option<FFIException>,
 }
 
 // Compile-time assertion that `FFIMaybeException` is pointer-sized.
@@ -42,7 +42,7 @@ impl FFIMaybeException {
         Self { exception: None }
     }
 
-    pub(crate) fn from_exception(exception: ExceptionPtr) -> Self {
+    pub(crate) fn from_exception(exception: FFIException) -> Self {
         Self {
             exception: Some(exception),
         }
@@ -62,14 +62,14 @@ impl FFIMaybeException {
 }
 
 #[repr(transparent)]
-pub struct RustExceptionConstructor(unsafe extern "C" fn(message: FFIStr<'_>) -> ExceptionPtr);
+pub struct RustExceptionConstructor(unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException);
 
 impl RustExceptionConstructor {
     /// Creates a generic C# exception for unexpected Rust errors.
     ///
     /// Prefixes the message with "Rust exception:" and forwards it
     /// across the FFI boundary to construct the managed exception.
-    pub(crate) fn construct_from_rust(&self, err: impl Display) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, err: impl Display) -> FFIException {
         let message = format!("Rust exception: {}", err);
         let ffi_message = FFIStr::new(&message);
         unsafe { (self.0)(ffi_message) }
@@ -83,11 +83,11 @@ impl RustExceptionConstructor {
 /// FFI constructor for C# `FunctionFailureException`.
 #[repr(transparent)]
 pub struct FunctionFailureExceptionConstructor(
-    unsafe extern "C" fn(message: FFIStr<'_>) -> ExceptionPtr,
+    unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException,
 );
 
 impl FunctionFailureExceptionConstructor {
-    pub(crate) fn construct_from_rust(&self, message: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
         let message = FFIStr::new(message);
         unsafe { (self.0)(message) }
     }
@@ -96,11 +96,11 @@ impl FunctionFailureExceptionConstructor {
 /// FFI constructor for C# `InvalidConfigurationInQueryException`.
 #[repr(transparent)]
 pub struct InvalidConfigurationInQueryExceptionConstructor(
-    unsafe extern "C" fn(message: FFIStr) -> ExceptionPtr,
+    unsafe extern "C" fn(message: FFIStr) -> FFIException,
 );
 
 impl InvalidConfigurationInQueryExceptionConstructor {
-    pub(crate) fn construct_from_rust(&self, message: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
         let message = FFIStr::new(message);
         unsafe { (self.0)(message) }
     }
@@ -109,11 +109,11 @@ impl InvalidConfigurationInQueryExceptionConstructor {
 /// FFI constructor for C# `NoHostAvailableException`.
 #[repr(transparent)]
 pub struct NoHostAvailableExceptionConstructor(
-    unsafe extern "C" fn(message: FFIStr) -> ExceptionPtr,
+    unsafe extern "C" fn(message: FFIStr) -> FFIException,
 );
 
 impl NoHostAvailableExceptionConstructor {
-    pub(crate) fn construct_from_rust(&self, message: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
         let message = FFIStr::new(message);
         unsafe { (self.0)(message) }
     }
@@ -122,11 +122,11 @@ impl NoHostAvailableExceptionConstructor {
 /// FFI constructor for C# `OperationTimedOutException`.
 #[repr(transparent)]
 pub struct OperationTimedOutExceptionConstructor(
-    unsafe extern "C" fn(timeout_ms: i32) -> ExceptionPtr,
+    unsafe extern "C" fn(timeout_ms: i32) -> FFIException,
 );
 
 impl OperationTimedOutExceptionConstructor {
-    pub(crate) fn construct_from_rust(&self, timeout_ms: i32) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, timeout_ms: i32) -> FFIException {
         unsafe { (self.0)(timeout_ms) }
     }
 }
@@ -134,14 +134,14 @@ impl OperationTimedOutExceptionConstructor {
 /// FFI constructor for C# `PreparedQueryNotFoundException`.
 #[repr(transparent)]
 pub struct PreparedQueryNotFoundExceptionConstructor(
-    unsafe extern "C" fn(message: FFIStr<'_>, unknown_id: FFISlice<'_, u8>) -> ExceptionPtr,
+    unsafe extern "C" fn(message: FFIStr<'_>, unknown_id: FFISlice<'_, u8>) -> FFIException,
 );
 
 impl PreparedQueryNotFoundExceptionConstructor {
     /// Builds a `PreparedQueryNotFoundException` with message and statement id.
     ///
     /// `unknown_id` is the raw statement id bytes associated with the error.
-    pub(crate) fn construct_from_rust(&self, message: &str, unknown_id: &[u8]) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str, unknown_id: &[u8]) -> FFIException {
         let message = FFIStr::new(message);
         let unknown_id = FFISlice::new(unknown_id);
         unsafe { (self.0)(message, unknown_id) }
@@ -152,12 +152,12 @@ impl PreparedQueryNotFoundExceptionConstructor {
 /// FFI constructor for C# `RequestInvalidException` (currently unused).
 #[repr(transparent)]
 pub struct RequestInvalidExceptionConstructor(
-    unsafe extern "C" fn(message: FFIStr<'_>) -> ExceptionPtr,
+    unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException,
 );
 
 impl RequestInvalidExceptionConstructor {
     #[expect(dead_code)] // Currently unused
-    pub(crate) fn construct_from_rust(&self, message: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
         let message = FFIStr::new(message);
         unsafe { (self.0)(message) }
     }
@@ -166,11 +166,11 @@ impl RequestInvalidExceptionConstructor {
 /// FFI constructor for C# `AlreadyShutdownException`.
 #[repr(transparent)]
 pub struct AlreadyShutdownExceptionConstructor(
-    unsafe extern "C" fn(message: FFIStr<'_>) -> ExceptionPtr,
+    unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException,
 );
 
 impl AlreadyShutdownExceptionConstructor {
-    pub(crate) fn construct_from_rust(&self, message: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
         let message = FFIStr::new(message);
         unsafe { (self.0)(message) }
     }
@@ -179,11 +179,11 @@ impl AlreadyShutdownExceptionConstructor {
 /// FFI constructor for C# `SyntaxErrorException`.
 #[repr(transparent)]
 pub struct SyntaxErrorExceptionConstructor(
-    unsafe extern "C" fn(message: FFIStr<'_>) -> ExceptionPtr,
+    unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException,
 );
 
 impl SyntaxErrorExceptionConstructor {
-    pub(crate) fn construct_from_rust(&self, message: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
         let message = FFIStr::new(message);
         unsafe { (self.0)(message) }
     }
@@ -193,12 +193,12 @@ impl SyntaxErrorExceptionConstructor {
 /// FFI constructor for C# `TraceRetrievalException` (currently unused).
 #[repr(transparent)]
 pub struct TraceRetrievalExceptionConstructor(
-    unsafe extern "C" fn(message: FFIStr<'_>) -> ExceptionPtr,
+    unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException,
 );
 
 impl TraceRetrievalExceptionConstructor {
     #[expect(dead_code)] // Currently unused
-    pub(crate) fn construct_from_rust(&self, message: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
         let message = FFIStr::new(message);
         unsafe { (self.0)(message) }
     }
@@ -206,10 +206,10 @@ impl TraceRetrievalExceptionConstructor {
 
 /// FFI constructor for C# `TruncateException`.
 #[repr(transparent)]
-pub struct TruncateExceptionConstructor(unsafe extern "C" fn(message: FFIStr<'_>) -> ExceptionPtr);
+pub struct TruncateExceptionConstructor(unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException);
 
 impl TruncateExceptionConstructor {
-    pub(crate) fn construct_from_rust(&self, message: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
         let message = FFIStr::new(message);
         unsafe { (self.0)(message) }
     }
@@ -218,11 +218,11 @@ impl TruncateExceptionConstructor {
 /// FFI constructor for C# `UnauthorizedException`.
 #[repr(transparent)]
 pub struct UnauthorizedExceptionConstructor(
-    unsafe extern "C" fn(message: FFIStr<'_>) -> ExceptionPtr,
+    unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException,
 );
 
 impl UnauthorizedExceptionConstructor {
-    pub(crate) fn construct_from_rust(&self, message: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
         let message = FFIStr::new(message);
         unsafe { (self.0)(message) }
     }
@@ -231,12 +231,12 @@ impl UnauthorizedExceptionConstructor {
 /// FFI constructor for C# `AlreadyExistsException`.
 #[repr(transparent)]
 pub struct AlreadyExistsConstructor(
-    unsafe extern "C" fn(keyspace: FFIStr<'_>, table: FFIStr<'_>) -> ExceptionPtr,
+    unsafe extern "C" fn(keyspace: FFIStr<'_>, table: FFIStr<'_>) -> FFIException,
 );
 
 impl AlreadyExistsConstructor {
     /// Builds an `AlreadyExistsException` from keyspace and table names.
-    pub(crate) fn construct_from_rust(&self, keyspace: &str, table: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, keyspace: &str, table: &str) -> FFIException {
         let ks = FFIStr::new(keyspace);
         let tb = FFIStr::new(table);
         unsafe { (self.0)(ks, tb) }
@@ -246,11 +246,11 @@ impl AlreadyExistsConstructor {
 /// FFI constructor for C# `InvalidArgumentException`.
 #[repr(transparent)]
 pub struct InvalidArgumentExceptionConstructor(
-    unsafe extern "C" fn(message: FFIStr<'_>) -> ExceptionPtr,
+    unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException,
 );
 
 impl InvalidArgumentExceptionConstructor {
-    pub(crate) fn construct_from_rust(&self, message: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
         let message = FFIStr::new(message);
         unsafe { (self.0)(message) }
     }
@@ -258,10 +258,10 @@ impl InvalidArgumentExceptionConstructor {
 
 /// FFI constructor for C# `InvalidQueryException`.
 #[repr(transparent)]
-pub struct InvalidQueryConstructor(unsafe extern "C" fn(message: FFIStr<'_>) -> ExceptionPtr);
+pub struct InvalidQueryConstructor(unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException);
 
 impl InvalidQueryConstructor {
-    pub(crate) fn construct_from_rust(&self, message: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
         let message = FFIStr::new(message);
         unsafe { (self.0)(message) }
     }
@@ -269,11 +269,11 @@ impl InvalidQueryConstructor {
 
 /// FFI constructor for C# `InvalidTypeException`.
 pub struct InvalidTypeExceptionConstructor(
-    unsafe extern "C" fn(message: FFIStr<'_>) -> ExceptionPtr,
+    unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException,
 );
 
 impl InvalidTypeExceptionConstructor {
-    pub(crate) fn construct_from_rust(&self, message: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
         let message = FFIStr::new(message);
         unsafe { (self.0)(message) }
     }
@@ -281,11 +281,11 @@ impl InvalidTypeExceptionConstructor {
 
 /// FFI constructor for C# `SerializationException`.
 pub struct SerializationExceptionConstructor(
-    unsafe extern "C" fn(message: FFIStr<'_>) -> ExceptionPtr,
+    unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException,
 );
 
 impl SerializationExceptionConstructor {
-    pub(crate) fn construct_from_rust(&self, message: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
         let message = FFIStr::new(message);
         unsafe { (self.0)(message) }
     }
@@ -293,11 +293,11 @@ impl SerializationExceptionConstructor {
 
 /// FFI constructor for C# `DeserializationException`.
 pub struct DeserializationExceptionConstructor(
-    unsafe extern "C" fn(message: FFIStr<'_>) -> ExceptionPtr,
+    unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException,
 );
 
 impl DeserializationExceptionConstructor {
-    pub(crate) fn construct_from_rust(&self, message: &str) -> ExceptionPtr {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
         let message = FFIStr::new(message);
         unsafe { (self.0)(message) }
     }
@@ -328,23 +328,23 @@ pub(crate) enum MaybeShutdownError<E> {
 /// as exceptions in C#.
 ///
 /// # Safety
-/// The returned [`ExceptionPtr`] is an opaque handle pointer to a C# Exception object. Implementors must ensure
+/// The returned [`FFIException`] is an opaque handle pointer to a C# Exception object. Implementors must ensure
 /// that any pointers passed to the constructors are valid for the duration of the call.
 /// The handle must be freed on the C# side when no longer needed.
 pub trait ErrorToException {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr;
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException;
 }
 
 // This allows returning Infallible as an error type in functions that cannot fail.
 impl ErrorToException for std::convert::Infallible {
-    fn to_exception(self, _ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, _ctors: &ExceptionConstructors) -> FFIException {
         match self {}
     }
 }
 
-// This allows returning ExceptionPtr directly as an error type in functions that already produce C# exceptions.
-impl ErrorToException for ExceptionPtr {
-    fn to_exception(self, _ctors: &ExceptionConstructors) -> ExceptionPtr {
+// This allows returning FFIException directly as an error type in functions that already produce C# exceptions.
+impl ErrorToException for FFIException {
+    fn to_exception(self, _ctors: &ExceptionConstructors) -> FFIException {
         self
     }
 }
@@ -353,7 +353,7 @@ impl ErrorToException for ExceptionPtr {
 // For now it only maps specific connection-related error kinds (ConnectionRefused, TimedOut, NotConnected) to a C# NoHostAvailableException.
 // This mapping doesn't deny wildcard matches to ensure all other IO errors are still converted to Rust exceptions without needing to list them all.
 impl ErrorToException for Arc<std::io::Error> {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self.kind() {
             std::io::ErrorKind::ConnectionRefused
             | std::io::ErrorKind::TimedOut
@@ -369,7 +369,7 @@ impl ErrorToException for Arc<std::io::Error> {
 // Specific mapping for PagerExecutionError.
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for PagerExecutionError {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self {
             PagerExecutionError::PrepareError(e) => e.to_exception(ctors),
 
@@ -393,7 +393,7 @@ impl ErrorToException for PagerExecutionError {
 // Specific mapping for NextPageError.
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for NextPageError {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self {
             NextPageError::RequestFailure(e) => e.to_exception(ctors),
 
@@ -411,7 +411,7 @@ impl ErrorToException for NextPageError {
 // Specific mapping for RequestError.
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for RequestError {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self {
             RequestError::ConnectionPoolError(e) => e.to_exception(ctors),
 
@@ -431,7 +431,7 @@ impl ErrorToException for RequestError {
 // Specific mapping for RequestAttemptError.
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for RequestAttemptError {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self {
             RequestAttemptError::SerializationError(e) => e.to_exception(ctors),
 
@@ -460,7 +460,7 @@ impl ErrorToException for RequestAttemptError {
 // Specific mapping for PrepareError
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for PrepareError {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self {
             PrepareError::ConnectionPoolError(e) => e.to_exception(ctors),
 
@@ -478,7 +478,7 @@ impl ErrorToException for PrepareError {
 // Specific mapping for NewSessionError
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for NewSessionError {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self {
             NewSessionError::MetadataError(e) => e.to_exception(ctors),
 
@@ -496,7 +496,7 @@ impl ErrorToException for NewSessionError {
 
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for MetadataError {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self {
             MetadataError::ConnectionPoolError(e) => e.to_exception(ctors),
 
@@ -515,7 +515,7 @@ impl ErrorToException for MetadataError {
 
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for UseKeyspaceError {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self {
             UseKeyspaceError::BadKeyspaceName(e) => e.to_exception(ctors),
 
@@ -536,7 +536,7 @@ impl ErrorToException for UseKeyspaceError {
 
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for BadKeyspaceName {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self {
             // Rust considers an empty keyspace name invalid, but the C# wrapper should never allow this to be passed in.
             // (At least for the case of setting a keyspace on Connect().)
@@ -560,7 +560,7 @@ impl ErrorToException for BadKeyspaceName {
 // Tuple-based mapping to include the server-provided message alongside DbError
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for (&DbError, &str) {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         let (db_error, message) = self;
         match db_error {
             DbError::AlreadyExists { keyspace, table } => ctors
@@ -617,7 +617,7 @@ impl ErrorToException for (&DbError, &str) {
 
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for ConnectionPoolError {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self {
             ConnectionPoolError::Broken {
                 last_connection_error: ConnectionError::IoError(io_err),
@@ -642,7 +642,7 @@ impl ErrorToException for ConnectionPoolError {
 
 #[deny(clippy::wildcard_enum_match_arm)]
 impl ErrorToException for NextRowError {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self {
             NextRowError::NextPageError(e) => e.to_exception(ctors),
 
@@ -654,7 +654,7 @@ impl ErrorToException for NextRowError {
 }
 
 impl ErrorToException for DeserializationError {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         ctors
             .deserialization_exception_constructor
             .construct_from_rust(&self.to_string())
@@ -662,7 +662,7 @@ impl ErrorToException for DeserializationError {
 }
 
 impl ErrorToException for SerializationError {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         ctors
             .serialization_exception_constructor
             .construct_from_rust(&self.to_string())
@@ -670,7 +670,7 @@ impl ErrorToException for SerializationError {
 }
 
 impl ErrorToException for TypeCheckError {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         ctors
             .invalid_type_exception_constructor
             .construct_from_rust(&self.to_string())
@@ -681,7 +681,7 @@ impl<E> ErrorToException for MaybeShutdownError<E>
 where
     E: ErrorToException,
 {
-    fn to_exception(self, ctors: &ExceptionConstructors) -> ExceptionPtr {
+    fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self {
             MaybeShutdownError::Inner(e) => e.to_exception(ctors),
             MaybeShutdownError::AlreadyShutdown => ctors

--- a/rust/src/error_conversion.rs
+++ b/rust/src/error_conversion.rs
@@ -29,15 +29,15 @@ pub struct ExceptionPtr(NonNull<Exception>);
 /// All changes to this struct must be mirrored in C# code in the exact same order.
 #[repr(transparent)]
 #[must_use]
-pub struct FFIException {
+pub struct FFIMaybeException {
     pub exception: Option<ExceptionPtr>,
 }
 
-// Compile-time assertion that `FFIException` is pointer-sized.
+// Compile-time assertion that `FFIMaybeException` is pointer-sized.
 // Ensures ABI compatibility with C# (opaque GCHandle/IntPtr across FFI).
-const _: [(); size_of::<FFIException>()] = [(); size_of::<*const ()>()];
+const _: [(); size_of::<FFIMaybeException>()] = [(); size_of::<*const ()>()];
 
-impl FFIException {
+impl FFIMaybeException {
     pub(crate) fn ok() -> Self {
         Self { exception: None }
     }

--- a/rust/src/error_conversion.rs
+++ b/rust/src/error_conversion.rs
@@ -58,6 +58,11 @@ impl FFIMaybeException {
     pub(crate) fn has_exception(&self) -> bool {
         !self.0.is_empty()
     }
+
+    #[expect(dead_code)] // Will be used in a follow-up PR.
+    pub(crate) fn try_into_ffi_exception(self) -> Option<FFIException> {
+        self.0.try_into_ffi_gc_handle().map(FFIException)
+    }
 }
 
 #[repr(transparent)]

--- a/rust/src/error_conversion.rs
+++ b/rust/src/error_conversion.rs
@@ -1,4 +1,4 @@
-use crate::ffi::{FFISlice, FFIStr};
+use crate::ffi::{FFIGCHandle, FFIMaybeGCHandle, FFISlice, FFIStr};
 use scylla::errors::{
     BadKeyspaceName, ConnectionError, ConnectionPoolError, DbError, DeserializationError,
     MetadataError, NewSessionError, NextPageError, NextRowError, PagerExecutionError, PrepareError,
@@ -6,7 +6,6 @@ use scylla::errors::{
 };
 use std::fmt::{Debug, Display};
 use std::mem::size_of;
-use std::ptr::NonNull;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -15,11 +14,15 @@ use crate::task::ExceptionConstructors;
 // Opaque type representing a C# Exception.
 enum Exception {}
 
-/// A pointer to a C# Exception.
+/// A GCHandle'd C# Exception.
 /// This is used across the FFI boundary to represent exceptions created on the C# side.
 #[derive(Debug)]
 #[repr(transparent)]
-pub struct FFIException(NonNull<Exception>);
+pub struct FFIException(FFIGCHandle<Exception>);
+
+// Compile-time assertion that `FFI` is double-pointer-sized.
+// Ensures ABI compatibility with C# (opaque FFIGCHandle across FFI).
+const _: [(); size_of::<FFIException>()] = [(); size_of::<(*const (), *const ())>()];
 
 /// Wrapper struct for returning exceptions over FFI.
 ///
@@ -29,23 +32,19 @@ pub struct FFIException(NonNull<Exception>);
 /// All changes to this struct must be mirrored in C# code in the exact same order.
 #[repr(transparent)]
 #[must_use]
-pub struct FFIMaybeException {
-    pub exception: Option<FFIException>,
-}
+pub struct FFIMaybeException(FFIMaybeGCHandle<Exception>);
 
-// Compile-time assertion that `FFIMaybeException` is pointer-sized.
-// Ensures ABI compatibility with C# (opaque GCHandle/IntPtr across FFI).
-const _: [(); size_of::<FFIMaybeException>()] = [(); size_of::<*const ()>()];
+// Compile-time assertion that `FFIMaybeException` is double-pointer-sized.
+// Ensures ABI compatibility with C# (opaque FFIMaybeGCHandle across FFI).
+const _: [(); size_of::<FFIMaybeException>()] = [(); size_of::<(*const (), *const ())>()];
 
 impl FFIMaybeException {
     pub(crate) fn ok() -> Self {
-        Self { exception: None }
+        Self(FFIMaybeGCHandle::empty())
     }
 
     pub(crate) fn from_exception(exception: FFIException) -> Self {
-        Self {
-            exception: Some(exception),
-        }
+        Self(exception.0.into_ffi_maybe_gc_handle())
     }
 
     pub(crate) fn from_error<E>(error: E, constructors: &ExceptionConstructors) -> Self
@@ -57,7 +56,7 @@ impl FFIMaybeException {
     }
 
     pub(crate) fn has_exception(&self) -> bool {
-        self.exception.is_some()
+        !self.0.is_empty()
     }
 }
 

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -970,6 +970,23 @@ impl<T> FFIMaybeGCHandle<T> {
             .as_ref()
             .map(|&GCHandlePtr(ptr)| GCHandlePtr(ptr))
     }
+
+    pub(crate) fn try_into_ffi_gc_handle(self) -> Option<FFIGCHandle<T>> {
+        // We perform a move wrt ownership: RustFreeableHandle now owns the gchandle, not we.
+        let (Some(gchandle), Some(free)) = (&self.gchandle, self.free) else {
+            return None;
+        };
+
+        let ret = FFIGCHandle {
+            gchandle: GCHandlePtr(gchandle.0),
+            free,
+        };
+
+        // This is crucial: we must prevent freeing the GCHandle here.
+        std::mem::forget(self);
+
+        Some(ret)
+    }
 }
 
 impl<T> Debug for FFIMaybeGCHandle<T> {

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -1,4 +1,4 @@
-use crate::error_conversion::FFIException;
+use crate::error_conversion::FFIMaybeException;
 use std::ffi::{CStr, c_char, c_void};
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -847,7 +847,7 @@ enum CSharpManagedString {}
 pub(crate) struct CSharpManagedStringPtr(FFIPtr<'static, CSharpManagedString>);
 
 pub(crate) type WriteStringCallback =
-    extern "C" fn(FFIStr<'_>, CSharpManagedStringPtr) -> FFIException;
+    extern "C" fn(FFIStr<'_>, CSharpManagedStringPtr) -> FFIMaybeException;
 
 /// Feeds each item from an iterator to a C FFI callback, one at a time.
 ///
@@ -859,9 +859,9 @@ pub(crate) type WriteStringCallback =
 /// - `context` must remain valid for the duration of iteration
 pub(crate) unsafe fn ffi_callback_for_each<Ctx: Copy, T>(
     context: Ctx,
-    callback: unsafe extern "C" fn(Ctx, T) -> FFIException,
+    callback: unsafe extern "C" fn(Ctx, T) -> FFIMaybeException,
     iter: impl Iterator<Item = T>,
-) -> FFIException {
+) -> FFIMaybeException {
     for item in iter {
         unsafe {
             let res = callback(context, item);
@@ -870,7 +870,7 @@ pub(crate) unsafe fn ffi_callback_for_each<Ctx: Copy, T>(
             }
         }
     }
-    FFIException::ok()
+    FFIMaybeException::ok()
 }
 
 #[repr(transparent)]

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -872,3 +872,124 @@ pub(crate) unsafe fn ffi_callback_for_each<Ctx: Copy, T>(
     }
     FFIException::ok()
 }
+
+#[repr(transparent)]
+pub(crate) struct GCHandlePtr<'a, T>(FFINonNullPtr<'a, T>);
+
+impl<'a, T> Debug for GCHandlePtr<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+unsafe impl<T> Send for GCHandlePtr<'_, T> {}
+
+// Compile-time assertion that `GCHandlePtr` is pointer-sized.
+// Ensures ABI compatibility with C#.
+const _: [(); std::mem::size_of::<GCHandlePtr<'_, ()>>()] = [(); std::mem::size_of::<*const ()>()];
+
+/// A pointer to GCHandle owned by Rust, together with the destructor.
+/// This is useful to ensure that GCHandle is freed when Rust-side
+/// object is dropped. Mainly employable in async scenarios.
+#[repr(C)]
+pub struct FFIGCHandle<T> {
+    gchandle: GCHandlePtr<'static, T>,
+    free: unsafe extern "C" fn(GCHandlePtr<T>),
+}
+
+impl<T> FFIGCHandle<T> {
+    /// Borrows the GCHandle, for use by C#.
+    /// Borrow checker prevents use-after-free, ensuring that FFIGCHandle
+    /// is kept alive.
+    #[expect(dead_code)] // Will be used soon.
+    pub(crate) fn borrow<'gc>(&'gc self) -> GCHandlePtr<'gc, T> {
+        GCHandlePtr(self.gchandle.0)
+    }
+
+    pub(crate) fn into_ffi_maybe_gc_handle(self) -> FFIMaybeGCHandle<T> {
+        // We perform a move wrt ownership: MaybeRustFreeableHandle now owns the gchandle, not we.
+        let ret = FFIMaybeGCHandle {
+            gchandle: Some(GCHandlePtr(self.gchandle.0)),
+            free: Some(self.free),
+        };
+
+        // This is crucial: we must prevent freeing the GCHandle here.
+        std::mem::forget(self);
+
+        ret
+    }
+}
+
+impl<T> Debug for FFIGCHandle<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FFIGCHandle")
+            .field("gchandle", &self.gchandle)
+            .field("free", &self.free)
+            .finish()
+    }
+}
+
+impl<T> Drop for FFIGCHandle<T> {
+    fn drop(&mut self) {
+        unsafe {
+            // SAFETY: free function is provided by the user of the struct.
+            // The GCHandlePtr is "cloned" manually here, because it purposely does not
+            // implement Clone to avoid accidental double-free, as well as accidental UAF.
+            (self.free)(GCHandlePtr(self.gchandle.0));
+        }
+    }
+}
+
+/// An **optional** pointer to GCHandle owned by Rust, together with the destructor.
+/// This is useful to ensure that GCHandle is freed when Rust-side
+/// object is dropped. Mainly employable in async scenarios.
+#[repr(C)]
+pub struct FFIMaybeGCHandle<T> {
+    gchandle: Option<GCHandlePtr<'static, T>>,
+    free: Option<unsafe extern "C" fn(GCHandlePtr<T>)>,
+}
+
+impl<T> FFIMaybeGCHandle<T> {
+    pub(crate) fn empty() -> Self {
+        Self {
+            gchandle: None,
+            free: None,
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.gchandle.is_none()
+    }
+
+    /// Borrows the GCHandle, for use by C#.
+    /// Borrow checker prevents use-after-free, ensuring that FFIGCHandle
+    /// is kept alive.
+    #[expect(dead_code)] // Will be used soon.
+    pub(crate) fn borrow<'gc>(&'gc self) -> Option<GCHandlePtr<'gc, T>> {
+        self.gchandle
+            .as_ref()
+            .map(|&GCHandlePtr(ptr)| GCHandlePtr(ptr))
+    }
+}
+
+impl<T> Debug for FFIMaybeGCHandle<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FFIMaybeGCHandle")
+            .field("gchandle", &self.gchandle)
+            .field("free", &self.free)
+            .finish()
+    }
+}
+
+impl<T> Drop for FFIMaybeGCHandle<T> {
+    fn drop(&mut self) {
+        if let (Some(gchandle), Some(free)) = (&self.gchandle, self.free) {
+            // SAFETY: free function is provided by the user of the struct.
+            // The GCHandlePtr is "cloned" manually here, because it purposely does not
+            // implement Clone to avoid accidental double-free, as well as accidental UAF.
+            unsafe {
+                (free)(GCHandlePtr(gchandle.0));
+            }
+        }
+    }
+}

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -1,4 +1,4 @@
-use crate::error_conversion::FFIException;
+use crate::error_conversion::FFIMaybeException;
 use crate::ffi::{
     ArcFFI, BridgedBorrowedSharedPtr, CSharpStr, FFI, FFIBool, FFIPtr, FFISlice, FFIStr, FromArc,
     RefFFI, ffi_callback_for_each,
@@ -56,7 +56,7 @@ pub extern "C" fn cluster_state_fill_nodes(
     cluster_state_ptr: BridgedBorrowedSharedPtr<'_, ClusterState>,
     refresh_context_ptr: RefreshContextPtr,
     callback: ConstructCSharpHost,
-) -> FFIException {
+) -> FFIMaybeException {
     let cluster_state =
         ArcFFI::as_ref(cluster_state_ptr).expect("valid and non-null ClusterState pointer");
 
@@ -115,7 +115,7 @@ pub extern "C" fn cluster_state_fill_nodes(
         }
     }
 
-    FFIException::ok()
+    FFIMaybeException::ok()
 }
 
 /// Opaque type representing the C# KeyspaceNameList.
@@ -136,7 +136,7 @@ pub struct KeyspaceNameListPtr(FFIPtr<'static, KeyspaceNameList>);
 type AddKeyspaceName = unsafe extern "C" fn(
     keyspace_name_list_ptr: KeyspaceNameListPtr,
     keyspace_name: FFIStr<'_>,
-) -> FFIException;
+) -> FFIMaybeException;
 
 /// Populates a C# List with keyspace names from the cluster state. For each keyspace in the cluster state,
 /// this function invokes the callback with a single keyspace name. The callback must synchronously copy
@@ -146,13 +146,13 @@ type AddKeyspaceName = unsafe extern "C" fn(
 /// - `keyspace_name_list_ptr` must point to a valid C# List that remains allocated during this call
 /// - All string pointers passed to the callback are temporary and only valid during that invocation
 /// - The callback must copy string data of keyspace names (e.g., via Marshal.PtrToStringUTF8) immediately.
-/// - The callback must return a valid FFIException.
+/// - The callback must return a valid FFIMaybeException.
 #[unsafe(no_mangle)]
 pub extern "C" fn cluster_state_get_keyspace_names(
     cluster_state_ptr: BridgedBorrowedSharedPtr<'_, ClusterState>,
     keyspace_name_list_ptr: KeyspaceNameListPtr,
     add_keyspace_name_callback: AddKeyspaceName,
-) -> FFIException {
+) -> FFIMaybeException {
     tracing::trace!("[FFI] cluster_state_get_keyspace_names called");
 
     let cluster_state =
@@ -171,7 +171,7 @@ pub extern "C" fn cluster_state_get_keyspace_names(
         }
     }
 
-    FFIException::ok()
+    FFIMaybeException::ok()
 }
 
 /// Opaque type representing the C# KeyspaceContext.
@@ -193,19 +193,19 @@ pub struct ReplicationOptionsPtr(FFIPtr<'static, ReplicationOptions>);
 type SimpleStrategyAddRepFactor = unsafe extern "C" fn(
     replication_options_ptr: ReplicationOptionsPtr,
     rep_factor: usize,
-) -> FFIException;
+) -> FFIMaybeException;
 
 type NetworkTopologyStrategyAddRepFactor = unsafe extern "C" fn(
     replication_options_ptr: ReplicationOptionsPtr,
     datacenter: FFIStr<'_>,
     rep_factor: usize,
-) -> FFIException;
+) -> FFIMaybeException;
 
 type OtherStrategyAddRepFactor = unsafe extern "C" fn(
     replication_options_ptr: ReplicationOptionsPtr,
     key: FFIStr<'_>,
     value: FFIStr<'_>,
-) -> FFIException;
+) -> FFIMaybeException;
 
 // Replication factor callbacks grouped into a single struct to simplify passing them to the keyspace metadata construction function.
 #[repr(C)]
@@ -224,13 +224,13 @@ pub struct StrategyAddRepFactor {
 /// - All pointer parameters must be immediately copied/consumed during the callback invocation.
 /// - String pointers (strategy_class, key-value pairs) are only valid for the duration of the callback.
 /// - The callback must not store these pointers or access them after returning.
-/// - The callback must return a valid FFIException.
+/// - The callback must return a valid FFIMaybeException.
 type ConstructCSharpKeyspaceMetadata = unsafe extern "C" fn(
     keyspace_context_ptr: KeyspaceContextPtr,
     durable_writes: bool,
     strategy_class: FFIStr<'_>,
     replication_options_ptr: ReplicationOptionsPtr,
-) -> FFIException;
+) -> FFIMaybeException;
 
 /// Populates a C# KeyspaceContext with keyspace metadata from the cluster state.
 /// For the specified keyspace in the cluster state, this function:
@@ -242,7 +242,7 @@ type ConstructCSharpKeyspaceMetadata = unsafe extern "C" fn(
 /// - `keyspace_context_ptr` and `replication_options_ptr` must point to valid C# KeyspaceContext and ReplicationOptions that remain allocated during this call.
 /// - All string pointers passed to the callback are temporary and only valid during that invocation.
 /// - The callback must copy string data (e.g., via Marshal.PtrToStringUTF8) immediately.
-/// - The callback must return a valid FFIException.
+/// - The callback must return a valid FFIMaybeException.
 #[unsafe(no_mangle)]
 pub extern "C" fn cluster_state_get_keyspace_metadata(
     cluster_state_ptr: BridgedBorrowedSharedPtr<'_, ClusterState>,
@@ -252,7 +252,7 @@ pub extern "C" fn cluster_state_get_keyspace_metadata(
     add_rep_factor_callback: StrategyAddRepFactor,
     construct_keyspace_callback: ConstructCSharpKeyspaceMetadata,
     constructors: &'static ExceptionConstructors,
-) -> FFIException {
+) -> FFIMaybeException {
     tracing::trace!("[FFI] cluster_state_get_keyspace_metadata");
 
     let cluster_state =
@@ -269,7 +269,7 @@ pub extern "C" fn cluster_state_get_keyspace_metadata(
         let ex = constructors
             .invalid_argument_exception_constructor
             .construct_from_rust("Keyspace not found in cluster metadata");
-        return FFIException::from_exception(ex);
+        return FFIMaybeException::from_exception(ex);
     };
 
     tracing::trace!("[FFI] Found keyspace: '{}'", keyspace_name);
@@ -368,7 +368,7 @@ pub struct TableNameListPtr(FFIPtr<'static, TableNameList>);
 type AddTableName = unsafe extern "C" fn(
     table_name_list_ptr: TableNameListPtr,
     table_name: FFIStr<'_>,
-) -> FFIException;
+) -> FFIMaybeException;
 
 /// Populates a C# List with table names from the cluster state. For each table in the cluster state,
 /// this function invokes the callback with a single table name. The callback must synchronously copy
@@ -378,7 +378,7 @@ type AddTableName = unsafe extern "C" fn(
 /// - `table_name_list_ptr` must point to a valid C# List that remains allocated during this call.
 /// - All string pointers passed to the callback are temporary and only valid during that invocation.
 /// - The callback must copy string data of table names (e.g., via Marshal.PtrToStringUTF8) immediately.
-/// - The callback must return a valid FFIException.
+/// - The callback must return a valid FFIMaybeException.
 #[unsafe(no_mangle)]
 pub extern "C" fn cluster_state_get_table_names(
     cluster_state_ptr: BridgedBorrowedSharedPtr<'_, ClusterState>,
@@ -386,7 +386,7 @@ pub extern "C" fn cluster_state_get_table_names(
     table_name_list_ptr: TableNameListPtr,
     callback: AddTableName,
     constructors: &'static ExceptionConstructors,
-) -> FFIException {
+) -> FFIMaybeException {
     let cluster_state =
         ArcFFI::as_ref(cluster_state_ptr).expect("valid and non-null ClusterState pointer");
 
@@ -401,7 +401,7 @@ pub extern "C" fn cluster_state_get_table_names(
         let ex = constructors
             .invalid_argument_exception_constructor
             .construct_from_rust("Keyspace not found in cluster metadata");
-        return FFIException::from_exception(ex);
+        return FFIMaybeException::from_exception(ex);
     };
 
     unsafe {
@@ -426,7 +426,7 @@ type ConstructCSharpTableColumn = unsafe extern "C" fn(
     type_info: BridgedBorrowedSharedPtr<'_, ColumnType<'_>>,
     is_static: FFIBool,
     is_frozen: FFIBool,
-) -> FFIException;
+) -> FFIMaybeException;
 
 /// Opaque type representing the C# primary keys (PartitionKey or ClusteringKey).
 enum PrimaryKey {}
@@ -439,8 +439,10 @@ pub struct PrimaryKeysPtr(FFIPtr<'static, PrimaryKey>);
 /// Callback type for adding a single primary key column name to a C# PartitionKeys / ClusteringKeys.
 /// The callback receives a primary key name and is responsible for adding it to
 /// the C# PartitionKeys / ClusteringKeys referenced by primary_keys_ptr.
-type AddPrimaryKey =
-    unsafe extern "C" fn(primary_keys_ptr: PrimaryKeysPtr, primary_key: FFIStr<'_>) -> FFIException;
+type AddPrimaryKey = unsafe extern "C" fn(
+    primary_keys_ptr: PrimaryKeysPtr,
+    primary_key: FFIStr<'_>,
+) -> FFIMaybeException;
 
 /// Opaque type representing the C# TableContext.
 #[derive(Clone, Copy)]
@@ -456,7 +458,7 @@ type ConstructCSharpTableMetadata = unsafe extern "C" fn(
     table_columns_ptr: TableColumnsPtr,
     partition_keys: PrimaryKeysPtr,
     clustering_keys: PrimaryKeysPtr,
-) -> FFIException;
+) -> FFIMaybeException;
 
 /// Retrieves metadata for a single table and exposes it to C# via callbacks.
 ///
@@ -494,7 +496,7 @@ pub extern "C" fn cluster_state_get_table_metadata(
     table_context_ptr: TableContextPtr,
     construct_table_metadata: ConstructCSharpTableMetadata,
     constructors: &'static ExceptionConstructors,
-) -> FFIException {
+) -> FFIMaybeException {
     tracing::trace!("[FFI] cluster_state_get_table_metadata called");
 
     let cluster_state =
@@ -511,7 +513,7 @@ pub extern "C" fn cluster_state_get_table_metadata(
         let ex = constructors
             .invalid_argument_exception_constructor
             .construct_from_rust("Keyspace not found in cluster metadata");
-        return FFIException::from_exception(ex);
+        return FFIMaybeException::from_exception(ex);
     };
 
     let table_name = table_name
@@ -525,7 +527,7 @@ pub extern "C" fn cluster_state_get_table_metadata(
         let ex = constructors
             .invalid_argument_exception_constructor
             .construct_from_rust("Table not found in keyspace metadata");
-        return FFIException::from_exception(ex);
+        return FFIMaybeException::from_exception(ex);
     };
 
     for (column_name, column) in table.columns.iter() {
@@ -620,5 +622,5 @@ pub extern "C" fn cluster_state_get_table_metadata(
         }
     }
 
-    FFIException::ok()
+    FFIMaybeException::ok()
 }

--- a/rust/src/pre_serialized_values.rs
+++ b/rust/src/pre_serialized_values.rs
@@ -1,4 +1,4 @@
-use crate::error_conversion::FFIException;
+use crate::error_conversion::FFIMaybeException;
 use crate::ffi::{
     BoxFFI, BridgedBorrowedExclusivePtr, BridgedOwnedExclusivePtr, FFI, FFISlice, FromBox,
 };
@@ -99,13 +99,13 @@ pub unsafe extern "C" fn pre_serialized_values_add_value(
     values_ptr: BridgedBorrowedExclusivePtr<'_, PreSerializedValues>,
     value: FFISlice<'_, u8>,
     constructors: &'static ExceptionConstructors,
-) -> FFIException {
+) -> FFIMaybeException {
     let Some(values) = BoxFFI::as_mut_ref(values_ptr) else {
         panic!("invalid PreSerializedValues pointer in pre_serialized_values_add_value");
     };
     match values.add_value(value) {
-        Ok(()) => FFIException::ok(),
-        Err(e) => FFIException::from_error(e, constructors),
+        Ok(()) => FFIMaybeException::ok(),
+        Err(e) => FFIMaybeException::from_error(e, constructors),
     }
 }
 
@@ -114,13 +114,13 @@ pub unsafe extern "C" fn pre_serialized_values_add_value(
 pub extern "C" fn pre_serialized_values_add_null(
     values_ptr: BridgedBorrowedExclusivePtr<'_, PreSerializedValues>,
     constructors: &'static ExceptionConstructors,
-) -> FFIException {
+) -> FFIMaybeException {
     let Some(values) = BoxFFI::as_mut_ref(values_ptr) else {
         panic!("invalid PreSerializedValues pointer in pre_serialized_values_add_null");
     };
     match values.add_null() {
-        Ok(()) => FFIException::ok(),
-        Err(e) => FFIException::from_error(e, constructors),
+        Ok(()) => FFIMaybeException::ok(),
+        Err(e) => FFIMaybeException::from_error(e, constructors),
     }
 }
 
@@ -129,13 +129,13 @@ pub extern "C" fn pre_serialized_values_add_null(
 pub extern "C" fn pre_serialized_values_add_unset(
     values_ptr: BridgedBorrowedExclusivePtr<'_, PreSerializedValues>,
     constructors: &'static ExceptionConstructors,
-) -> FFIException {
+) -> FFIMaybeException {
     let Some(values) = BoxFFI::as_mut_ref(values_ptr) else {
         panic!("invalid PreSerializedValues pointer in pre_serialized_values_add_unset");
     };
     match values.add_unset() {
-        Ok(()) => FFIException::ok(),
-        Err(e) => FFIException::from_error(e, constructors),
+        Ok(()) => FFIMaybeException::ok(),
+        Err(e) => FFIMaybeException::from_error(e, constructors),
     }
 }
 

--- a/rust/src/prepared_statement.rs
+++ b/rust/src/prepared_statement.rs
@@ -1,4 +1,4 @@
-use crate::error_conversion::FFIException;
+use crate::error_conversion::FFIMaybeException;
 use crate::ffi::{ArcFFI, BridgedBorrowedSharedPtr, FFI, FFIPtr, FFIStr, FromArc, RefFFI};
 use crate::row_set::column_type_to_code;
 use scylla::frame::response::result::ColumnType;
@@ -17,14 +17,14 @@ impl FFI for BridgedPreparedStatement {
 pub extern "C" fn prepared_statement_is_lwt(
     prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
     is_lwt: *mut bool,
-) -> FFIException {
+) -> FFIMaybeException {
     unsafe {
         *is_lwt = ArcFFI::as_ref(prepared_statement_ptr)
             .unwrap()
             .inner
             .is_confirmed_lwt();
     }
-    FFIException::ok()
+    FFIMaybeException::ok()
 }
 
 /// Gets the number of variable column specifications in the prepared statement.
@@ -32,14 +32,14 @@ pub extern "C" fn prepared_statement_is_lwt(
 pub extern "C" fn prepared_statement_get_variables_column_specs_count(
     prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
     out_num_fields: *mut usize,
-) -> FFIException {
+) -> FFIMaybeException {
     let prepared_statement = ArcFFI::as_ref(prepared_statement_ptr).unwrap();
 
     unsafe {
         *out_num_fields = prepared_statement.inner.get_variable_col_specs().len();
     }
 
-    FFIException::ok()
+    FFIMaybeException::ok()
 }
 
 #[derive(Clone, Copy)]
@@ -59,7 +59,7 @@ type SetPreparedStatementVariablesMetadata = unsafe extern "C" fn(
     type_code: u8,
     type_info_handle: BridgedBorrowedSharedPtr<'_, ColumnType<'_>>,
     is_frozen: u8,
-) -> FFIException;
+) -> FFIMaybeException;
 
 /// Calls back into C# for each column to provide column specs metadata.
 /// `metadata_setter` is a function pointer supplied by C# - it will be called synchronously for each column.
@@ -71,7 +71,7 @@ pub extern "C" fn prepared_statement_fill_column_specs_metadata(
     prepared_statement_ptr: BridgedBorrowedSharedPtr<'_, BridgedPreparedStatement>,
     columns_ptr: ColumnsPtr,
     set_prepared_statement_variables_metadata: SetPreparedStatementVariablesMetadata,
-) -> FFIException {
+) -> FFIMaybeException {
     let prepared_statement = ArcFFI::as_ref(prepared_statement_ptr).unwrap();
 
     // Iterate column specs and call the metadata setter
@@ -118,5 +118,5 @@ pub extern "C" fn prepared_statement_fill_column_specs_metadata(
             }
         }
     }
-    FFIException::ok()
+    FFIMaybeException::ok()
 }

--- a/rust/src/row_set.rs
+++ b/rust/src/row_set.rs
@@ -2,7 +2,7 @@ use scylla::client::pager::QueryPager;
 use scylla::cluster::metadata::CollectionType;
 use scylla::frame::response::result::{ColumnType, NativeType};
 
-use crate::error_conversion::FFIException;
+use crate::error_conversion::FFIMaybeException;
 use crate::ffi::{
     ArcFFI, BridgedBorrowedSharedPtr, FFI, FFIPtr, FFISlice, FFIStr, FromArc, FromRef, RefFFI,
 };
@@ -37,13 +37,13 @@ impl FFI for ColumnType<'_> {
 pub extern "C" fn row_set_get_columns_count(
     row_set_ptr: BridgedBorrowedSharedPtr<'_, RowSet>,
     out_num_fields: *mut usize,
-) -> FFIException {
+) -> FFIMaybeException {
     let row_set = ArcFFI::as_ref(row_set_ptr).unwrap();
     let pager = row_set.pager.lock().unwrap();
     unsafe {
         *out_num_fields = pager.column_specs().len();
     }
-    FFIException::ok()
+    FFIMaybeException::ok()
 }
 
 // Function pointer type for setting column metadata in C#.
@@ -56,7 +56,7 @@ type SetMetadata = unsafe extern "C" fn(
     type_code: u8,
     type_info_handle: BridgedBorrowedSharedPtr<'_, ColumnType<'_>>,
     is_frozen: u8,
-) -> FFIException;
+) -> FFIMaybeException;
 
 /// Calls back into C# for each column to provide metadata.
 /// `metadata_setter` is a function pointer supplied by C# - it will be called synchronously for each column.
@@ -68,7 +68,7 @@ pub extern "C" fn row_set_fill_columns_metadata(
     row_set_ptr: BridgedBorrowedSharedPtr<'_, RowSet>,
     columns_ptr: ColumnsPtr,
     set_metadata: SetMetadata,
-) -> FFIException {
+) -> FFIMaybeException {
     let row_set = ArcFFI::as_ref(row_set_ptr).unwrap();
     let pager = row_set.pager.lock().unwrap();
 
@@ -110,7 +110,7 @@ pub extern "C" fn row_set_fill_columns_metadata(
             }
         }
     }
-    FFIException::ok()
+    FFIMaybeException::ok()
 }
 
 enum Columns {}
@@ -137,7 +137,7 @@ type DeserializeValue = unsafe extern "C" fn(
     value_index: usize,
     serializer_ptr: SerializerPtr,
     frame_slice: FFISlice<'_, u8>,
-) -> FFIException;
+) -> FFIMaybeException;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn row_set_next_row<'row_set>(
@@ -148,7 +148,7 @@ pub extern "C" fn row_set_next_row<'row_set>(
     serializer_ptr: SerializerPtr,
     out_has_row: *mut bool,
     constructors: &'static ExceptionConstructors,
-) -> FFIException {
+) -> FFIMaybeException {
     let row_set = ArcFFI::as_ref(row_set_ptr).unwrap();
     let mut pager = row_set.pager.lock().unwrap();
     let num_columns = pager.column_specs().len();
@@ -156,7 +156,7 @@ pub extern "C" fn row_set_next_row<'row_set>(
     let deserialize_fut = async {
         // Returns Ok(true) when a row was read and deserialized,
         // Ok(false) when there are no more rows,
-        // Err(FFIException) when an error occurs and should be propagated to C#.
+        // Err(FFIMaybeException) when an error occurs and should be propagated to C#.
         // TODO: consider how to handle possibility of the metadata to change between pages.
         // While unlikely, it's not impossible.
         // For now, we just assume it won't happen and ignore `_new_page_began`.
@@ -172,7 +172,7 @@ pub extern "C" fn row_set_next_row<'row_set>(
             // Successfully obtained the next row's column iterator
             Ok(values) => values,
             // Error while fetching the column value
-            Err(err) => return Err(FFIException::from_error(err, constructors)),
+            Err(err) => return Err(FFIMaybeException::from_error(err, constructors)),
         };
 
         for value_index in 0..num_columns {
@@ -185,12 +185,12 @@ pub extern "C" fn row_set_next_row<'row_set>(
                         "Row contains fewer columns ({} of {}) than metadata claims",
                         value_index, num_columns
                     ));
-                return Err(FFIException::from_exception(ex));
+                return Err(FFIMaybeException::from_exception(ex));
             };
 
             let raw_column = match column_res {
                 Ok(rc) => rc,
-                Err(err) => return Err(FFIException::from_error(err, constructors)),
+                Err(err) => return Err(FFIMaybeException::from_error(err, constructors)),
             };
 
             let Some(frame_slice) = raw_column.slice else {
@@ -219,7 +219,7 @@ pub extern "C" fn row_set_next_row<'row_set>(
     // This is inherently inefficient, but necessary due to blocking C# API upon page boundaries.
     // TODO: implement async C# API (IAsyncEnumerable) to avoid this.
     let (has_row, result) = match BridgedFuture::block_on(deserialize_fut) {
-        Ok(has_row) => (has_row, FFIException::ok()),
+        Ok(has_row) => (has_row, FFIMaybeException::ok()),
         Err(exception) => (false, exception),
     };
     unsafe {

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -7,7 +7,7 @@ use scylla::errors::{NewSessionError, PagerExecutionError, PrepareError};
 use scylla_cql::serialize::row::SerializedValues;
 use tokio::sync::RwLock;
 
-use crate::error_conversion::{FFIException, MaybeShutdownError};
+use crate::error_conversion::{FFIMaybeException, MaybeShutdownError};
 use crate::ffi::{
     ArcFFI, BoxFFI, BridgedBorrowedSharedPtr, BridgedOwnedExclusivePtr, BridgedOwnedSharedPtr,
     CSharpManagedStringPtr, CSharpStr, FFI, FFIStr, FromArc, WriteStringCallback,
@@ -375,7 +375,7 @@ pub extern "C" fn session_get_keyspace(
     write_cs_str: WriteStringCallback,
     cs_string: CSharpManagedStringPtr,
     constructors: &'static ExceptionConstructors,
-) -> FFIException {
+) -> FFIMaybeException {
     let session_arc =
         ArcFFI::as_ref(session_ptr).expect("valid and non-null BridgedSession pointer");
 
@@ -385,7 +385,7 @@ pub extern "C" fn session_get_keyspace(
         let ex = constructors
             .already_shutdown_exception_constructor
             .construct_from_rust("Session has been shut down and can no longer execute operations");
-        return FFIException::from_exception(ex);
+        return FFIMaybeException::from_exception(ex);
     };
 
     // Check if session is connected or if it has been shut down.
@@ -393,13 +393,13 @@ pub extern "C" fn session_get_keyspace(
         let ex = constructors
             .already_shutdown_exception_constructor
             .construct_from_rust("Session has been shut down and can no longer execute operations");
-        return FFIException::from_exception(ex);
+        return FFIMaybeException::from_exception(ex);
     };
 
     let Some(keyspace) = session.get_keyspace() else {
         // If no keyspace is set, we don't set FFIStr.
         // This will be treated as null on the C# side.
-        return FFIException::ok();
+        return FFIMaybeException::ok();
     };
 
     let ffi_str = FFIStr::new(keyspace.as_ref());
@@ -417,7 +417,7 @@ pub extern "C" fn session_get_cluster_state(
     session_ptr: BridgedBorrowedSharedPtr<'_, BridgedSession>,
     out_cluster_state: *mut ManuallyDestructible,
     constructors: &'static ExceptionConstructors,
-) -> FFIException {
+) -> FFIMaybeException {
     let session_arc =
         ArcFFI::as_ref(session_ptr).expect("valid and non-null BridgedSession pointer");
 
@@ -427,7 +427,7 @@ pub extern "C" fn session_get_cluster_state(
         let ex = constructors
             .already_shutdown_exception_constructor
             .construct_from_rust("Session has been shut down and can no longer execute operations");
-        return FFIException::from_exception(ex);
+        return FFIMaybeException::from_exception(ex);
     };
 
     // Check if session is connected or if it has been shut down.
@@ -435,7 +435,7 @@ pub extern "C" fn session_get_cluster_state(
         let ex = constructors
             .already_shutdown_exception_constructor
             .construct_from_rust("Session has been shut down and can no longer execute operations");
-        return FFIException::from_exception(ex);
+        return FFIMaybeException::from_exception(ex);
     };
 
     // Get the cluster state from the session and convert it into an ArcFFI-wrapped pointer.
@@ -444,5 +444,5 @@ pub extern "C" fn session_get_cluster_state(
     unsafe {
         *out_cluster_state = md;
     }
-    FFIException::ok()
+    FFIMaybeException::ok()
 }

--- a/rust/src/task.rs
+++ b/rust/src/task.rs
@@ -9,7 +9,7 @@ use tokio::runtime::Runtime;
 
 use crate::error_conversion::{
     AlreadyExistsConstructor, AlreadyShutdownExceptionConstructor,
-    DeserializationExceptionConstructor, ErrorToException, ExceptionPtr,
+    DeserializationExceptionConstructor, ErrorToException, FFIException,
     FunctionFailureExceptionConstructor, InvalidArgumentExceptionConstructor,
     InvalidConfigurationInQueryExceptionConstructor, InvalidQueryConstructor,
     InvalidTypeExceptionConstructor, NoHostAvailableExceptionConstructor,
@@ -143,7 +143,7 @@ pub struct Tcb<R> {
     /// Function pointer type to complete a TaskCompletionSource with a result.
     complete_task: unsafe extern "C" fn(tcs: FFIGCHandle<Tcs<R>>, result: R),
     /// Function pointer type to fail a TaskCompletionSource with an exception handle.
-    fail_task: unsafe extern "C" fn(tcs: FFIGCHandle<Tcs<R>>, exception_handle: ExceptionPtr),
+    fail_task: unsafe extern "C" fn(tcs: FFIGCHandle<Tcs<R>>, exception_handle: FFIException),
     /// Pointer to the collection of exception constructors.
     // SAFETY: The memory is a leaked unmanaged allocation on the C# side.
     // This guarantees that the pointer remains valid and is not moved or deallocated.
@@ -184,7 +184,7 @@ impl<R> Tcb<R> {
     }
 
     /// Fails the task with the provided exception, consuming the TCB.
-    pub(crate) fn fail_task(self, exception: ExceptionPtr) {
+    pub(crate) fn fail_task(self, exception: FFIException) {
         unsafe {
             (self.fail_task)(self.tcs, exception);
         }

--- a/rust/src/task.rs
+++ b/rust/src/task.rs
@@ -19,7 +19,7 @@ use crate::error_conversion::{
     TraceRetrievalExceptionConstructor, TruncateExceptionConstructor,
     UnauthorizedExceptionConstructor,
 };
-use crate::ffi::{ArcFFI, BridgedOwnedSharedPtr, FFIPtr};
+use crate::ffi::{ArcFFI, BridgedOwnedSharedPtr, FFIGCHandle};
 
 /// The global Tokio runtime used to execute async tasks.
 static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| Runtime::new().unwrap());
@@ -123,7 +123,6 @@ impl<T: Destructible> From<Option<Arc<T>>> for ManuallyDestructible {
         }
     }
 }
-
 enum TcsInner {}
 
 /// Opaque type representing a C# TaskCompletionSource<T>.
@@ -131,12 +130,6 @@ struct Tcs<T> {
     _tcs: TcsInner,
     _phantom: PhantomData<T>,
 }
-
-/// A pointer to a TaskCompletionSource<T> on the C# side.
-#[repr(transparent)]
-pub struct TcsPtr<T>(FFIPtr<'static, Tcs<T>>);
-
-unsafe impl<T> Send for TcsPtr<T> {}
 
 /// **Task Control Block** (TCB)
 ///
@@ -146,11 +139,11 @@ unsafe impl<T> Send for TcsPtr<T> {}
 /// or fail (set an exception) the task.
 #[repr(C)] // <- Ensure FFI-compatible layout
 pub struct Tcb<R> {
-    tcs: TcsPtr<R>,
+    tcs: FFIGCHandle<Tcs<R>>,
     /// Function pointer type to complete a TaskCompletionSource with a result.
-    complete_task: unsafe extern "C" fn(tcs: TcsPtr<R>, result: R),
+    complete_task: unsafe extern "C" fn(tcs: FFIGCHandle<Tcs<R>>, result: R),
     /// Function pointer type to fail a TaskCompletionSource with an exception handle.
-    fail_task: unsafe extern "C" fn(tcs: TcsPtr<R>, exception_handle: ExceptionPtr),
+    fail_task: unsafe extern "C" fn(tcs: FFIGCHandle<Tcs<R>>, exception_handle: ExceptionPtr),
     /// Pointer to the collection of exception constructors.
     // SAFETY: The memory is a leaked unmanaged allocation on the C# side.
     // This guarantees that the pointer remains valid and is not moved or deallocated.

--- a/src/Cassandra/Exceptions/AlreadyExistsException.cs
+++ b/src/Cassandra/Exceptions/AlreadyExistsException.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -53,7 +54,7 @@ namespace Cassandra
         }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr AlreadyExistsExceptionFromRust(RustBridge.FFIString keyspace, RustBridge.FFIString table)
+        internal static FFIGCHandle AlreadyExistsExceptionFromRust(FFIString keyspace, FFIString table)
         {
             string keyspaceStr = keyspace.ToManagedString();
             string tableStr = table.ToManagedString();
@@ -61,8 +62,7 @@ namespace Cassandra
             var exception = new AlreadyExistsException(keyspaceStr, tableStr);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            IntPtr handlePtr = GCHandle.ToIntPtr(handle);
-            return handlePtr;
+            return new(handle);
         }
 
         private static string MakeMsg(string keyspace, string table)

--- a/src/Cassandra/Exceptions/AlreadyShutdownException.cs
+++ b/src/Cassandra/Exceptions/AlreadyShutdownException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -10,15 +11,14 @@ namespace Cassandra
         { }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr AlreadyShutdownExceptionFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle AlreadyShutdownExceptionFromRust(FFIString message)
         {
             string msg = message.ToManagedString();
 
             var exception = new AlreadyShutdownException(msg);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            IntPtr handlePtr = GCHandle.ToIntPtr(handle);
-            return handlePtr;
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/DeserializationException.cs
+++ b/src/Cassandra/Exceptions/DeserializationException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -13,15 +14,14 @@ namespace Cassandra
         { }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr DeserializationExceptionFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle DeserializationExceptionFromRust(FFIString message)
         {
             string msg = message.ToManagedString();
 
             var exception = new DeserializationException(msg);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            IntPtr handlePtr = GCHandle.ToIntPtr(handle);
-            return handlePtr;
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/FunctionFailureException.cs
+++ b/src/Cassandra/Exceptions/FunctionFailureException.cs
@@ -18,6 +18,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
+using static Cassandra.RustBridge;
 
 // ReSharper disable once CheckNamespace
 namespace Cassandra
@@ -55,13 +56,13 @@ namespace Cassandra
         }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr FunctionFailureExceptionFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle FunctionFailureExceptionFromRust(FFIString message)
         {
             string msg = message.ToManagedString();
             var exception = new FunctionFailureException(msg);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            return GCHandle.ToIntPtr(handle);
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/InvalidArgumentException.cs
+++ b/src/Cassandra/Exceptions/InvalidArgumentException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -14,15 +15,14 @@ namespace Cassandra
         { }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr InvalidArgumentExceptionFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle InvalidArgumentExceptionFromRust(FFIString message)
         {
             string msg = message.ToManagedString();
 
             var exception = new InvalidArgumentException(msg);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            IntPtr handlePtr = GCHandle.ToIntPtr(handle);
-            return handlePtr;
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/InvalidConfigurationInQueryException.cs
+++ b/src/Cassandra/Exceptions/InvalidConfigurationInQueryException.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -33,13 +34,13 @@ namespace Cassandra
         }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr InvalidConfigurationInQueryExceptionFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle InvalidConfigurationInQueryExceptionFromRust(FFIString message)
         {
             string msg = message.ToManagedString();
             var exception = new InvalidConfigurationInQueryException(msg);
 
-            var handle = GCHandle.Alloc(exception);
-            return GCHandle.ToIntPtr(handle);
+            GCHandle handle = GCHandle.Alloc(exception);
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/InvalidQueryException.cs
+++ b/src/Cassandra/Exceptions/InvalidQueryException.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -36,14 +37,13 @@ namespace Cassandra
         }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr InvalidQueryExceptionFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle InvalidQueryExceptionFromRust(FFIString message)
         {
             string msg = message.ToManagedString();
             var exception = new InvalidQueryException(msg);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            IntPtr handlePtr = GCHandle.ToIntPtr(handle);
-            return handlePtr;
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/InvalidTypeException.cs
+++ b/src/Cassandra/Exceptions/InvalidTypeException.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -49,14 +50,13 @@ namespace Cassandra
         }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr InvalidTypeExceptionFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle InvalidTypeExceptionFromRust(FFIString message)
         {
             string msg = message.ToManagedString();
             var exception = new InvalidTypeException(msg);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            IntPtr handlePtr = GCHandle.ToIntPtr(handle);
-            return handlePtr;
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/NoHostAvailableException.cs
+++ b/src/Cassandra/Exceptions/NoHostAvailableException.cs
@@ -22,6 +22,7 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -102,14 +103,13 @@ namespace Cassandra
         }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr NoHostAvailableExceptionFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle NoHostAvailableExceptionFromRust(FFIString message)
         {
             string msg = message.ToManagedString();
             var exception = new NoHostAvailableException(msg);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            IntPtr handlePtr = GCHandle.ToIntPtr(handle);
-            return handlePtr;
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/OperationTimedOutException.cs
+++ b/src/Cassandra/Exceptions/OperationTimedOutException.cs
@@ -18,6 +18,7 @@ using System.Net;
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using static Cassandra.RustBridge;
 
 // ReSharper disable once CheckNamespace
 namespace Cassandra
@@ -40,13 +41,12 @@ namespace Cassandra
         }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr OperationTimedOutExceptionFromRust(int timeout)
+        internal static FFIGCHandle OperationTimedOutExceptionFromRust(int timeout)
         {
             Exception exception = new OperationTimedOutException(timeout);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            IntPtr handlePtr = GCHandle.ToIntPtr(handle);
-            return handlePtr;
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/PreparedQueryNotFoundException.cs
+++ b/src/Cassandra/Exceptions/PreparedQueryNotFoundException.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -31,15 +32,14 @@ namespace Cassandra
         }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr PreparedQueryNotFoundExceptionFromRust(RustBridge.FFIString message, RustBridge.FFISliceRaw unknownId)
+        internal static FFIGCHandle PreparedQueryNotFoundExceptionFromRust(FFIString message, FFISliceRaw unknownId)
         {
             string msg = message.ToManagedString();
             byte[] unknownIdBytes = unknownId.As<byte>().ToSpan().ToArray();
             var exception = new PreparedQueryNotFoundException(msg, unknownIdBytes);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            IntPtr handlePtr = GCHandle.ToIntPtr(handle);
-            return handlePtr;
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/RequestInvalidException.cs
+++ b/src/Cassandra/Exceptions/RequestInvalidException.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -30,13 +31,13 @@ namespace Cassandra
         }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr RequestInvalidExceptionFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle RequestInvalidExceptionFromRust(FFIString message)
         {
             string msg = message.ToManagedString();
             var exception = new RequestInvalidException(msg);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            return GCHandle.ToIntPtr(handle);
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/RustException.cs
+++ b/src/Cassandra/Exceptions/RustException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -10,15 +11,14 @@ namespace Cassandra
         { }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr RustExceptionFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle RustExceptionFromRust(FFIString message)
         {
             string msg = message.ToManagedString();
 
             var exception = new RustException(msg);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            IntPtr handlePtr = GCHandle.ToIntPtr(handle);
-            return handlePtr;
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/SerializationException.cs
+++ b/src/Cassandra/Exceptions/SerializationException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -13,15 +14,14 @@ namespace Cassandra
         { }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr SerializationExceptionFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle SerializationExceptionFromRust(FFIString message)
         {
             string msg = message.ToManagedString();
 
             var exception = new SerializationException(msg);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            IntPtr handlePtr = GCHandle.ToIntPtr(handle);
-            return handlePtr;
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/SyntaxError.cs
+++ b/src/Cassandra/Exceptions/SyntaxError.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -30,13 +31,13 @@ namespace Cassandra
         }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr SyntaxErrorFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle SyntaxErrorFromRust(FFIString message)
         {
             string msg = message.ToManagedString();
             var exception = new SyntaxError(msg);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            return GCHandle.ToIntPtr(handle);
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/TraceRetrievalException.cs
+++ b/src/Cassandra/Exceptions/TraceRetrievalException.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -36,13 +37,13 @@ namespace Cassandra
         }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr TraceRetrievalExceptionFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle TraceRetrievalExceptionFromRust(FFIString message)
         {
             string messageStr = message.ToManagedString();
             var exception = new TraceRetrievalException(messageStr);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            return GCHandle.ToIntPtr(handle);
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/TruncateException.cs
+++ b/src/Cassandra/Exceptions/TruncateException.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -30,13 +31,13 @@ namespace Cassandra
         }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr TruncateExceptionFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle TruncateExceptionFromRust(FFIString message)
         {
             string msg = message.ToManagedString();
             var exception = new TruncateException(msg);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            return GCHandle.ToIntPtr(handle);
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/Exceptions/UnauthorizedException.cs
+++ b/src/Cassandra/Exceptions/UnauthorizedException.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
@@ -30,13 +31,13 @@ namespace Cassandra
         }
 
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static IntPtr UnauthorizedExceptionFromRust(RustBridge.FFIString message)
+        internal static FFIGCHandle UnauthorizedExceptionFromRust(FFIString message)
         {
             string messageStr = message.ToManagedString();
             var exception = new UnauthorizedException(messageStr);
 
             GCHandle handle = GCHandle.Alloc(exception);
-            return GCHandle.ToIntPtr(handle);
+            return new(handle);
         }
     }
 }

--- a/src/Cassandra/RustBridge/BridgedClusterState.cs
+++ b/src/Cassandra/RustBridge/BridgedClusterState.cs
@@ -20,7 +20,7 @@ namespace Cassandra
         }
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        private static extern RustBridge.FFIException cluster_state_fill_nodes(
+        private static extern RustBridge.FFIMaybeException cluster_state_fill_nodes(
             IntPtr clusterState,
             IntPtr contextPtr,
             IntPtr callback);
@@ -37,7 +37,7 @@ namespace Cassandra
         {
             try
             {
-                // Safety: 
+                // Safety:
                 // contextPtr is a pointer to the stack slot holding the 'context' reference (not to the heap object itself).
                 // Unsafe.AsPointer(ref T) returns the address of the managed pointer (the stack local).
                 // The stack slot is stable for the duration of this callback since:
@@ -50,8 +50,8 @@ namespace Cassandra
 
                 var hostId = new Guid(idBytes.As<byte>().ToSpan());
 
-                // Construct IPAddress directly from bytes (4 for IPv4, 16 for IPv6). ipBytes is an FFISlice<byte> 
-                // and it accesses unmanaged memory that is only valid for the duration of this callback invocation. 
+                // Construct IPAddress directly from bytes (4 for IPv4, 16 for IPv6). ipBytes is an FFISlice<byte>
+                // and it accesses unmanaged memory that is only valid for the duration of this callback invocation.
                 // The IPAddress constructor must be called synchronously here so it can copy the data immediately.
                 var ipAddress = new IPAddress(ipBytes.As<byte>().ToSpan());
                 var address = new IPEndPoint(ipAddress, port);
@@ -100,7 +100,7 @@ namespace Cassandra
         }
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIException cluster_state_get_keyspace_metadata(
+        unsafe private static extern FFIMaybeException cluster_state_get_keyspace_metadata(
             IntPtr clusterState,
             [MarshalAs(UnmanagedType.LPUTF8Str)] string keyspaceName,
             IntPtr contextPtr,
@@ -109,9 +109,9 @@ namespace Cassandra
             IntPtr callback,
             IntPtr constructorsPtr);
 
-        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, nuint, FFIException> SimpleStrategyAddRepFactorPtr = &SimpleStrategyAddRepFactor;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, nuint, FFIMaybeException> SimpleStrategyAddRepFactorPtr = &SimpleStrategyAddRepFactor;
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        private static unsafe FFIException SimpleStrategyAddRepFactor(
+        private static unsafe FFIMaybeException SimpleStrategyAddRepFactor(
             IntPtr replicationOptionsPtr,
             nuint repFactor)
         {
@@ -122,15 +122,15 @@ namespace Cassandra
             }
             catch (Exception ex)
             {
-                return FFIException.FromException(ex);
+                return FFIMaybeException.FromException(ex);
             }
 
-            return FFIException.Ok();
+            return FFIMaybeException.Ok();
         }
 
-        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFIString, nuint, FFIException> NetworkTopologyStrategyAddRepFactorPtr = &NetworkTopologyStrategyAddRepFactor;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFIString, nuint, FFIMaybeException> NetworkTopologyStrategyAddRepFactorPtr = &NetworkTopologyStrategyAddRepFactor;
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        private static unsafe FFIException NetworkTopologyStrategyAddRepFactor(
+        private static unsafe FFIMaybeException NetworkTopologyStrategyAddRepFactor(
             IntPtr replicationOptionsPtr,
             FFIString datacenter,
             nuint repFactor)
@@ -142,15 +142,15 @@ namespace Cassandra
             }
             catch (Exception ex)
             {
-                return FFIException.FromException(ex);
+                return FFIMaybeException.FromException(ex);
             }
 
-            return FFIException.Ok();
+            return FFIMaybeException.Ok();
         }
 
-        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFIString, FFIString, FFIException> OtherStrategyAddRepFactorPtr = &OtherStrategyAddRepFactor;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFIString, FFIString, FFIMaybeException> OtherStrategyAddRepFactorPtr = &OtherStrategyAddRepFactor;
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        private static unsafe FFIException OtherStrategyAddRepFactor(
+        private static unsafe FFIMaybeException OtherStrategyAddRepFactor(
             IntPtr replicationOptionsPtr,
             FFIString strategyClass,
             FFIString repFactor)
@@ -162,10 +162,10 @@ namespace Cassandra
             }
             catch (Exception ex)
             {
-                return FFIException.FromException(ex);
+                return FFIMaybeException.FromException(ex);
             }
 
-            return FFIException.Ok();
+            return FFIMaybeException.Ok();
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -183,9 +183,9 @@ namespace Cassandra
             }
         }
 
-        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFIBool, FFIString, IntPtr, FFIException> FillKeyspaceMetadataPtr = &FillKeyspaceMetadata;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFIBool, FFIString, IntPtr, FFIMaybeException> FillKeyspaceMetadataPtr = &FillKeyspaceMetadata;
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        private static unsafe FFIException FillKeyspaceMetadata(
+        private static unsafe FFIMaybeException FillKeyspaceMetadata(
             IntPtr contextPtr,
             FFIBool durableWrites,
             FFIString strategyClass,
@@ -213,10 +213,10 @@ namespace Cassandra
             }
             catch (Exception ex)
             {
-                return FFIException.FromException(ex);
+                return FFIMaybeException.FromException(ex);
             }
 
-            return FFIException.Ok();
+            return FFIMaybeException.Ok();
         }
 
         internal KeyspaceMetadata GetKeyspaceMetadata(BridgedClusterState clusterState, string keyspaceName)
@@ -259,14 +259,14 @@ namespace Cassandra
         }
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIException cluster_state_get_keyspace_names(
+        unsafe private static extern FFIMaybeException cluster_state_get_keyspace_names(
             IntPtr clusterState,
             IntPtr keyspaceNameListPtr,
             IntPtr callback);
 
-        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFIString, FFIException> AddKeyspaceNamePtr = &AddKeyspaceName;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFIString, FFIMaybeException> AddKeyspaceNamePtr = &AddKeyspaceName;
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        private static unsafe FFIException AddKeyspaceName(
+        private static unsafe FFIMaybeException AddKeyspaceName(
             IntPtr keyspaceNameListPtr,
             FFIString keyspaceName)
         {
@@ -277,10 +277,10 @@ namespace Cassandra
             }
             catch (Exception ex)
             {
-                return FFIException.FromException(ex);
+                return FFIMaybeException.FromException(ex);
             }
 
-            return FFIException.Ok();
+            return FFIMaybeException.Ok();
         }
 
         internal List<string> GetKeyspaceNames()
@@ -302,16 +302,16 @@ namespace Cassandra
         }
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIException cluster_state_get_table_names(
+        unsafe private static extern FFIMaybeException cluster_state_get_table_names(
             IntPtr clusterState,
             [MarshalAs(UnmanagedType.LPUTF8Str)] string keyspaceName,
             IntPtr tableNameListPtr,
             IntPtr callback,
             IntPtr constructorsPtr);
 
-        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFIString, FFIException> AddTableNamesPtr = &AddTableName;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFIString, FFIMaybeException> AddTableNamesPtr = &AddTableName;
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        private static unsafe FFIException AddTableName(
+        private static unsafe FFIMaybeException AddTableName(
             IntPtr tableNameListPtr,
             FFIString tableName)
         {
@@ -322,10 +322,10 @@ namespace Cassandra
             }
             catch (Exception ex)
             {
-                return FFIException.FromException(ex);
+                return FFIMaybeException.FromException(ex);
             }
 
-            return FFIException.Ok();
+            return FFIMaybeException.Ok();
         }
 
         internal List<string> GetTableNames(string keyspaceName)
@@ -361,9 +361,9 @@ namespace Cassandra
             return tableNames;
         }
 
-        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFIString, byte, IntPtr, FFIBool, FFIBool, FFIException> ConstructTableColumnPtr = &ConstructTableColumn;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFIString, byte, IntPtr, FFIBool, FFIBool, FFIMaybeException> ConstructTableColumnPtr = &ConstructTableColumn;
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        private static unsafe FFIException ConstructTableColumn(
+        private static unsafe FFIMaybeException ConstructTableColumn(
             IntPtr tableColumnsListPtr,
             FFIString columnName,
             byte typeCode,
@@ -389,17 +389,17 @@ namespace Cassandra
                 };
                 tableColumnsList.Add(column);
 
-                return FFIException.Ok();
+                return FFIMaybeException.Ok();
             }
             catch (Exception ex)
             {
-                return FFIException.FromException(ex);
+                return FFIMaybeException.FromException(ex);
             }
         }
 
-        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFIString, FFIException> AddPrimaryKeyPtr = &AddPrimaryKey;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFIString, FFIMaybeException> AddPrimaryKeyPtr = &AddPrimaryKey;
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        private static unsafe FFIException AddPrimaryKey(
+        private static unsafe FFIMaybeException AddPrimaryKey(
             IntPtr keysListPtr,
             FFIString keyName)
         {
@@ -410,14 +410,14 @@ namespace Cassandra
             }
             catch (Exception ex)
             {
-                return FFIException.FromException(ex);
+                return FFIMaybeException.FromException(ex);
             }
 
-            return FFIException.Ok();
+            return FFIMaybeException.Ok();
         }
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIException cluster_state_get_table_metadata(
+        unsafe private static extern FFIMaybeException cluster_state_get_table_metadata(
             IntPtr clusterState,
             [MarshalAs(UnmanagedType.LPUTF8Str)] string keyspaceName,
             [MarshalAs(UnmanagedType.LPUTF8Str)] string tableName,
@@ -430,9 +430,9 @@ namespace Cassandra
             IntPtr constructTableMetadataCallback,
             IntPtr constructorsPtr);
 
-        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, IntPtr, FFIException> FillTableMetadataPtr = &FillTableMetadata;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, IntPtr, FFIMaybeException> FillTableMetadataPtr = &FillTableMetadata;
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        private static unsafe FFIException FillTableMetadata(
+        private static unsafe FFIMaybeException FillTableMetadata(
             IntPtr tableContextPtr,
             IntPtr tableColumnsListPtr,
             IntPtr partitionKeys,
@@ -479,11 +479,11 @@ namespace Cassandra
                 // TODO: bridge table options.
                 tableMetadata.SetValues(tableColumnsDictionary, partitionKeysColumns, clusteringKeysColumns, null);
 
-                return FFIException.Ok();
+                return FFIMaybeException.Ok();
             }
             catch (Exception ex)
             {
-                return FFIException.FromException(ex);
+                return FFIMaybeException.FromException(ex);
             }
         }
 

--- a/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
+++ b/src/Cassandra/RustBridge/BridgedPreparedStatement.cs
@@ -53,13 +53,13 @@ namespace Cassandra
         }
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIException prepared_statement_is_lwt(IntPtr prepared_statement, out FFIBool isLwt);
+        unsafe private static extern FFIMaybeException prepared_statement_is_lwt(IntPtr prepared_statement, out FFIBool isLwt);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIException prepared_statement_get_variables_column_specs_count(IntPtr prepared_statement, out nuint count);
+        unsafe private static extern FFIMaybeException prepared_statement_get_variables_column_specs_count(IntPtr prepared_statement, out nuint count);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIException prepared_statement_fill_column_specs_metadata(IntPtr prepared_statement, IntPtr columnsPtr, IntPtr metadataSetter);
+        unsafe private static extern FFIMaybeException prepared_statement_fill_column_specs_metadata(IntPtr prepared_statement, IntPtr columnsPtr, IntPtr metadataSetter);
 
         private nuint GetVariablesColumnSpecsCount()
         {
@@ -73,6 +73,6 @@ namespace Cassandra
             RunWithIncrement(handle => prepared_statement_fill_column_specs_metadata(handle, columnsPtr, metadataSetter));
         }
 
-        unsafe static readonly delegate* unmanaged[Cdecl]<IntPtr, nuint, FFIString, FFIString, FFIString, byte, IntPtr, byte, FFIException> setColumnMetaPtr = &BridgedRowSet.SetColumnMeta;
+        unsafe static readonly delegate* unmanaged[Cdecl]<IntPtr, nuint, FFIString, FFIString, FFIString, byte, IntPtr, byte, FFIMaybeException> setColumnMetaPtr = &BridgedRowSet.SetColumnMeta;
     }
 }

--- a/src/Cassandra/RustBridge/BridgedRowSet.cs
+++ b/src/Cassandra/RustBridge/BridgedRowSet.cs
@@ -87,13 +87,13 @@ namespace Cassandra
             return columns;
         }
 
-        unsafe static readonly delegate* unmanaged[Cdecl]<IntPtr, nuint, FFIString, FFIString, FFIString, byte, IntPtr, byte, FFIException> setColumnMetaPtr = &SetColumnMeta;
+        unsafe static readonly delegate* unmanaged[Cdecl]<IntPtr, nuint, FFIString, FFIString, FFIString, byte, IntPtr, byte, FFIMaybeException> setColumnMetaPtr = &SetColumnMeta;
 
         /// <summary>
         /// This shall be called by Rust code for each column.
         /// </summary>
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static FFIException SetColumnMeta(
+        internal static FFIMaybeException SetColumnMeta(
             IntPtr columnsPtr,
             nuint columnIndex,
             FFIString name,
@@ -122,7 +122,7 @@ namespace Cassandra
                     if (index < 0 || index >= columns.Length)
                     {
                         // I am not sure whether this warrant panicking or returning an error.
-                        return FFIException.FromException(
+                        return FFIMaybeException.FromException(
                             new IndexOutOfRangeException($"Column index {index} is out of range (0..{columns.Length - 1})")
                         );
                     }
@@ -142,20 +142,20 @@ namespace Cassandra
                         col.TypeInfo = BuildTypeInfoFromHandle(typeInfoPtr, col.TypeCode);
                     }
                 }
-                return FFIException.Ok();
+                return FFIMaybeException.Ok();
             }
         }
 
         // Private methods and P/Invoke
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIException row_set_next_row(IntPtr rowSetPtr, IntPtr deserializeValue, IntPtr columnsPtr, IntPtr valuesPtr, IntPtr serializerPtr, out FFIBool hasRow, IntPtr constructorsPtr);
+        unsafe private static extern FFIMaybeException row_set_next_row(IntPtr rowSetPtr, IntPtr deserializeValue, IntPtr columnsPtr, IntPtr valuesPtr, IntPtr serializerPtr, out FFIBool hasRow, IntPtr constructorsPtr);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIException row_set_get_columns_count(IntPtr rowSetPtr, out nuint count);
+        unsafe private static extern FFIMaybeException row_set_get_columns_count(IntPtr rowSetPtr, out nuint count);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIException row_set_fill_columns_metadata(IntPtr rowSetPtr, IntPtr columnsPtr, IntPtr metadataSetter);
+        unsafe private static extern FFIMaybeException row_set_fill_columns_metadata(IntPtr rowSetPtr, IntPtr columnsPtr, IntPtr metadataSetter);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern byte row_set_type_info_get_code(IntPtr typeInfoHandle);
@@ -304,13 +304,13 @@ namespace Cassandra
             }
         }
 
-        unsafe readonly static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, nuint, IntPtr, FFISliceRaw, FFIException> deserializeValue = &DeserializeValue;
+        unsafe readonly static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, nuint, IntPtr, FFISliceRaw, FFIMaybeException> deserializeValue = &DeserializeValue;
 
         /// <summary>
         /// This shall be called by Rust code for each column in a row.
         /// </summary>
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        private static FFIException DeserializeValue(
+        private static FFIMaybeException DeserializeValue(
             IntPtr columnsPtr,
             IntPtr valuesPtr,
             nuint valueIndex,
@@ -337,12 +337,12 @@ namespace Cassandra
                 {
                     throw new InvalidOperationException("GCHandle referenced type mismatch.");
                 }
-                return FFIException.Ok();
+                return FFIMaybeException.Ok();
             }
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"[FFI] DeserializeValue threw exception: {ex}");
-                return FFIException.FromException(ex);
+                return FFIMaybeException.FromException(ex);
             }
         }
 

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -37,7 +37,7 @@ namespace Cassandra
         unsafe private static extern void session_query(Tcb<ManuallyDestructible> tcb, IntPtr session, [MarshalAs(UnmanagedType.LPUTF8Str)] string statement);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        private static extern FFIException session_get_cluster_state(IntPtr sessionPtr, out ManuallyDestructible clusterState, IntPtr constructorsPtr);
+        private static extern FFIMaybeException session_get_cluster_state(IntPtr sessionPtr, out ManuallyDestructible clusterState, IntPtr constructorsPtr);
 
         /// <summary>
         /// Executes a query with already-serialized values.
@@ -59,7 +59,7 @@ namespace Cassandra
         unsafe private static extern void session_query_bound_with_values(Tcb<ManuallyDestructible> tcb, IntPtr session, IntPtr preparedStatement, IntPtr valuesPtr);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern FFIException session_get_keyspace(IntPtr session, IntPtr writeToStr, IntPtr context, IntPtr constructorsPtr);
+        unsafe private static extern FFIMaybeException session_get_keyspace(IntPtr session, IntPtr writeToStr, IntPtr context, IntPtr constructorsPtr);
 
         /// <summary>
         /// Creates a new session connected to the specified Cassandra URI.
@@ -167,7 +167,7 @@ namespace Cassandra
         /// <summary>
         /// Gets the keyspace of the session. Returns the name of the current keyspace as a string, or null if no keyspace is set.
         /// Note: This method involves marshaling a string from native code, which can be expensive.
-        /// Exceptions thrown by the native code will be propagated as FFIException.
+        /// Exceptions thrown by the native code will be propagated as FFIMaybeException.
         /// </summary>
         internal string GetKeyspace()
         {

--- a/src/Cassandra/RustBridge/EmptyRustResource.cs
+++ b/src/Cassandra/RustBridge/EmptyRustResource.cs
@@ -16,7 +16,7 @@ namespace Cassandra
         {
         }
 
-        internal override void RunWithIncrement(Func<IntPtr, RustBridge.FFIException> invoke)
+        internal override void RunWithIncrement(Func<IntPtr, RustBridge.FFIMaybeException> invoke)
         {
             Environment.FailFast("Attempted to use a null RustResource.");
         }

--- a/src/Cassandra/RustBridge/RustBridge.cs
+++ b/src/Cassandra/RustBridge/RustBridge.cs
@@ -534,10 +534,10 @@ namespace Cassandra
                         {
                             // Create the exception to pass to the TCS.
                             Exception exception;
-                            if (ffiException.exception != IntPtr.Zero)
+                            if (ffiException.HasException)
                             {
                                 // Recover the exception from the GCHandle passed from Rust.
-                                var exHandle = GCHandle.FromIntPtr(ffiException.exception);
+                                var exHandle = GCHandle.FromIntPtr(ffiException.maybeException.gchandle);
                                 try
                                 {
                                     if (exHandle.Target is Exception ex)
@@ -598,24 +598,24 @@ namespace Cassandra
         internal static unsafe class Globals
         {
             // Exception constructors passed to Rust
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIString, IntPtr> AlreadyExistsConstructorPtr = &AlreadyExistsException.AlreadyExistsExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> AlreadyShutdownExceptionConstructorPtr = &AlreadyShutdownException.AlreadyShutdownExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> DeserializationExceptionConstructorPtr = &DeserializationException.DeserializationExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> FunctionFailureExceptionConstructorPtr = &FunctionFailureException.FunctionFailureExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> InvalidArgumentExceptionConstructorPtr = &InvalidArgumentException.InvalidArgumentExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> InvalidConfigurationInQueryExceptionConstructorPtr = &InvalidConfigurationInQueryException.InvalidConfigurationInQueryExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> InvalidQueryConstructorPtr = &InvalidQueryException.InvalidQueryExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> InvalidTypeExceptionConstructorPtr = &InvalidTypeException.InvalidTypeExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> NoHostAvailableExceptionConstructorPtr = &NoHostAvailableException.NoHostAvailableExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<int, IntPtr> OperationTimedOutExceptionConstructorPtr = &OperationTimedOutException.OperationTimedOutExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFISliceRaw, IntPtr> PreparedQueryNotFoundExceptionConstructorPtr = &PreparedQueryNotFoundException.PreparedQueryNotFoundExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> RequestInvalidExceptionConstructorPtr = &RequestInvalidException.RequestInvalidExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> RustExceptionConstructorPtr = &RustException.RustExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> SerializationExceptionConstructorPtr = &SerializationException.SerializationExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> SyntaxErrorExceptionConstructorPtr = &SyntaxError.SyntaxErrorFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> TraceRetrievalExceptionConstructorPtr = &TraceRetrievalException.TraceRetrievalExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> TruncateExceptionConstructorPtr = &TruncateException.TruncateExceptionFromRust;
-            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, IntPtr> UnauthorizedExceptionConstructorPtr = &UnauthorizedException.UnauthorizedExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIString, FFIGCHandle> AlreadyExistsConstructorPtr = &AlreadyExistsException.AlreadyExistsExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> AlreadyShutdownExceptionConstructorPtr = &AlreadyShutdownException.AlreadyShutdownExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> DeserializationExceptionConstructorPtr = &DeserializationException.DeserializationExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> FunctionFailureExceptionConstructorPtr = &FunctionFailureException.FunctionFailureExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> InvalidArgumentExceptionConstructorPtr = &InvalidArgumentException.InvalidArgumentExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> InvalidConfigurationInQueryExceptionConstructorPtr = &InvalidConfigurationInQueryException.InvalidConfigurationInQueryExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> InvalidQueryConstructorPtr = &InvalidQueryException.InvalidQueryExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> InvalidTypeExceptionConstructorPtr = &InvalidTypeException.InvalidTypeExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> NoHostAvailableExceptionConstructorPtr = &NoHostAvailableException.NoHostAvailableExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<int, FFIGCHandle> OperationTimedOutExceptionConstructorPtr = &OperationTimedOutException.OperationTimedOutExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFISliceRaw, FFIGCHandle> PreparedQueryNotFoundExceptionConstructorPtr = &PreparedQueryNotFoundException.PreparedQueryNotFoundExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> RequestInvalidExceptionConstructorPtr = &RequestInvalidException.RequestInvalidExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> RustExceptionConstructorPtr = &RustException.RustExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> SerializationExceptionConstructorPtr = &SerializationException.SerializationExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> SyntaxErrorExceptionConstructorPtr = &SyntaxError.SyntaxErrorFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> TraceRetrievalExceptionConstructorPtr = &TraceRetrievalException.TraceRetrievalExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> TruncateExceptionConstructorPtr = &TruncateException.TruncateExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> UnauthorizedExceptionConstructorPtr = &UnauthorizedException.UnauthorizedExceptionFromRust;
 
             /// <summary>
             /// Table of exception constructors passed to Rust via TCB.
@@ -725,41 +725,40 @@ namespace Cassandra
         }
 
         /// <summary>
-        /// Package used to pass exceptions from Rust to C# over FFI boundary.
-        /// If the underlying pointer is IntPtr.Zero, no exception occurred.
-        /// If it's non-zero, it points to a GCHandle referencing the Exception.
+        /// Package used to pass optional exceptions from Rust to C# over FFI boundary.
+        /// If the underlying FFIMaybeGCHandle is empty, no exception occurred.
+        /// If it's non-empty, it points to a GCHandle referencing the Exception.
         /// This handle must be freed even when a different exception is thrown.
         /// All changes to this struct's fields must be mirrored in Rust code in the exact same order.
         /// </summary>
+        // Note that there's no FFIException on the C# side, because lack of move semantics in C# makes
+        // it impossible to enforce _freeing exactly once_.
         [StructLayout(LayoutKind.Sequential)]
         internal struct FFIMaybeException
         {
             // Fields:
-            // Pointer to a GCHandle referencing the Exception.
-            internal IntPtr exception;
+            // Maybe a GCHandle referencing the Exception.
+            internal FFIMaybeGCHandle maybeException;
 
             // Functions:
+            private FFIMaybeException(FFIMaybeGCHandle maybeHandle)
+            {
+                maybeException = maybeHandle;
+            }
             // Creates an FFIMaybeException from the given Exception.
             internal static FFIMaybeException FromException(Exception ex)
             {
                 var handle = GCHandle.Alloc(ex);
-                IntPtr handlePtr = GCHandle.ToIntPtr(handle);
-                return new FFIMaybeException
-                {
-                    exception = handlePtr
-                };
+                return new(new FFIMaybeGCHandle(handle));
             }
 
             // Creates an FFIMaybeException representing no exception.
             internal static FFIMaybeException Ok()
             {
-                return new FFIMaybeException
-                {
-                    exception = IntPtr.Zero
-                };
+                return new(FFIMaybeGCHandle.Empty());
             }
 
-            internal bool HasException => exception != IntPtr.Zero;
+            internal readonly bool HasException => !maybeException.IsEmpty();
         }
 
         /// <summary>
@@ -769,13 +768,13 @@ namespace Cassandra
         /// </summary>
         internal static void ThrowIfException(ref FFIMaybeException res)
         {
-            if (res.exception == IntPtr.Zero)
+            if (!res.HasException)
             {
                 return;
             }
 
             Exception exception;
-            var exHandle = GCHandle.FromIntPtr(res.exception);
+            var exHandle = GCHandle.FromIntPtr(res.maybeException.gchandle);
             try
             {
                 if (exHandle.Target is Exception ex)
@@ -795,7 +794,7 @@ namespace Cassandra
                     exHandle.Free();
                 }
                 // Zero out the pointer to avoid double free if caller invokes FreeIfPresent
-                res.exception = IntPtr.Zero;
+                res.maybeException = FFIMaybeGCHandle.Empty();
             }
             throw exception;
         }
@@ -806,11 +805,11 @@ namespace Cassandra
         /// </summary>
         internal static void FreeExceptionHandle(ref FFIMaybeException res)
         {
-            if (res.exception == IntPtr.Zero)
+            if (!res.HasException)
             {
                 return;
             }
-            var exHandle = GCHandle.FromIntPtr(res.exception);
+            var exHandle = GCHandle.FromIntPtr(res.maybeException.gchandle);
             try
             {
                 if (exHandle.IsAllocated)
@@ -820,7 +819,7 @@ namespace Cassandra
             }
             finally
             {
-                res.exception = IntPtr.Zero;
+                res.maybeException = FFIMaybeGCHandle.Empty();
             }
         }
     }

--- a/src/Cassandra/RustBridge/RustBridge.cs
+++ b/src/Cassandra/RustBridge/RustBridge.cs
@@ -272,14 +272,14 @@ namespace Cassandra
             /// This shall be called by Rust code when the operation failed.
             /// </summary>
             //
-            // Signature in Rust: extern "C" fn(tcs: FFIGCHandle, exception_handle: ExceptionPtr)
+            // Signature in Rust: extern "C" fn(tcs: FFIGCHandle, exception_handle: FFIException)
             //
             // This attribute makes the method callable from native code.
             // It also allows taking a function pointer to the method.
             [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-            internal static void FailTask(FFIGCHandle tcsHandle, FFIMaybeException exceptionPtr)
+            internal static void FailTask(FFIGCHandle tcsHandle, FFIMaybeException ffiException)
             {
-                Tcb<FFIBool>.FailTask(tcsHandle, exceptionPtr);
+                Tcb<FFIBool>.FailTask(tcsHandle, ffiException);
             }
 
             internal unsafe readonly static delegate* unmanaged[Cdecl]<FFIGCHandle, FFIBool, void> completeTaskDel = &CompleteTask;
@@ -342,14 +342,14 @@ namespace Cassandra
             /// This shall be called by Rust code when the operation failed.
             /// </summary>
             //
-            // Signature in Rust: extern "C" fn(tcs: FFIGCHandle, exception_handle: ExceptionPtr)
+            // Signature in Rust: extern "C" fn(tcs: FFIGCHandle, exception_handle: FFIException)
             //
             // This attribute makes the method callable from native code.
             // It also allows taking a function pointer to the method.
             [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-            internal static void FailTask(FFIGCHandle tcsHandle, FFIMaybeException exceptionPtr)
+            internal static void FailTask(FFIGCHandle tcsHandle, FFIMaybeException ffiException)
             {
-                Tcb<ManuallyDestructible>.FailTask(tcsHandle, exceptionPtr);
+                Tcb<ManuallyDestructible>.FailTask(tcsHandle, ffiException);
             }
 
 
@@ -516,11 +516,11 @@ namespace Cassandra
             /// This shall be called by Rust code when the operation failed.
             /// </summary>
             //
-            // Signature in Rust: extern "C" fn(tcs: FFIGCHandle, exception_handle: ExceptionPtr)
+            // Signature in Rust: extern "C" fn(tcs: FFIGCHandle, exception_handle: FFIException)
             //
             // This attribute makes the method callable from native code.
             // It also allows taking a function pointer to the method.
-            internal static void FailTask(FFIGCHandle tcsHandle, FFIMaybeException exceptionPtr)
+            internal static void FailTask(FFIGCHandle tcsHandle, FFIMaybeException ffiException)
             {
                 try
                 {
@@ -534,10 +534,10 @@ namespace Cassandra
                         {
                             // Create the exception to pass to the TCS.
                             Exception exception;
-                            if (exceptionPtr.exception != IntPtr.Zero)
+                            if (ffiException.exception != IntPtr.Zero)
                             {
                                 // Recover the exception from the GCHandle passed from Rust.
-                                var exHandle = GCHandle.FromIntPtr(exceptionPtr.exception);
+                                var exHandle = GCHandle.FromIntPtr(ffiException.exception);
                                 try
                                 {
                                     if (exHandle.Target is Exception ex)

--- a/src/Cassandra/RustBridge/RustBridge.cs
+++ b/src/Cassandra/RustBridge/RustBridge.cs
@@ -123,10 +123,10 @@ namespace Cassandra
 
         internal static class FFIManagedStringWriter
         {
-            unsafe static internal readonly delegate* unmanaged[Cdecl]<FFIString, IntPtr, FFIException> WriteToStrPtr = &WriteToString;
+            unsafe static internal readonly delegate* unmanaged[Cdecl]<FFIString, IntPtr, FFIMaybeException> WriteToStrPtr = &WriteToString;
 
             [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-            internal static unsafe FFIException WriteToString(FFIString str, IntPtr ptr)
+            internal static unsafe FFIMaybeException WriteToString(FFIString str, IntPtr ptr)
             {
                 try
                 {
@@ -136,9 +136,9 @@ namespace Cassandra
                 catch (Exception ex)
                 {
                     Console.Error.WriteLine($"[FFI] WriteToString threw exception: {ex}");
-                    return FFIException.FromException(ex);
+                    return FFIMaybeException.FromException(ex);
                 }
-                return FFIException.Ok();
+                return FFIMaybeException.Ok();
             }
 
             internal class StringContainer
@@ -232,7 +232,7 @@ namespace Cassandra
             /// <summary>
             /// This must return a pointer to the appropriate [UnmanagedCallersOnly] FailTask method for the result type R.
             /// This MUST have the following signature:
-            /// unsafe static delegate* unmanaged[Cdecl]&lt;FFIGCHandle tcs, FFIException exception_ptr, void&gt;
+            /// unsafe static delegate* unmanaged[Cdecl]&lt;FFIGCHandle tcs, FFIMaybeException exception_ptr, void&gt;
             /// </summary>
             internal static abstract IntPtr FailTaskDelegate { get; }
         }
@@ -277,13 +277,13 @@ namespace Cassandra
             // This attribute makes the method callable from native code.
             // It also allows taking a function pointer to the method.
             [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-            internal static void FailTask(FFIGCHandle tcsHandle, FFIException exceptionPtr)
+            internal static void FailTask(FFIGCHandle tcsHandle, FFIMaybeException exceptionPtr)
             {
                 Tcb<FFIBool>.FailTask(tcsHandle, exceptionPtr);
             }
 
             internal unsafe readonly static delegate* unmanaged[Cdecl]<FFIGCHandle, FFIBool, void> completeTaskDel = &CompleteTask;
-            internal unsafe readonly static delegate* unmanaged[Cdecl]<FFIGCHandle, FFIException, void> failTaskDel = &FailTask;
+            internal unsafe readonly static delegate* unmanaged[Cdecl]<FFIGCHandle, FFIMaybeException, void> failTaskDel = &FailTask;
 
             static IntPtr IBridgedTaskResult.CompleteTaskDelegate
             {
@@ -347,7 +347,7 @@ namespace Cassandra
             // This attribute makes the method callable from native code.
             // It also allows taking a function pointer to the method.
             [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-            internal static void FailTask(FFIGCHandle tcsHandle, FFIException exceptionPtr)
+            internal static void FailTask(FFIGCHandle tcsHandle, FFIMaybeException exceptionPtr)
             {
                 Tcb<ManuallyDestructible>.FailTask(tcsHandle, exceptionPtr);
             }
@@ -366,7 +366,7 @@ namespace Cassandra
             // Note that we can get this pointer because the method is static and
             // decorated with [UnmanagedCallersOnly].
             internal unsafe readonly static delegate* unmanaged[Cdecl]<FFIGCHandle, ManuallyDestructible, void> completeTaskDel = &CompleteTask;
-            internal unsafe readonly static delegate* unmanaged[Cdecl]<FFIGCHandle, FFIException, void> failTaskDel = &FailTask;
+            internal unsafe readonly static delegate* unmanaged[Cdecl]<FFIGCHandle, FFIMaybeException, void> failTaskDel = &FailTask;
 
             static IntPtr IBridgedTaskResult.CompleteTaskDelegate
             {
@@ -520,7 +520,7 @@ namespace Cassandra
             //
             // This attribute makes the method callable from native code.
             // It also allows taking a function pointer to the method.
-            internal static void FailTask(FFIGCHandle tcsHandle, FFIException exceptionPtr)
+            internal static void FailTask(FFIGCHandle tcsHandle, FFIMaybeException exceptionPtr)
             {
                 try
                 {
@@ -732,28 +732,28 @@ namespace Cassandra
         /// All changes to this struct's fields must be mirrored in Rust code in the exact same order.
         /// </summary>
         [StructLayout(LayoutKind.Sequential)]
-        internal struct FFIException
+        internal struct FFIMaybeException
         {
             // Fields:
             // Pointer to a GCHandle referencing the Exception.
             internal IntPtr exception;
 
             // Functions:
-            // Creates an FFIException from the given Exception.
-            internal static FFIException FromException(Exception ex)
+            // Creates an FFIMaybeException from the given Exception.
+            internal static FFIMaybeException FromException(Exception ex)
             {
                 var handle = GCHandle.Alloc(ex);
                 IntPtr handlePtr = GCHandle.ToIntPtr(handle);
-                return new FFIException
+                return new FFIMaybeException
                 {
                     exception = handlePtr
                 };
             }
 
-            // Creates an FFIException representing no exception.
-            internal static FFIException Ok()
+            // Creates an FFIMaybeException representing no exception.
+            internal static FFIMaybeException Ok()
             {
-                return new FFIException
+                return new FFIMaybeException
                 {
                     exception = IntPtr.Zero
                 };
@@ -763,11 +763,11 @@ namespace Cassandra
         }
 
         /// <summary>
-        /// Throws the exception contained in the FFIException if any.
+        /// Throws the exception contained in the FFIMaybeException if any.
         /// This mustn't be used in UnmanagedCallersOnly methods because throwing exceptions
         /// across FFI boundary is UB.
         /// </summary>
-        internal static void ThrowIfException(ref FFIException res)
+        internal static void ThrowIfException(ref FFIMaybeException res)
         {
             if (res.exception == IntPtr.Zero)
             {
@@ -804,7 +804,7 @@ namespace Cassandra
         /// Frees the exception handle contained in the package without throwing.
         /// Safe to call multiple times; subsequent calls become no-ops.
         /// </summary>
-        internal static void FreeExceptionHandle(ref FFIException res)
+        internal static void FreeExceptionHandle(ref FFIMaybeException res)
         {
             if (res.exception == IntPtr.Zero)
             {

--- a/src/Cassandra/RustBridge/RustBridge.cs
+++ b/src/Cassandra/RustBridge/RustBridge.cs
@@ -225,14 +225,14 @@ namespace Cassandra
             /// <summary>
             /// This must return a pointer to the appropriate [UnmanagedCallersOnly] CompleteTask method for the result type R.
             /// This MUST have the following signature:
-            /// unsafe static delegate* unmanaged[Cdecl]&lt;IntPtr tcs, Self this, void&gt;
+            /// unsafe static delegate* unmanaged[Cdecl]&lt;FFIGCHandle tcs, Self this, void&gt;
             /// </summary>
             internal static abstract IntPtr CompleteTaskDelegate { get; }
 
             /// <summary>
             /// This must return a pointer to the appropriate [UnmanagedCallersOnly] FailTask method for the result type R.
             /// This MUST have the following signature:
-            /// unsafe static delegate* unmanaged[Cdecl]&lt;IntPtr tcs, FFIException exception_ptr, void&gt;
+            /// unsafe static delegate* unmanaged[Cdecl]&lt;FFIGCHandle tcs, FFIException exception_ptr, void&gt;
             /// </summary>
             internal static abstract IntPtr FailTaskDelegate { get; }
         }
@@ -258,32 +258,32 @@ namespace Cassandra
             /// <summary>
             /// This shall be called by Rust code when the operation is completed.
             /// </summary>
-            // Signature in Rust: extern "C" fn(tcs: *mut c_void, res: bool)
+            // Signature in Rust: extern "C" fn(tcs: FFIGCHandle, res: bool)
             //
             // This attribute makes the method callable from native code.
             // It also allows taking a function pointer to the method.
             [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-            internal static void CompleteTask(IntPtr tcsPtr, FFIBool result)
+            internal static void CompleteTask(FFIGCHandle tcsHandle, FFIBool result)
             {
-                Tcb<FFIBool>.CompleteTask(tcsPtr, result);
+                Tcb<FFIBool>.CompleteTask(tcsHandle, result);
             }
 
             /// <summary>
             /// This shall be called by Rust code when the operation failed.
             /// </summary>
             //
-            // Signature in Rust: extern "C" fn(tcs: *mut c_void, exception_handle: ExceptionPtr)
+            // Signature in Rust: extern "C" fn(tcs: FFIGCHandle, exception_handle: ExceptionPtr)
             //
             // This attribute makes the method callable from native code.
             // It also allows taking a function pointer to the method.
             [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-            internal static void FailTask(IntPtr tcsPtr, FFIException exceptionPtr)
+            internal static void FailTask(FFIGCHandle tcsHandle, FFIException exceptionPtr)
             {
-                Tcb<FFIBool>.FailTask(tcsPtr, exceptionPtr);
+                Tcb<FFIBool>.FailTask(tcsHandle, exceptionPtr);
             }
 
-            internal unsafe readonly static delegate* unmanaged[Cdecl]<IntPtr, FFIBool, void> completeTaskDel = &CompleteTask;
-            internal unsafe readonly static delegate* unmanaged[Cdecl]<IntPtr, FFIException, void> failTaskDel = &FailTask;
+            internal unsafe readonly static delegate* unmanaged[Cdecl]<FFIGCHandle, FFIBool, void> completeTaskDel = &CompleteTask;
+            internal unsafe readonly static delegate* unmanaged[Cdecl]<FFIGCHandle, FFIException, void> failTaskDel = &FailTask;
 
             static IntPtr IBridgedTaskResult.CompleteTaskDelegate
             {
@@ -328,28 +328,28 @@ namespace Cassandra
             /// <summary>
             /// This shall be called by Rust code when the operation is completed.
             /// </summary>
-            // Signature in Rust: extern "C" fn(tcs: *mut c_void, res: ManuallyDestructible)
+            // Signature in Rust: extern "C" fn(tcs: FFIGCHandle, res: ManuallyDestructible)
             //
             // This attribute makes the method callable from native code.
             // It also allows taking a function pointer to the method.
             [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-            internal static void CompleteTask(IntPtr tcsPtr, ManuallyDestructible manuallyDestructible)
+            internal static void CompleteTask(FFIGCHandle tcsHandle, ManuallyDestructible manuallyDestructible)
             {
-                Tcb<ManuallyDestructible>.CompleteTask(tcsPtr, manuallyDestructible);
+                Tcb<ManuallyDestructible>.CompleteTask(tcsHandle, manuallyDestructible);
             }
 
             /// <summary>
             /// This shall be called by Rust code when the operation failed.
             /// </summary>
             //
-            // Signature in Rust: extern "C" fn(tcs: *mut c_void, exception_handle: ExceptionPtr)
+            // Signature in Rust: extern "C" fn(tcs: FFIGCHandle, exception_handle: ExceptionPtr)
             //
             // This attribute makes the method callable from native code.
             // It also allows taking a function pointer to the method.
             [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-            internal static void FailTask(IntPtr tcsPtr, FFIException exceptionPtr)
+            internal static void FailTask(FFIGCHandle tcsHandle, FFIException exceptionPtr)
             {
-                Tcb<ManuallyDestructible>.FailTask(tcsPtr, exceptionPtr);
+                Tcb<ManuallyDestructible>.FailTask(tcsHandle, exceptionPtr);
             }
 
 
@@ -365,8 +365,8 @@ namespace Cassandra
             // `unsafe` is required to get a function pointer to a static method.
             // Note that we can get this pointer because the method is static and
             // decorated with [UnmanagedCallersOnly].
-            internal unsafe readonly static delegate* unmanaged[Cdecl]<IntPtr, ManuallyDestructible, void> completeTaskDel = &CompleteTask;
-            internal unsafe readonly static delegate* unmanaged[Cdecl]<IntPtr, FFIException, void> failTaskDel = &FailTask;
+            internal unsafe readonly static delegate* unmanaged[Cdecl]<FFIGCHandle, ManuallyDestructible, void> completeTaskDel = &CompleteTask;
+            internal unsafe readonly static delegate* unmanaged[Cdecl]<FFIGCHandle, FFIException, void> failTaskDel = &FailTask;
 
             static IntPtr IBridgedTaskResult.CompleteTaskDelegate
             {
@@ -407,7 +407,7 @@ namespace Cassandra
             ///  and freed by the C# callback executed by the Rust code once the operation
             ///  is completed (either successfully or with an error).
             /// </summary>
-            internal readonly IntPtr tcs;
+            internal readonly FFIGCHandle tcs;
 
             /// <summary>
             ///  Pointer to the C# method to call when the operation is completed successfully.
@@ -427,7 +427,7 @@ namespace Cassandra
             /// </summary>
             private readonly IntPtr constructors;
 
-            private Tcb(IntPtr tcs, IntPtr completeTask, IntPtr failTask)
+            private Tcb(FFIGCHandle tcs, IntPtr completeTask, IntPtr failTask)
             {
                 this.tcs = tcs;
                 this.complete_task = completeTask;
@@ -455,32 +455,30 @@ namespace Cassandra
                  * We must remember to free the handle later when the TCS is completed (see CompleteTask
                  * method).
                  */
-                var handle = GCHandle.Alloc(tcs);
-
-                IntPtr tcsPtr = GCHandle.ToIntPtr(handle);
+                var tcsHandle = new FFIGCHandle(GCHandle.Alloc(tcs));
 
                 // `unsafe` is required to get a function pointer to a static method.
                 unsafe
                 {
                     IntPtr completeTaskPtr = R.CompleteTaskDelegate;
                     IntPtr failTaskPtr = R.FailTaskDelegate;
-                    return new Tcb<R>(tcsPtr, completeTaskPtr, failTaskPtr);
+                    return new Tcb<R>(tcsHandle, completeTaskPtr, failTaskPtr);
                 }
             }
 
             /// <summary>
             /// This shall be called by Rust code when the operation is completed.
             /// </summary>
-            // Signature in Rust: extern "C" fn(tcs: *mut c_void, res: R)
+            // Signature in Rust: extern "C" fn(tcs: FFIGCHandle, res: R)
             //
             // This attribute makes the method callable from native code.
             // It also allows taking a function pointer to the method.
-            internal static void CompleteTask(IntPtr tcsPtr, R result)
+            internal static void CompleteTask(FFIGCHandle tcsHandle, R result)
             {
                 try
                 {
                     // Recover the GCHandle that was allocated for the TaskCompletionSource.
-                    var handle = GCHandle.FromIntPtr(tcsPtr);
+                    var handle = GCHandle.FromIntPtr(tcsHandle.gchandle);
 
                     try
                     {
@@ -518,16 +516,16 @@ namespace Cassandra
             /// This shall be called by Rust code when the operation failed.
             /// </summary>
             //
-            // Signature in Rust: extern "C" fn(tcs: *mut c_void, exception_handle: ExceptionPtr)
+            // Signature in Rust: extern "C" fn(tcs: FFIGCHandle, exception_handle: ExceptionPtr)
             //
             // This attribute makes the method callable from native code.
             // It also allows taking a function pointer to the method.
-            internal static void FailTask(IntPtr tcsPtr, FFIException exceptionPtr)
+            internal static void FailTask(FFIGCHandle tcsHandle, FFIException exceptionPtr)
             {
                 try
                 {
                     // Recover the GCHandle that was allocated for the TaskCompletionSource.
-                    var handle = GCHandle.FromIntPtr(tcsPtr);
+                    var handle = GCHandle.FromIntPtr(tcsHandle.gchandle);
 
                     try
                     {

--- a/src/Cassandra/RustBridge/RustBridge.cs
+++ b/src/Cassandra/RustBridge/RustBridge.cs
@@ -15,6 +15,91 @@ namespace Cassandra
     static class RustBridge
     {
         /// <summary>
+        /// Struct used to pass a GCHandle along with its destructor function pointer.
+        /// This is used to transfer ownership of GCHandles to Rust code.
+        /// All changes to this struct's fields must be mirrored in Rust code in the exact same order.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        internal readonly struct FFIGCHandle
+        {
+            internal readonly IntPtr gchandle;
+            internal readonly IntPtr free;
+
+            internal FFIGCHandle(GCHandle handle)
+            {
+                gchandle = GCHandle.ToIntPtr(handle);
+                unsafe
+                {
+                    free = (IntPtr)freeGCHandleDel;
+                }
+            }
+
+            internal unsafe readonly static delegate* unmanaged[Cdecl]<IntPtr, void> freeGCHandleDel = &FreeGCHandle;
+
+            [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+            internal static void FreeGCHandle(IntPtr gchandlePtr)
+            {
+                var handle = GCHandle.FromIntPtr(gchandlePtr);
+                if (handle.IsAllocated)
+                {
+                    handle.Free();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Struct used to pass an *optional* GCHandle along with its destructor function pointer.
+        /// This is used to transfer ownership of GCHandles to Rust code.
+        /// All changes to this struct's fields must be mirrored in Rust code in the exact same order.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        internal readonly struct FFIMaybeGCHandle
+        {
+            internal readonly IntPtr gchandle;
+            internal readonly IntPtr free;
+
+            internal FFIMaybeGCHandle(GCHandle handle)
+            {
+                gchandle = GCHandle.ToIntPtr(handle);
+                unsafe
+                {
+                    free = (IntPtr)freeGCHandleDel;
+                }
+            }
+
+            // Intended just for null instantiation using `empty()`.
+            private FFIMaybeGCHandle(IntPtr _gchandle, IntPtr _free)
+            {
+                gchandle = _gchandle;
+                free = _free;
+            }
+
+            static internal FFIMaybeGCHandle Empty()
+            {
+                return new FFIMaybeGCHandle(IntPtr.Zero, IntPtr.Zero);
+            }
+
+            internal bool IsEmpty()
+            {
+                return gchandle == IntPtr.Zero;
+            }
+
+            internal unsafe readonly static delegate* unmanaged[Cdecl]<IntPtr, void> freeGCHandleDel = &FreeGCHandle;
+
+            [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+            internal static void FreeGCHandle(IntPtr gchandlePtr)
+            {
+                var handle = GCHandle.FromIntPtr(gchandlePtr);
+                if (handle.IsAllocated)
+                {
+                    handle.Free();
+                }
+            }
+        }
+
+
+
+        /// <summary>
         /// Represents a UTF-8 string passed over FFI boundary.
         /// Used to pass strings from Rust to C#.
         /// </summary>

--- a/src/Cassandra/RustBridge/RustResource.cs
+++ b/src/Cassandra/RustBridge/RustResource.cs
@@ -5,23 +5,23 @@ using static Cassandra.RustBridge;
 
 namespace Cassandra
 {
-    /// <summary>  
-    /// Base class for Rust-owned native resources managed through <see cref="SafeHandle"/>.  
-    /// </summary>  
-    /// <remarks>  
-    /// <para>  
-    /// This type encapsulates a native pointer returned by Rust together with a corresponding  
-    /// destructor function. The destructor is invoked exactly once from <see cref="ReleaseHandle"/>  
-    /// when the handle is released by the <see cref="SafeHandle"/> infrastructure.  
-    /// </para>  
-    /// <para>  
-    /// Derive from this class for any Rust resource that needs to be lifetime-managed from C#.  
-    /// Implementations must not expose the raw <see cref="SafeHandle.handle"/> to callers except  
-    /// where it is safe to do so, and they must respect the ownership model: once wrapped in  
-    /// <see cref="RustResource"/>, the native pointer must only be freed by the associated  
-    /// destructor.  
-    /// </para>  
-    /// </remarks> 
+    /// <summary>
+    /// Base class for Rust-owned native resources managed through <see cref="SafeHandle"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This type encapsulates a native pointer returned by Rust together with a corresponding
+    /// destructor function. The destructor is invoked exactly once from <see cref="ReleaseHandle"/>
+    /// when the handle is released by the <see cref="SafeHandle"/> infrastructure.
+    /// </para>
+    /// <para>
+    /// Derive from this class for any Rust resource that needs to be lifetime-managed from C#.
+    /// Implementations must not expose the raw <see cref="SafeHandle.handle"/> to callers except
+    /// where it is safe to do so, and they must respect the ownership model: once wrapped in
+    /// <see cref="RustResource"/>, the native pointer must only be freed by the associated
+    /// destructor.
+    /// </para>
+    /// </remarks>
     internal abstract class RustResource : SafeHandle
     {
         private readonly IntPtr _destructor;
@@ -34,13 +34,13 @@ namespace Cassandra
 
         public sealed override bool IsInvalid => handle == IntPtr.Zero;
 
-        /// <summary>  
-        /// Releases the underlying native resource by invoking the Rust-provided destructor.  
-        /// </summary>  
-        /// <remarks>  
-        /// This method is called by the <see cref="SafeHandle"/> finalization and disposal  
-        /// mechanisms. It must not be called directly by user code. 
-        /// </remarks>  
+        /// <summary>
+        /// Releases the underlying native resource by invoking the Rust-provided destructor.
+        /// </summary>
+        /// <remarks>
+        /// This method is called by the <see cref="SafeHandle"/> finalization and disposal
+        /// mechanisms. It must not be called directly by user code.
+        /// </remarks>
         protected sealed override bool ReleaseHandle()
         {
             if (_destructor != IntPtr.Zero && handle != IntPtr.Zero)
@@ -103,14 +103,14 @@ namespace Cassandra
         /// Helper to encapsulate the common pattern for sync native calls with incremented ref count:
         /// DangerousAddRef, invoke native function, finally DangerousRelease.
         /// Using this method ensures that the handle remains valid for the duration of the native call.
-        /// Invoke must be a function that takes an IntPtr (the handle) and returns an FFIException.
+        /// Invoke must be a function that takes an IntPtr (the handle) and returns an FFIMaybeException.
         /// If the exception is not null, it will be thrown.
         /// </summary>
         /// <param name="invoke"></param>
-        internal virtual void RunWithIncrement(Func<IntPtr, RustBridge.FFIException> invoke)
+        internal virtual void RunWithIncrement(Func<IntPtr, RustBridge.FFIMaybeException> invoke)
         {
             bool refAdded = false;
-            RustBridge.FFIException exception;
+            RustBridge.FFIMaybeException exception;
             try
             {
                 DangerousAddRef(ref refAdded);

--- a/src/Cassandra/RustBridge/Serialization/SerializedValues.cs
+++ b/src/Cassandra/RustBridge/Serialization/SerializedValues.cs
@@ -128,13 +128,13 @@ namespace Cassandra
         private static extern void pre_serialized_values_free(IntPtr ptr);
 
         [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
-        private static extern RustBridge.FFIException pre_serialized_values_add_unset(IntPtr valuesPtr, IntPtr constructorsPtr);
+        private static extern RustBridge.FFIMaybeException pre_serialized_values_add_unset(IntPtr valuesPtr, IntPtr constructorsPtr);
 
         [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
-        private static extern RustBridge.FFIException pre_serialized_values_add_null(IntPtr valuesPtr, IntPtr constructorsPtr);
+        private static extern RustBridge.FFIMaybeException pre_serialized_values_add_null(IntPtr valuesPtr, IntPtr constructorsPtr);
 
         [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
-        private static extern RustBridge.FFIException pre_serialized_values_add_value(
+        private static extern RustBridge.FFIMaybeException pre_serialized_values_add_value(
             IntPtr valuesPtr,
             RustBridge.FFISlice<byte> valueSlice,
             IntPtr constructorsPtr);


### PR DESCRIPTION
## Contents

`FFIGCHandle` is a pointer to GCHandle owned by Rust, together with the destructor. This is useful to ensure that GCHandle is freed when Rust-side object is dropped. Mainly employable in async scenarios.

- Without that, we would have to be careful to free GCHandles in C# code after async operations are completed no matter the code path, which is error-prone and can easily lead to memory leaks, especially on error paths.
- With `FFIGCHandle`, we can transfer ownership of GCHandles to Rust, and let Rust's ownership system and RAII take care of freeing them, which is much safer.

We also introduce `FFIMaybeGCHandle`. This is just like `FFIGCHandle`, but may be empty. Will be useful for storing, e.g., exceptions.


### The story how I arrived here (_3 months ago..._)

1. _Add tests for IAsyncEnumerable RowSet._
2. _This needed parsing of non-string addresses in Configuration._
3. _After that, still no luck: tests would hang._
4. _Claude Opus helped by adding debug logs._
5. _It turned out that the problem was in the way we were handling the GCHandle on C# side._
   _GCHandles were freed synchronously, even though the Rust async task was still using the memory._
6. _To fix that, we need to make sure that GCHandles are freed only after the Rust async task is completed._
7. _This is done by introducing a new struct `RustFreeableGCHandle` on both sides, with Drop impl that frees the GCHandle._
   _C# side creates an instance of this struct when it needs to pass a pointer to Rust, and keeps it alive until Rust_
   _is done with the pointer. Once Rust is done, it drops the struct, which in turn frees the GCHandle._
8. _Then I found out that our FFI abstractions are scattered around: ffi.rs, lib.rs, and strange files by phalat24._
   _So, moving them all to ffi.rs makes sense._
9. _...years later..._



## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
