### PR TITLE
automate building rust and symlink 

### DIFF
--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -47,4 +47,34 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="9.0.13" />
   </ItemGroup>
+
+  <Target Name="BuildRustNativeWrapperDebug"
+          BeforeTargets="Build"
+      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Debug' and '$(IsCrossTargetingBuild)' == 'true'">
+    <PropertyGroup>
+      <RepoRootDir>$(MSBuildThisFileDirectory)../..</RepoRootDir>
+    </PropertyGroup>
+
+    <Exec WorkingDirectory="$(RepoRootDir)" Command="make build-rust" />
+  </Target>
+
+  <Target Name="BuildRustNativeWrapperRelease"
+          BeforeTargets="Build"
+      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Release' and '$(IsCrossTargetingBuild)' == 'true'">
+    <PropertyGroup>
+      <RustProjectDir>$(MSBuildThisFileDirectory)../../rust</RustProjectDir>
+    </PropertyGroup>
+
+    <Exec WorkingDirectory="$(RustProjectDir)" Command="cargo build --release" />
+  </Target>
+
+  <Target Name="LinkRustNativeWrapperDebug"
+          AfterTargets="Build"
+      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Debug' and '$(IsCrossTargetingBuild)' == 'true'">
+    <PropertyGroup>
+      <RepoRootDir>$(MSBuildThisFileDirectory)../..</RepoRootDir>
+    </PropertyGroup>
+
+    <Exec WorkingDirectory="$(RepoRootDir)" Command="make create-rust-lib-symlinks" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~

## Motivations
I wasted an unreasonable amount of time debugging something only to find out I forgot to build the rust library before running the C# project. 

## What's happening
When `dotnet build` is run the rust library is built in either debug or release mode specified by the flag in `dotnet build`. This allows us to avoid wasting time on debugging non existing problems.