### PR TITLE
Remove obsolete Bind and BindObjects API from SimpleStatement

### DIFF
--- a/docs/source/migration-guide/index.md
+++ b/docs/source/migration-guide/index.md
@@ -131,3 +131,9 @@ public SocketOptions SetReadTimeoutMillis(int milliseconds)
 The underlying Rust driver only supports a global, session-level request timeout configured at session creation time. It does not expose a mechanism for per-attempt timeouts. As a result, the value set through `SetReadTimeoutMillis` is accepted by the API but currently has no effect.
 
 **Migration Impact:** Remove any calls to `SetReadTimeoutMillis`. Once the Rust driver gains support for per-attempt timeouts, this option will usable again.
+
+## SimpleStatement API
+
+### Removed APIs
+
+Removed `Bind` / `BindObjects` methods from `SimpleStatement`. These methods have been marked as obsolete in the original C# driver for a while. To set values for a `SimpleStatement`, one should pass them as parameters to the constructor. Generally, the recommended approach is to use `PreparedStatement` for queries with parameters, which provides better performance and security.

--- a/src/Cassandra/SimpleStatement.cs
+++ b/src/Cassandra/SimpleStatement.cs
@@ -204,29 +204,6 @@ namespace Cassandra
         }
 
         /// <summary>
-        /// Sets the parameter values for the query.
-        /// <para>
-        /// The same amount of values must be provided as parameter markers in the query.
-        /// </para>
-        /// <para>
-        /// Specify the parameter values by the position of the markers in the query or by name, 
-        /// using a single instance of an anonymous type, with property names as parameter names.
-        /// </para>
-        /// </summary>
-        [Obsolete("The method Bind() is deprecated, use SimpleStatement constructor parameters to provide query values")]
-        public SimpleStatement Bind(params object[] values)
-        {
-            SetValues(values, Serializer);
-            return this;
-        }
-
-        [Obsolete("The method BindObject() is deprecated, use SimpleStatement constructor parameters to provide query values")]
-        public SimpleStatement BindObjects(object[] values)
-        {
-            return Bind(values);
-        }
-
-        /// <summary>
         /// Sets the keyspace this Statement operates on. The keyspace should only be set when the
         /// <see cref="IStatement"/> applies to a different keyspace to the logged keyspace of the
         /// <see cref="ISession"/>.


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~

Both `SimpleStatement.Bind` and `SimpleStatement.BindObjects` are marked as obsolete. This PR removes them from the class and mentions the change in the migration guide.