### PR TITLE
Fix SafeHandle lifetime race in session shutdown and dispose temporary cluster-state handles

### DIFF
--- a/src/Cassandra/Metadata.cs
+++ b/src/Cassandra/Metadata.cs
@@ -249,7 +249,7 @@ namespace Cassandra
             try
             {
                 var clusterState = session.GetClusterState();
-                return clusterState.GetKeyspaceMetadata(clusterState, keyspace);
+                return clusterState.GetKeyspaceMetadata(keyspace);
             }
             finally
             {
@@ -267,7 +267,10 @@ namespace Cassandra
             var session = _getActiveSessionOrThrow();
             try
             {
-                return session.GetClusterState().GetKeyspaceNames();
+                using (var clusterState = session.GetClusterState())
+                {
+                    return clusterState.GetKeyspaceNames();
+                }
             }
             finally
             {
@@ -288,7 +291,10 @@ namespace Cassandra
             var session = _getActiveSessionOrThrow();
             try
             {
-                return session.GetClusterState().GetTableNames(keyspace);
+                using (var clusterState = session.GetClusterState())
+                {
+                    return clusterState.GetTableNames(keyspace);
+                }
             }
             finally
             {
@@ -308,7 +314,10 @@ namespace Cassandra
             var session = _getActiveSessionOrThrow();
             try
             {
-                return session.GetClusterState().GetTableMetadata(keyspace, tableName);
+                using (var clusterState = session.GetClusterState())
+                {
+                    return clusterState.GetTableMetadata(keyspace, tableName);
+                }
             }
             finally
             {
@@ -334,13 +343,12 @@ namespace Cassandra
         public UdtColumnInfo GetUdtDefinition(string keyspace, string typeName)
         {
             var session = _getActiveSessionOrThrow();
-            BridgedClusterState clusterState;
             try
             {
-                clusterState = session.GetClusterState();
-                var result = clusterState.GetUdtMetadata(keyspace, typeName);
-                clusterState.Dispose();
-                return result;
+                using (var clusterState = session.GetClusterState())
+                {
+                    return clusterState.GetUdtMetadata(keyspace, typeName);
+                }
             }
             finally
             {

--- a/src/Cassandra/RustBridge/BridgedClusterState.cs
+++ b/src/Cassandra/RustBridge/BridgedClusterState.cs
@@ -219,9 +219,9 @@ namespace Cassandra
             return FFIMaybeException.Ok();
         }
 
-        internal KeyspaceMetadata GetKeyspaceMetadata(BridgedClusterState clusterState, string keyspaceName)
+        internal KeyspaceMetadata GetKeyspaceMetadata(string keyspaceName)
         {
-            var ksmd = new KeyspaceMetadata(clusterState, keyspaceName);
+            var ksmd = new KeyspaceMetadata(this, keyspaceName);
             var replicationOptions = new Dictionary<string, string>();
             var addRepFactorCallbacks = new StrategyAddRepFactorCallbacks();
             try

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -97,10 +97,7 @@ namespace Cassandra
         /// </summary>
         internal Task<ManuallyDestructible> Shutdown()
         {
-            TaskCompletionSource<ManuallyDestructible> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            var tcb = Tcb<ManuallyDestructible>.WithTcs(tcs);
-            session_shutdown(tcb, handle);
-            return tcs.Task;
+            return RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) => session_shutdown(tcb, ptr));
         }
 
         /// <summary>


### PR DESCRIPTION
## Shutdown safety
Updated session shutdown to use the same ref-counted async path as other session operations. This prevents a race where the native handle could be invalidated between read and P/Invoke during concurrent dispose/finalization.

## Cluster-state disposal in metadata calls
Added deterministic disposal for temporary cluster-state instances in metadata APIs (`GetKeyspaces`, `GetTables`, `GetTable`, `GetUdtDefinition`). This avoids relying on nondeterministic GC/finalization.

Minor cleanup to remove redundant self-passing of cluster state in keyspace metadata retrieval.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
