### PR TITLE
Remove SetLwt API from PreparedStatement and BoundStatement

### DIFF
--- a/docs/source/migration-guide/index.md
+++ b/docs/source/migration-guide/index.md
@@ -137,3 +137,15 @@ The underlying Rust driver only supports a global, session-level request timeout
 ### Removed APIs
 
 Removed `Bind` / `BindObjects` methods from `SimpleStatement`. These methods have been marked as obsolete in the original C# driver for a while. To set values for a `SimpleStatement`, one should pass them as parameters to the constructor. Generally, the recommended approach is to use `PreparedStatement` for queries with parameters, which provides better performance and security.
+
+## PreparedStatement API
+
+### Removed APIs
+
+Removed `SetLwt` method from `PreparedStatement`. It was mistakenly added to the public API in the original C# driver, but it was never intended to be used for any purpose.
+
+## BoundStatement API
+
+### Removed APIs
+
+Removed `SetLwt` method from `BoundStatement`. It was mistakenly added to the public API in the original C# driver, but it was never intended to be used for any purpose.

--- a/src/Cassandra/BoundStatement.cs
+++ b/src/Cassandra/BoundStatement.cs
@@ -82,12 +82,6 @@ namespace Cassandra
             return _preparedStatement.IsLwt;
         }
 
-        public BoundStatement SetLwt(bool isLwt)
-        {
-            _preparedStatement.SetLwt(isLwt);
-            return this;
-        }
-
         /// <summary>
         /// Initializes a new instance of the Cassandra.BoundStatement class
         /// </summary>

--- a/src/Cassandra/PreparedStatement.cs
+++ b/src/Cassandra/PreparedStatement.cs
@@ -287,12 +287,6 @@ namespace Cassandra
             return this;
         }
 
-        public PreparedStatement SetLwt(bool isLwt)
-        {
-            _isLwt = isLwt;
-            return this;
-        }
-
         /// <summary>
         /// Returns the string of the query that was prepared to yield this PreparedStatement.
         /// </summary>


### PR DESCRIPTION
Remove SetLwt API from PreparedStatement and BoundStatement. Update the migration guide with the new API change.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- [x] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
