### PR TITLE
Remove Session from Cluster's list on Shutdown

### DIFF
--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -267,6 +267,11 @@ namespace Cassandra
             return Metadata.RefreshSchemaAsync(keyspace, table);
         }
 
+        internal void RemoveSession(ISession session)
+        {
+            _connectedSessions.Remove(session);
+        }
+
         /// <inheritdoc />
         public void Shutdown(int timeoutMs = Timeout.Infinite)
         {

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -171,8 +171,10 @@ namespace Cassandra
                 return;
             }
 
-            // FIXME: Actually perform shutdown.
-            // Remember to dequeue from Cluster's sessions list.
+            if (_cluster is Cluster cluster)
+            {
+                cluster.RemoveSession(this);
+            }
 
             // First, we shutdown the session in Rust - this acquires a write lock,
             // waits for all ongoing queries to complete, and blocks future queries.


### PR DESCRIPTION
When shutting down a Session, remove it from Cluster's _connectedSessions list.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
