### PR TITLE
Bridge Load Balancing Policies

### DIFF
--- a/docs/source/migration-guide/index.md
+++ b/docs/source/migration-guide/index.md
@@ -190,3 +190,25 @@ After:
 - Warning: `Rust: MM/dd/yyyy H:mm:ss.fff zzz WARNING [csharp_wrapper::logging] This is a warning message`
 - Info: `Rust: MM/dd/yyyy H:mm:ss.fff zzz INFO [csharp_wrapper::logging] This is an info message`
 - Verbose: `Rust: MM/dd/yyyy H:mm:ss.fff zzz VERBOSE [csharp_wrapper::logging] This is a verbose message`
+
+## Load Balancing Policies
+
+### DefaultLoadBalancingPolicy
+- DC-awareness-by-default, with the DC of the contact point as the local DC, was removed. Now, if the user does not specify a load balancing policy when building the `Cluster`, the driver will be DC unaware, treating all nodes equally.
+
+### DCAwareRoundRobinPolicy
+- The local DC detection mechanism was fully removed. Now the local DC must be specified in the constructor.
+
+- `usedHostsPerRemoteDc` field is not supported anymore. There is a new boolean property `PermitDcFailover`. Setting it to true permits the driver to query nodes from remote DCs. Nodes from the local DC are always tried first.
+
+- This policy no longer uses a round-robin algorithm.
+The nodes are chosen at random, from the nodes from the local 
+DC (and after that, from remote DCs, if `PermitDcFailover` is enabled), exactly like in the Rust driver.
+
+### RoundRobinPolicy
+- This policy no longer uses a round-robin algorithm.
+The nodes are chosen at random, exactly like in the Rust driver.
+
+### NewQueryPlan()
+All the `NewQueryPlan` methods in the policy classes are no longer supported, since all query routing is handled by the Rust driver.
+

--- a/rust/src/error_conversion.rs
+++ b/rust/src/error_conversion.rs
@@ -180,6 +180,17 @@ impl AlreadyShutdownExceptionConstructor {
     }
 }
 
+/// FFI constructor for C# `System.ArgumentException`.
+#[repr(transparent)]
+pub struct ArgumentExceptionConstructor(unsafe extern "C" fn(message: FFIStr<'_>) -> FFIException);
+
+impl ArgumentExceptionConstructor {
+    pub(crate) fn construct_from_rust(&self, message: &str) -> FFIException {
+        let message = FFIStr::new(message);
+        unsafe { (self.0)(message) }
+    }
+}
+
 /// FFI constructor for C# `SyntaxErrorException`.
 #[repr(transparent)]
 pub struct SyntaxErrorExceptionConstructor(

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -104,6 +104,68 @@ pub extern "C" fn session_create(tcb: Tcb<ManuallyDestructible>, config: Bridged
     })
 }
 
+/// Validates that `local_dc` matches the datacenter of at least one node in the cluster
+/// reachable through `session`. Raises a `System.ArgumentException` (listing the available
+/// datacenters) when it does not.
+/// Called from C# right after session creation.
+#[unsafe(no_mangle)]
+pub extern "C" fn session_check_local_dc_existence(
+    session_ptr: BridgedBorrowedSharedPtr<'_, BridgedSession>,
+    local_dc: CSharpStr<'_>,
+    constructors: &'static ExceptionConstructors,
+) -> FFIMaybeException {
+    let session_arc =
+        ArcFFI::as_ref(session_ptr).expect("valid and non-null BridgedSession pointer");
+
+    // Try to acquire an owned read lock.
+    // If the operation fails, treat it as session shutting down.
+    let Ok(session_guard) = session_arc.try_read() else {
+        // Session is currently shutting down.
+        let ex = constructors
+            .already_shutdown_exception_constructor
+            .construct_from_rust("Session has been shut down and can no longer execute operations");
+        return FFIMaybeException::from_exception(ex);
+    };
+
+    // Check if session is connected or if it has been shut down.
+    // If it has been shut down, return appropriate error.
+    let Some(session) = session_guard.session.as_ref() else {
+        let ex = constructors
+            .already_shutdown_exception_constructor
+            .construct_from_rust("Session has been shut down and can no longer execute operations");
+        return FFIMaybeException::from_exception(ex);
+    };
+
+    let local_dc = local_dc.as_cstr().unwrap().to_str().unwrap();
+
+    let cluster_state = session.get_cluster_state();
+
+    if cluster_state
+        .get_nodes_info()
+        .iter()
+        .any(|node| node.datacenter.as_deref() == Some(local_dc))
+    {
+        return FFIMaybeException::ok();
+    }
+
+    // No node matches: build the list of available datacenters and put it in the message.
+    let mut available_dcs: Vec<String> = cluster_state
+        .get_nodes_info()
+        .iter()
+        .filter_map(|node| node.datacenter.clone())
+        .collect();
+    available_dcs.sort_unstable();
+    available_dcs.dedup();
+
+    let ex = constructors
+        .argument_exception_constructor
+        .construct_from_rust(&format!(
+            "Datacenter {local_dc} does not match any of the nodes, available datacenters: {}.",
+            available_dcs.join(", ")
+        ));
+    FFIMaybeException::from_exception(ex)
+}
+
 /// Shuts down the session by acquiring a write lock and clearing the connected state.
 /// This blocks all future queries. Once shutdown, the session cannot be used for queries anymore.
 #[unsafe(no_mangle)]

--- a/rust/src/session_config.rs
+++ b/rust/src/session_config.rs
@@ -3,7 +3,10 @@ use std::time::Duration;
 use crate::ffi::CSharpStr;
 
 use scylla::client::SelfIdentity;
-use scylla::client::session_builder::SessionBuilder;
+use scylla::{
+    client::{execution_profile::ExecutionProfile, session_builder::SessionBuilder},
+    policies::load_balancing::DefaultPolicy,
+};
 
 const DEFAULT_DRIVER_NAME: &str = "ScyllaDB C# RS Driver";
 const DEFAULT_DRIVER_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -65,6 +68,38 @@ impl BridgedTcpConfig {
     }
 }
 
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct BridgedLoadBalancingPolicy<'a> {
+    is_token_aware: bool,
+    permit_dc_failover: bool,
+    local_dc: CSharpStr<'a>,
+}
+
+impl<'a> BridgedLoadBalancingPolicy<'a> {
+    /// Returns the configured builder
+    pub(crate) fn apply_to_builder(self, builder: SessionBuilder) -> SessionBuilder {
+        let local_dc = self
+            .local_dc
+            .as_cstr()
+            .map(|cstr| cstr.to_str().unwrap().to_owned());
+
+        let mut lbpbuilder = DefaultPolicy::builder()
+            .token_aware(self.is_token_aware)
+            .permit_dc_failover(self.permit_dc_failover);
+
+        if let Some(preferred_dc) = local_dc {
+            lbpbuilder = lbpbuilder.prefer_datacenter(preferred_dc);
+        }
+
+        let profile_handle = ExecutionProfile::builder()
+            .load_balancing_policy(lbpbuilder.build())
+            .build()
+            .into_handle();
+
+        builder.default_execution_profile_handle(profile_handle)
+    }
+}
 /// Output of [`BridgedSessionConfig::into_session_builder`]: a fully-configured
 /// [`SessionBuilder`] together with the URI and keyspace it was built from,
 /// borrowed directly from the C#-managed config memory.
@@ -93,6 +128,8 @@ pub(crate) struct BridgedSessionConfig<'a> {
 
     /// TCP socket options.
     tcp: BridgedTcpConfig,
+
+    load_balancing_policy: BridgedLoadBalancingPolicy<'a>,
 }
 
 impl<'a> BridgedSessionConfig<'a> {
@@ -120,6 +157,7 @@ impl<'a> BridgedSessionConfig<'a> {
         }
 
         builder = self.tcp.apply_to_builder(builder);
+        builder = self.load_balancing_policy.apply_to_builder(builder);
 
         let identity = SelfIdentity::new()
             .with_custom_driver_name(DEFAULT_DRIVER_NAME)

--- a/rust/src/task.rs
+++ b/rust/src/task.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, LazyLock};
 use tokio::runtime::Runtime;
 
 use crate::error_conversion::{
-    AlreadyExistsConstructor, AlreadyShutdownExceptionConstructor,
+    AlreadyExistsConstructor, AlreadyShutdownExceptionConstructor, ArgumentExceptionConstructor,
     DeserializationExceptionConstructor, ErrorToException, FFIException,
     FunctionFailureExceptionConstructor, InvalidArgumentExceptionConstructor,
     InvalidConfigurationInQueryExceptionConstructor, InvalidQueryConstructor,
@@ -145,6 +145,7 @@ pub struct Tcb<R> {
 pub struct ExceptionConstructors {
     pub already_exists_constructor: AlreadyExistsConstructor,
     pub already_shutdown_exception_constructor: AlreadyShutdownExceptionConstructor,
+    pub argument_exception_constructor: ArgumentExceptionConstructor,
     pub deserialization_exception_constructor: DeserializationExceptionConstructor,
     pub function_failure_exception_constructor: FunctionFailureExceptionConstructor,
     pub invalid_argument_exception_constructor: InvalidArgumentExceptionConstructor,

--- a/src/Cassandra.BrokenIntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
+++ b/src/Cassandra.BrokenIntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
@@ -37,25 +37,6 @@ namespace Cassandra.IntegrationTests.Policies.Tests
         public LoadBalancingPolicyShortTests() : base(3, false, new TestClusterOptions { UseVNodes = true })
         {
         }
-
-        /// <summary>
-        /// Validate that two sessions connected to the same DC use separate Policy instances
-        /// </summary>
-        [Test]
-        public void TwoSessionsConnectedToSameDcUseSeparatePolicyInstances()
-        {
-            var builder = ClusterBuilder();
-
-            using (var cluster1 = builder.WithConnectionString($"Contact Points={TestCluster.ClusterIpPrefix}1").Build())
-            using (var cluster2 = builder.WithConnectionString($"Contact Points={TestCluster.ClusterIpPrefix}2").Build())
-            {
-                var session1 = (Session)cluster1.Connect();
-                var session2 = (Session)cluster2.Connect();
-                Assert.AreNotSame(session1.Policies.LoadBalancingPolicy, session2.Policies.LoadBalancingPolicy, "Load balancing policy instances should be different");
-                Assert.AreNotSame(session1.Policies.ReconnectionPolicy, session2.Policies.ReconnectionPolicy, "Reconnection policy instances should be different");
-                Assert.AreNotSame(session1.Policies.RetryPolicy, session2.Policies.RetryPolicy, "Retry policy instances should be different");
-            }
-        }
         /// <summary>
         /// Validate that no hops occur when inserting into a single partition
         ///

--- a/src/Cassandra.IntegrationTests/Policies/LoadBalancingPolicyShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Policies/LoadBalancingPolicyShortTests.cs
@@ -1,0 +1,301 @@
+//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using Cassandra.IntegrationTests.TestBase;
+using Cassandra.IntegrationTests.TestClusterManagement;
+using Cassandra.Serialization;
+using Cassandra.Tests;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+using CollectionAssert = NUnit.Framework.Legacy.CollectionAssert;
+
+namespace Cassandra.IntegrationTests.Policies.Tests
+{
+    [TestFixture, Category(TestCategory.Short), Category(TestCategory.RealCluster), Order(1)]
+    public class LoadBalancingPolicyShortTests : SharedClusterTest
+    {
+        public LoadBalancingPolicyShortTests() : base(3, false, new TestClusterOptions { UseVNodes = true })
+        {
+        }
+
+        /// <summary>
+        /// Validate that two sessions connected to the same DC use separate Policy instances
+        /// </summary>
+        [Test]
+        public void TwoSessionsConnectedToSameDcUseSeparatePolicyInstances()
+        {
+            var builder = ClusterBuilder();
+
+            using (var cluster1 = builder.WithConnectionString($"Contact Points={TestCluster.ClusterIpPrefix}1").Build())
+            using (var cluster2 = builder.WithConnectionString($"Contact Points={TestCluster.ClusterIpPrefix}2").Build())
+            {
+                var session1 = (Session)cluster1.Connect();
+                var session2 = (Session)cluster2.Connect();
+                Assert.AreNotSame(session1.Policies.LoadBalancingPolicy, session2.Policies.LoadBalancingPolicy, "Load balancing policy instances should be different");
+                Assert.AreNotSame(session1.Policies.ReconnectionPolicy, session2.Policies.ReconnectionPolicy, "Reconnection policy instances should be different");
+                Assert.AreNotSame(session1.Policies.RetryPolicy, session2.Policies.RetryPolicy, "Retry policy instances should be different");
+            }
+        }
+
+        /// <summary>
+        /// With RF=2 and a fixed prepared-statement key, the Rust driver rotates between
+        /// both replicas (<c>maybe_shuffled_replicas</c> in the Rust LBP). The test confirms
+        /// the driver routes only to replicas — not all 3 nodes — by asserting exactly 2
+        /// distinct coordinators appear across many executions.
+        /// <para>
+        /// Note: this test cannot verify that those 2 coordinators are the <em>correct</em>
+        /// replicas for this token; that requires <c>GetReplicas</c>, which is not yet implemented.
+        /// </para>
+        /// </summary>
+        [Test]
+        public void TokenAware_RF2_BothReplicasUsedAsCoordinators()
+        {
+            var cluster = GetNewTemporaryCluster(b => b.WithLoadBalancingPolicy(new TokenAwarePolicy(new RoundRobinPolicy())));
+            var session = cluster.Connect();
+            var ks = TestUtils.GetUniqueKeyspaceName().ToLowerInvariant();
+            session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 2}}");
+            session.ChangeKeyspace(ks);
+            session.Execute("CREATE TABLE tbl (k int PRIMARY KEY, v int)");
+
+            // Use a fixed key so every execution targets the same token and the same replica set
+            var ps = session.Prepare("SELECT v FROM tbl WHERE k = ?");
+            var coordinators = new HashSet<IPEndPoint>();
+            for (var i = 0; i < 30; i++)
+            {
+                var rs = session.Execute(ps.Bind(42));
+                coordinators.Add(rs.Info.QueriedHost);
+            }
+            // With RF=2 on a 3-node cluster, token-aware routing must use exactly 2 coordinators.
+            // If routing were random (not token-aware) we would see all 3; if broken we would see 1.
+            Assert.AreEqual(2, coordinators.Count,
+                "With RF=2 and token-aware routing, all queries for the same key must go to exactly the 2 owning replicas");
+        }
+
+        /// <summary>
+        /// With RF=1, every partition key has exactly one replica, so a token-aware
+        /// policy must always route the same key to the same coordinator.
+        /// </summary>
+        [Test]
+        public void TokenAware_SameKey_AlwaysSameCoordinator()
+        {
+            var cluster = GetNewTemporaryCluster(b => b.WithLoadBalancingPolicy(new TokenAwarePolicy(new RoundRobinPolicy())));
+            var session = cluster.Connect();
+            var ks = TestUtils.GetUniqueKeyspaceName().ToLowerInvariant();
+            session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 1}}");
+            session.ChangeKeyspace(ks);
+            session.Execute("CREATE TABLE tbl (k int PRIMARY KEY, v int)");
+            session.Execute("INSERT INTO tbl (k, v) VALUES (42, 1)");
+
+            var ps = session.Prepare("SELECT v FROM tbl WHERE k = ?");
+            var coordinators = new HashSet<IPEndPoint>();
+            for (var i = 0; i < 10; i++)
+            {
+                var rs = session.Execute(ps.Bind(42));
+                coordinators.Add(rs.Info.QueriedHost);
+            }
+            Assert.AreEqual(1, coordinators.Count, "With RF=1, the same partition key must always route to the same coordinator");
+        }
+
+        /// <summary>
+        /// With RF=1 and 3 nodes, 100 distinct partition keys should be distributed
+        /// across more than one coordinator.
+        /// </summary>
+        [Test]
+        public void TokenAware_DifferentKeys_MultipleCoordinators()
+        {
+            var cluster = GetNewTemporaryCluster(b => b.WithLoadBalancingPolicy(new TokenAwarePolicy(new RoundRobinPolicy())));
+            var session = cluster.Connect();
+            var ks = TestUtils.GetUniqueKeyspaceName().ToLowerInvariant();
+            session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 1}}");
+            session.ChangeKeyspace(ks);
+            session.Execute("CREATE TABLE tbl (k int PRIMARY KEY, v int)");
+            var ps = session.Prepare("INSERT INTO tbl (k, v) VALUES (?, ?)");
+            for (var i = 0; i < 100; i++)
+                session.Execute(ps.Bind(i, i));
+
+            var selectPs = session.Prepare("SELECT v FROM tbl WHERE k = ?");
+            var coordinators = new HashSet<IPEndPoint>();
+            for (var i = 0; i < 100; i++)
+            {
+                var rs = session.Execute(selectPs.Bind(i));
+                coordinators.Add(rs.Info.QueriedHost);
+            }
+            Assert.Greater(coordinators.Count, 1, "100 distinct partition keys across 3 nodes should use multiple coordinators");
+        }
+
+        /// <summary>
+        /// Validate that DCAwareRoundRobinPolicy with the correct datacenter allows queries to succeed.
+        /// Tests that the DC-aware config is correctly translated to the Rust layer.
+        /// </summary>
+        [Test]
+        public void DcAware_CorrectDc_QueriesSucceed()
+        {
+            var cluster = GetNewTemporaryCluster(b => b.WithLoadBalancingPolicy(new DCAwareRoundRobinPolicy("datacenter1")));
+            var session = cluster.Connect();
+            var ks = TestUtils.GetUniqueKeyspaceName().ToLowerInvariant();
+            session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 1}}");
+            session.ChangeKeyspace(ks);
+            session.Execute("CREATE TABLE tbl (k int PRIMARY KEY, v int)");
+            session.Execute("INSERT INTO tbl (k, v) VALUES (1, 42)");
+            var rs = session.Execute("SELECT v FROM tbl WHERE k = 1");
+            Assert.AreEqual(42, rs.First().GetValue<int>("v"));
+        }
+
+        [Test]
+        public void DcAware_ParameterlessConstructor_Throws()
+        {
+#pragma warning disable 618
+            NUnit.Framework.Assert.Throws<ArgumentException>(() => new DCAwareRoundRobinPolicy());
+#pragma warning restore 618
+        }
+
+        [Test]
+        public void DcAware_PermitDcFailover_QueriesSucceed()
+        {
+            var cluster = GetNewTemporaryCluster(b => b.WithLoadBalancingPolicy(new DCAwareRoundRobinPolicy("datacenter1", permitDcFailover: true)));
+            var session = cluster.Connect();
+            var ks = TestUtils.GetUniqueKeyspaceName().ToLowerInvariant();
+            session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 1}}");
+            session.ChangeKeyspace(ks);
+            session.Execute("CREATE TABLE tbl (k int PRIMARY KEY, v int)");
+            session.Execute("INSERT INTO tbl (k, v) VALUES (1, 42)");
+            var rs = session.Execute("SELECT v FROM tbl WHERE k = 1");
+            Assert.AreEqual(42, rs.First().GetValue<int>("v"));
+        }
+
+        [Test]
+        public void DcAware_WrongDc_Throws()
+        {
+            NUnit.Framework.Assert.Throws<ArgumentException>(() =>
+            {
+                var cluster = GetNewTemporaryCluster(b => b.WithLoadBalancingPolicy(new DCAwareRoundRobinPolicy("nonexistent_dc")));
+                cluster.Connect();
+            });
+        }
+
+        /// <summary>
+        /// Validate that TokenAwarePolicy wrapping RoundRobinPolicy allows queries to succeed.
+        /// Tests that token-aware config is correctly translated to the Rust layer.
+        /// </summary>
+        [Test]
+        public void TokenAware_RoundRobin_QueriesSucceed()
+        {
+            var cluster = GetNewTemporaryCluster(b => b.WithLoadBalancingPolicy(new TokenAwarePolicy(new RoundRobinPolicy())));
+            var session = cluster.Connect();
+            var ks = TestUtils.GetUniqueKeyspaceName().ToLowerInvariant();
+            session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 1}}");
+            session.ChangeKeyspace(ks);
+            session.Execute("CREATE TABLE tbl (k int PRIMARY KEY, v int)");
+            for (var i = 0; i < 5; i++)
+                session.Execute($"INSERT INTO tbl (k, v) VALUES ({i}, {i * 10})");
+            var count = session.Execute("SELECT COUNT(*) FROM tbl").First().GetValue<long>(0);
+            Assert.AreEqual(5, count);
+        }
+
+        /// <summary>
+        /// Validate that an explicit RoundRobinPolicy allows queries to succeed.
+        /// Tests that the round-robin config is correctly translated to the Rust layer.
+        /// </summary>
+        [Test]
+        public void RoundRobin_QueriesSucceed()
+        {
+            var cluster = GetNewTemporaryCluster(b => b.WithLoadBalancingPolicy(new RoundRobinPolicy()));
+            var session = cluster.Connect();
+            var ks = TestUtils.GetUniqueKeyspaceName().ToLowerInvariant();
+            session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 1}}");
+            session.ChangeKeyspace(ks);
+            session.Execute("CREATE TABLE tbl (k int PRIMARY KEY, v int)");
+            for (var i = 0; i < 5; i++)
+                session.Execute($"INSERT INTO tbl (k, v) VALUES ({i}, {i * 10})");
+            var count = session.Execute("SELECT COUNT(*) FROM tbl").First().GetValue<long>(0);
+            Assert.AreEqual(5, count);
+        }
+    }
+
+    /// <summary>
+    /// DC-aware and token-aware + DC-aware load balancing tests.
+    /// Uses a separate 2-DC cluster (1 node per DC) and must run after
+    /// <see cref="LoadBalancingPolicyShortTests"/> to avoid destroying its shared cluster.
+    /// </summary>
+    [TestFixture, Category(TestCategory.Short), Category(TestCategory.RealCluster), Order(2)]
+    public class LoadBalancingPolicyMultiDcTests : SharedClusterTest
+    {
+        public LoadBalancingPolicyMultiDcTests()
+            : base(1, false, new TestClusterOptions { Dc2NodeLength = 1 }) { }
+
+        /// <summary>
+        /// With a 2-DC cluster, DCAwareRoundRobinPolicy should route all queries to
+        /// the local DC while it is available.
+        /// </summary>
+        [Test]
+        public void DcAware_AllQueriesGoToLocalDc()
+        {
+            var localDcNode = TestCluster.ClusterIpPrefix + "1";
+            var cluster = GetNewTemporaryCluster(b => b.WithLoadBalancingPolicy(new DCAwareRoundRobinPolicy("dc1")));
+            var session = cluster.Connect();
+            var ks = TestUtils.GetUniqueKeyspaceName().ToLowerInvariant();
+            session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 1}}");
+            session.ChangeKeyspace(ks);
+            session.Execute("CREATE TABLE tbl (k int PRIMARY KEY, v int)");
+            session.Execute("INSERT INTO tbl (k, v) VALUES (1, 42)");
+
+            var coordinators = new HashSet<IPEndPoint>();
+            for (var i = 0; i < 20; i++)
+            {
+                var rs = session.Execute("SELECT v FROM tbl WHERE k = 1");
+                coordinators.Add(rs.Info.QueriedHost);
+            }
+            Assert.IsTrue(
+                coordinators.All(ep => ep.Address.ToString() == localDcNode),
+                $"All queries should go to the local DC node ({localDcNode}), but got: {string.Join(", ", coordinators)}");
+        }
+
+        /// <summary>
+        /// With a 2-DC cluster, TokenAwarePolicy wrapping DCAwareRoundRobinPolicy should
+        /// keep all coordinators inside the local DC.
+        /// </summary>
+        [Test]
+        public void TokenAware_DcAware_CoordinatorsStayInLocalDc()
+        {
+            var localDcNode = TestCluster.ClusterIpPrefix + "1";
+            var cluster = GetNewTemporaryCluster(b => b.WithLoadBalancingPolicy(new TokenAwarePolicy(new DCAwareRoundRobinPolicy("dc1"))));
+            var session = cluster.Connect();
+            var ks = TestUtils.GetUniqueKeyspaceName().ToLowerInvariant();
+            session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 1}}");
+            session.ChangeKeyspace(ks);
+            session.Execute("CREATE TABLE tbl (k int PRIMARY KEY, v int)");
+            var ps = session.Prepare("INSERT INTO tbl (k, v) VALUES (?, ?)");
+            for (var i = 0; i < 20; i++)
+                session.Execute(ps.Bind(i, i));
+
+            var selectPs = session.Prepare("SELECT v FROM tbl WHERE k = ?");
+            var coordinators = new HashSet<IPEndPoint>();
+            for (var i = 0; i < 20; i++)
+            {
+                var rs = session.Execute(selectPs.Bind(i));
+                coordinators.Add(rs.Info.QueriedHost);
+            }
+            Assert.IsTrue(
+                coordinators.All(ep => ep.Address.ToString() == localDcNode),
+                $"All queries should stay in the local DC ({localDcNode}), but got: {string.Join(", ", coordinators)}");
+        }
+    }
+}

--- a/src/Cassandra.IntegrationTests/Policies/LoadBalancingPolicyTests.cs
+++ b/src/Cassandra.IntegrationTests/Policies/LoadBalancingPolicyTests.cs
@@ -1,0 +1,53 @@
+//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Diagnostics;
+using Cassandra.IntegrationTests.TestBase;
+using Cassandra.IntegrationTests.TestClusterManagement;
+using Cassandra.Tests;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Cassandra.IntegrationTests.Policies.Tests
+{
+    [TestFixture, Category(TestCategory.Long)]
+    public class LoadBalancingPolicyTests : TestGlobals
+    {
+
+        /// <summary>
+        /// Validated that the driver fails as expected with a non-existing datacenter is specified via DCAwareRoundRobinPolicy 
+        /// 
+        /// @test_category load_balancing:dc_aware
+        /// </summary>
+        [Test]
+        public void RoundRobin_DcAware_BuildClusterWithNonExistentDc()
+        {
+            ITestCluster testCluster = TestClusterManager.GetTestCluster(1);
+            testCluster.Builder = ClusterBuilder().WithLoadBalancingPolicy(new DCAwareRoundRobinPolicy("dc2"));
+            try
+            {
+                testCluster.InitClient();
+                Assert.Fail("Expected exception was not thrown!");
+            }
+            catch (ArgumentException e)
+            {
+                string expectedErrMsg = "Datacenter dc2 does not match any of the nodes, available datacenters: datacenter1.";
+                Assert.IsTrue(e.Message.Contains(expectedErrMsg));
+            }
+        }
+    }
+}

--- a/src/Cassandra.IntegrationTests/Policies/LoadBalancingPolicyTests.cs
+++ b/src/Cassandra.IntegrationTests/Policies/LoadBalancingPolicyTests.cs
@@ -15,7 +15,6 @@
 //
 
 using System;
-using System.Diagnostics;
 using Cassandra.IntegrationTests.TestBase;
 using Cassandra.IntegrationTests.TestClusterManagement;
 using Cassandra.Tests;
@@ -29,7 +28,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
     {
 
         /// <summary>
-        /// Validated that the driver fails as expected with a non-existing datacenter is specified via DCAwareRoundRobinPolicy 
+        /// Validates that the driver fails as expected with a non-existing datacenter is specified via DCAwareRoundRobinPolicy 
         /// 
         /// @test_category load_balancing:dc_aware
         /// </summary>

--- a/src/Cassandra/Policies/DCAwareRoundRobinPolicy.cs
+++ b/src/Cassandra/Policies/DCAwareRoundRobinPolicy.cs
@@ -16,17 +16,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Linq;
 
 namespace Cassandra
 {
     /// <summary>
     /// A data-center aware Round-robin load balancing policy.
     /// <para>
-    /// This policy provides round-robin queries over the node of the local datacenter. Currently, it also includes in the query plans
-    /// returned a configurable number of hosts in the remote datacenters (which are always tried after the local nodes)
-    /// but this functionality will be removed in the next major version of the driver.
+    /// This policy provides queries over the nodes of the local datacenter. Also, if the `PermitDcFailover` flag is set, it includes in the query plans
+    /// hosts in remote datacenters (which are always tried after the local nodes).
     /// See the comments on <see cref="DCAwareRoundRobinPolicy(string, int)"/> for more information.
     /// </para>
     /// </summary>
@@ -37,16 +34,8 @@ namespace Cassandra
             "DC failover should not be done in the driver, which does not have the necessary context to know " +
             "what makes sense considering application semantics. See https://datastax-oss.atlassian.net/browse/CSHARP-722";
 
-        private static readonly Logger Logger = new Logger(typeof(DCAwareRoundRobinPolicy));
-
         private string _localDc;
         private readonly int _usedHostsPerRemoteDc;
-
-        private readonly int _maxIndex = Int32.MaxValue - 10000;
-        private volatile Tuple<List<Host>, List<Host>> _hosts;
-        private readonly object _hostCreationLock = new object();
-        ICluster _cluster;
-        int _index;
 
         /// <summary>
         /// Creates a new datacenter aware round robin policy that auto-discover the local data-center.
@@ -59,49 +48,77 @@ namespace Cassandra
         /// constructor of this class.
         /// </para>
         /// </summary>
-#pragma warning disable 618
-        public DCAwareRoundRobinPolicy() : this(null, 0)
-#pragma warning restore 618
+        [Obsolete("Automatic local datacenter detection is not supported. Specify the local datacenter explicitly: new DCAwareRoundRobinPolicy(localDc).")]
+        public DCAwareRoundRobinPolicy()
         {
+            throw new ArgumentException(
+                "Automatic local datacenter detection is no longer supported. " +
+                "Please specify the local datacenter explicitly: new DCAwareRoundRobinPolicy(localDc).");
         }
 
         /// <summary>
         ///  Creates a new datacenter aware round robin policy given the name of the local
         ///  datacenter. <p> The name of the local datacenter provided must be the local
         ///  datacenter name as known by Cassandra. </p><p> The policy created will ignore all
-        ///  remote hosts. In other words, this is equivalent to 
+        ///  remote hosts. In other words, this is equivalent to
         ///  <c>new DCAwareRoundRobinPolicy(localDc, 0)</c>.</p>
         /// </summary>
         /// <param name="localDc"> the name of the local datacenter (as known by Cassandra).</param>
 #pragma warning disable 618
-        public DCAwareRoundRobinPolicy(string localDc) : this(localDc, 0)
+        public DCAwareRoundRobinPolicy(string localDc) : this(localDc, 0, false)
 #pragma warning restore 618
         {
         }
 
         ///<summary>
-        /// Creates a new DCAwareRoundRobin policy given the name of the local
+        /// Obsolete constructor. Creates a new DCAwareRoundRobin policy given the name of the local
         /// datacenter and that uses the provided number of host per remote
-        /// datacenter as failover for the local hosts.
+        /// datacenter as failover for the local hosts. 
+        /// Setting the number of hosts per remote DC does not change anything. It is a deprecated parameter.
+        /// Use DCAwareRoundRobinPolicy(string localDc, bool permitDcFailover) instead, and set permitDcFailover to true to allow DC failover. 
         /// <p>
         /// The name of the local datacenter provided must be the local
         /// datacenter name as known by Cassandra.</p>
         ///</summary>
         /// <param name="localDc">The name of the local datacenter (as known by
         /// Cassandra).</param>
-        /// <param name="usedHostsPerRemoteDc">The number of host per remote
+        /// <param name="usedHostsPerRemoteDc">Obsolete. The number of host per remote
         /// datacenter that policies created by the returned factory should
         /// consider. Created policies <c>distance</c> method will return a
         /// <c>HostDistance.Remote</c> distance for only <c>usedHostsPerRemoteDc</c>
         /// hosts per remote datacenter. Other hosts of the remote datacenters will be ignored
         /// (and thus no connections to them will be maintained).
-        /// <para>Note that this parameter will be removed in the next major release of
+        /// <para>Note that setting this parameter does not change anything and it will be removed in the next major release of
         /// the driver.</para></param>
         [Obsolete(DCAwareRoundRobinPolicy.UsedHostsPerRemoteDcObsoleteMessage)]
         public DCAwareRoundRobinPolicy(string localDc, int usedHostsPerRemoteDc)
+            : this(localDc, usedHostsPerRemoteDc, false)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new datacenter aware round robin policy given the name of the local
+        /// datacenter and whether to permit datacenter failover.
+        /// <p>
+        /// The name of the local datacenter provided must be the local
+        /// datacenter name as known by Cassandra.</p>
+        /// </summary>
+        /// <param name="localDc">The name of the local datacenter (as known by Cassandra).</param>
+        /// <param name="permitDcFailover">Whether to permit failover to remote datacenters.</param>
+        public DCAwareRoundRobinPolicy(string localDc, bool permitDcFailover)
+            : this(localDc, 0, permitDcFailover)
+        {
+        }
+
+        private DCAwareRoundRobinPolicy(string localDc, int usedHostsPerRemoteDc, bool permitDcFailover)
         {
             _localDc = localDc;
+            if (string.IsNullOrWhiteSpace(localDc))
+            {
+                throw new ArgumentException("Local datacenter cannot be null or empty.", nameof(localDc));
+            }
             _usedHostsPerRemoteDc = usedHostsPerRemoteDc;
+            PermitDcFailover = permitDcFailover;
         }
 
         /// <summary>
@@ -115,57 +132,16 @@ namespace Cassandra
         [Obsolete(DCAwareRoundRobinPolicy.UsedHostsPerRemoteDcObsoleteMessage)]
         public int UsedHostsPerRemoteDc => _usedHostsPerRemoteDc;
 
+        /// <summary>
+        /// Gets whether this policy permits failover to remote datacenters.
+        /// </summary>
+        public bool PermitDcFailover { get; }
+
+        [Obsolete("Initialize is not supported. Load balancing is handled by the Rust driver internally.")]
         public void Initialize(ICluster cluster)
         {
-            _cluster = cluster;
-
-            //When the pool changes, it should clear the local cache
-            _cluster.HostAdded += _ => ClearHosts();
-            _cluster.HostRemoved += _ => ClearHosts();
-
-            var availableDcs = _cluster.AllHosts().Select(h => h.Datacenter).Where(dc => dc != null).Distinct().ToList();
-            var availableDcsStr = string.Join(", ", availableDcs);
-
-            if (_localDc == null)
-            {
-                DCAwareRoundRobinPolicy.Logger.Warning(
-                    "Local datacenter was not specified. In the next major release of the driver " +
-                    "applications will be required to specify the local datacenter in the load balancing policy. " +
-                    $"Available datacenters: {availableDcsStr}.");
-
-                var host = GetLocalHost();
-                if (host == null)
-                {
-                    throw new DriverInternalError("Local datacenter could not be determined");
-                }
-
-                _localDc = host.Datacenter;
-                return;
-            }
-
-            //Check that the datacenter exists
-            if (!availableDcs.Contains(_localDc))
-            {
-                throw new ArgumentException(
-                    $"Datacenter {_localDc} does not match any of the nodes, available datacenters: {availableDcsStr}.");
-            }
-        }
-
-        /// <summary>
-        /// Gets the current local host.
-        /// If can not be determined, it returns any of the nodes.
-        /// </summary>
-        private Host GetLocalHost()
-        {
-            if (!(_cluster is Cluster clusterImplementation))
-            {
-                //fallback to use any of the hosts
-                return _cluster.AllHosts().FirstOrDefault(h => h.Datacenter != null);
-            }
-
-            //Use the host used by the control connection
-            // return cc.Host;
-            throw new NotImplementedException(); // FIXME: bridge with Rust LBP implementation.
+            throw new NotSupportedException(
+                "Initialize is not supported. Load balancing is handled by the Rust driver internally.");
         }
 
         /// <summary>
@@ -179,7 +155,7 @@ namespace Cassandra
         /// <returns>the HostDistance to <c>host</c>.</returns>
         public HostDistance Distance(Host host)
         {
-            var dc = GetDatacenter(host);
+            var dc = host.Datacenter ?? _localDc;
             if (dc == _localDc)
             {
                 return HostDistance.Local;
@@ -188,6 +164,7 @@ namespace Cassandra
         }
 
         /// <summary>
+        ///  <b>This function is not supported. All query routing is handled by the Rust driver internally.</b>
         ///  Returns the hosts to use for a new query. <p> The returned plan will always
         ///  try each known host in the local datacenter first, and then, if none of the
         ///  local host is reachable, will try up to a configurable number of other host
@@ -198,100 +175,11 @@ namespace Cassandra
         /// <param name="query"> the query for which to build the plan. </param>
         /// <returns>a new query plan, i.e. an iterator indicating which host to try
         ///  first for querying, which one to use as failover, etc...</returns>
+        [Obsolete("NewQueryPlan is not supported. Load balancing is handled by the Rust driver internally.")]
         public IEnumerable<HostShard> NewQueryPlan(string keyspace, IStatement query)
         {
-            var startIndex = 0;
-            if (query?.IsLwt() != true)
-            {
-                startIndex = Interlocked.Increment(ref _index);
-                //Simplified overflow protection
-                if (startIndex > _maxIndex)
-                {
-                    Interlocked.Exchange(ref _index, 0);
-                }
-            }
-            var hosts = GetHosts();
-            var localHosts = hosts.Item1;
-            var remoteHosts = hosts.Item2;
-            //Round-robin through local nodes
-            for (var i = 0; i < localHosts.Count; i++)
-            {
-                yield return new HostShard(localHosts[(startIndex + i) % localHosts.Count], -1);
-            }
-
-            if (_usedHostsPerRemoteDc == 0)
-            {
-                yield break;
-            }
-            var dcHosts = new Dictionary<string, int>();
-            foreach (var h in remoteHosts)
-            {
-                var dc = GetDatacenter(h);
-                dcHosts.TryGetValue(dc, out int hostYieldedByDc);
-                if (hostYieldedByDc >= _usedHostsPerRemoteDc)
-                {
-                    //We already returned the amount of remotes nodes required
-                    continue;
-                }
-                dcHosts[dc] = hostYieldedByDc + 1;
-                yield return new HostShard(h, -1);
-            }
-        }
-
-        private void ClearHosts()
-        {
-            _hosts = null;
-        }
-
-        private string GetDatacenter(Host host)
-        {
-            var dc = host.Datacenter;
-            return dc ?? _localDc;
-        }
-
-        /// <summary>
-        /// Gets a tuple containing the list of local and remote nodes
-        /// </summary>
-        internal Tuple<List<Host>, List<Host>> GetHosts()
-        {
-            var hosts = _hosts;
-            if (hosts != null)
-            {
-                return hosts;
-            }
-            lock (_hostCreationLock)
-            {
-                //Check that if it has been updated since we were waiting for the lock
-                hosts = _hosts;
-                if (hosts != null)
-                {
-                    return hosts;
-                }
-                var localHosts = new List<Host>();
-                var remoteHosts = new List<Host>();
-
-                //Do not reorder instructions, the host list must be up to date now, not earlier
-                Thread.MemoryBarrier();
-
-                //shallow copy the nodes
-                var allNodes = _cluster.AllHosts().ToArray();
-
-                //Split between local and remote nodes 
-                foreach (var h in allNodes)
-                {
-                    if (GetDatacenter(h) == _localDc)
-                    {
-                        localHosts.Add(h);
-                    }
-                    else if (_usedHostsPerRemoteDc > 0)
-                    {
-                        remoteHosts.Add(h);
-                    }
-                }
-                hosts = new Tuple<List<Host>, List<Host>>(localHosts, remoteHosts);
-                _hosts = hosts;
-            }
-            return hosts;
+            throw new NotSupportedException(
+                "NewQueryPlan is not supported. Query routing is handled by the Rust driver internally.");
         }
     }
 }

--- a/src/Cassandra/Policies/DefaultLoadBalancingPolicy.cs
+++ b/src/Cassandra/Policies/DefaultLoadBalancingPolicy.cs
@@ -22,7 +22,8 @@ namespace Cassandra
     /// <summary>
     /// A load balancing policy designed to run against Apache Cassandra clusters.
     /// <para>
-    ///  For most workloads, the query plan will be determined in a similar way to TokenAwarePolicy(DCAwareRoundRobinPolicy).
+    /// If the local DC is specified, the behaviour will be the same as TokenAwarePolicy(DCAwareRoundRobinPolicy(localDc)).
+    /// By default, if no load balancing policy is specified when building the cluster, the policy will act like TokenAwarePolicy(RoundRobinPolicy).
     /// </para>
     /// <para>
     ///  For graph analytics queries, this policy sets the preferred analytics graph server
@@ -63,40 +64,28 @@ namespace Cassandra
         /// <returns>the HostDistance to <c>host</c>.</returns>
         public HostDistance Distance(Host host)
         {
-            // FIXME
-            // var lastPreferredHost = _lastPreferredHost;
-            // if (lastPreferredHost != null && host == lastPreferredHost)
-            // {
-            //     // Set the last preferred host as local.
-            //     // It's somewhat "hacky" but ensures that the pool for the graph analytics host has the appropriate size
-            //     return HostDistance.Local;
-            // }
-
-            // return ChildPolicy.Distance(host);
-            throw new NotImplementedException();
+            return ChildPolicy.Distance(host);
         }
 
         /// <summary>
         /// Initializes the policy.
         /// </summary>
+        [Obsolete("Initialize is not supported. Load balancing is handled by the Rust driver internally.")]
         public void Initialize(ICluster cluster)
         {
-            ChildPolicy.Initialize(cluster);
+            throw new NotSupportedException(
+                "Initialize is not supported. Load balancing is handled by the Rust driver internally.");
         }
 
         /// <summary>
-        /// Returns the hosts to used for a query.
+        /// <b>This function is not supported. All query routing is handled by the Rust driver internally.</b>
+        ///  Returns the hosts to be used for a query.
         /// </summary>
+        [Obsolete("NewQueryPlan is not supported. Load balancing is handled by the Rust driver internally.")]
         public IEnumerable<HostShard> NewQueryPlan(string keyspace, IStatement statement)
         {
-            // FIXME
-            // if (statement is TargettedSimpleStatement targetedStatement && targetedStatement.PreferredHost != null)
-            // {
-            //     _lastPreferredHost = targetedStatement.PreferredHost;
-            // return YieldPreferred(keyspace, targetedStatement);
-            // }
-
-            return ChildPolicy.NewQueryPlan(keyspace, statement);
+            throw new NotSupportedException(
+                "NewQueryPlan is not supported. Query routing is handled by the Rust driver internally.");
         }
     }
 }

--- a/src/Cassandra/Policies/Policies.cs
+++ b/src/Cassandra/Policies/Policies.cs
@@ -33,11 +33,11 @@ namespace Cassandra
         /// </para>  
         /// <para> 
         /// The default load balancing policy is <see cref="DefaultLoadBalancingPolicy"/> as a wrapper around
-        /// <see cref="TokenAwarePolicy"/> with <see cref="DCAwareRoundRobinPolicy"/> as child policy.
+        /// <see cref="TokenAwarePolicy"/> with <see cref="RoundRobinPolicy"/> as child policy.
         /// </para>
         /// </summary>
         public static ILoadBalancingPolicy DefaultLoadBalancingPolicy =>
-            new DefaultLoadBalancingPolicy(new TokenAwarePolicy(new DCAwareRoundRobinPolicy()));
+            new DefaultLoadBalancingPolicy(new TokenAwarePolicy(new RoundRobinPolicy()));
 
         /// <summary>
         /// Creates a new instance of the default load balancing policy with the provided local datacenter.

--- a/src/Cassandra/Policies/RetryLoadBalancingPolicy.cs
+++ b/src/Cassandra/Policies/RetryLoadBalancingPolicy.cs
@@ -16,14 +16,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace Cassandra
 {
     public class RetryLoadBalancingPolicy : ILoadBalancingPolicy
     {
-        public EventHandler<RetryLoadBalancingPolicyEventArgs> ReconnectionEvent;
-
         public RetryLoadBalancingPolicy(ILoadBalancingPolicy loadBalancingPolicy, IReconnectionPolicy reconnectionPolicy)
         {
             ReconnectionPolicy = reconnectionPolicy;
@@ -34,9 +31,12 @@ namespace Cassandra
 
         public ILoadBalancingPolicy LoadBalancingPolicy { get; }
 
+        [Obsolete("Initialize is not supported.")]
         public void Initialize(ICluster cluster)
         {
-            LoadBalancingPolicy.Initialize(cluster);
+            throw new NotSupportedException(
+                "RetryLoadBalancingPolicy is not supported. " +
+                "The Rust driver handles node reconnection internally.");
         }
 
         public HostDistance Distance(Host host)
@@ -44,25 +44,12 @@ namespace Cassandra
             return LoadBalancingPolicy.Distance(host);
         }
 
+        [Obsolete("NewQueryPlan is not supported.")]
         public IEnumerable<HostShard> NewQueryPlan(string keyspace, IStatement query)
         {
-            IReconnectionSchedule schedule = ReconnectionPolicy.NewSchedule();
-            while (true)
-            {
-                IEnumerable<HostShard> childQueryPlan = LoadBalancingPolicy.NewQueryPlan(keyspace, query);
-                foreach (HostShard host in childQueryPlan)
-                    yield return host;
-
-                if (ReconnectionEvent != null)
-                {
-                    var ea = new RetryLoadBalancingPolicyEventArgs(schedule.NextDelayMs());
-                    ReconnectionEvent(this, ea);
-                    if (ea.Cancel)
-                        break;
-                }
-                else
-                    Thread.Sleep((int)schedule.NextDelayMs());
-            }
+            throw new NotSupportedException(
+                "RetryLoadBalancingPolicy is not supported. " +
+                "The Rust driver handles node reconnection internally.");
         }
     }
 }

--- a/src/Cassandra/Policies/RoundRobinPolicy.cs
+++ b/src/Cassandra/Policies/RoundRobinPolicy.cs
@@ -14,33 +14,29 @@
 //   limitations under the License.
 //
 
+using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Linq;
 
 
 namespace Cassandra
 {
     /// <summary>
-    ///  A Round-robin load balancing policy.
-    /// <para> This policy queries nodes in a
-    ///  round-robin fashion. For a given query, if an host fail, the next one
-    ///  (following the round-robin order) is tried, until all hosts have been tried.
+    ///  A load balancing policy that queries nodes in a random order.
+    /// <para> <b> The name is misleading and legacy, it does not implement a round-robin algorithm. </b>
     ///  </para>
     /// <para> This policy is not datacenter aware and will include every known
-    ///  Cassandra host in its round robin algorithm. If you use multiple datacenter
+    ///  Cassandra host. If you use multiple datacenters,
     ///  this will be inefficient and you will want to use the
     ///  <see cref="DCAwareRoundRobinPolicy"/> load balancing policy instead.
     /// </para>
     /// </summary>
     public class RoundRobinPolicy : ILoadBalancingPolicy
     {
-        ICluster _cluster;
-        int _index;
-
+        [Obsolete("Initialize is not supported. Load balancing is handled by the Rust driver internally.")]
         public void Initialize(ICluster cluster)
         {
-            this._cluster = cluster;
+            throw new NotSupportedException(
+                "Initialize is not supported. Load balancing is handled by the Rust driver internally.");
         }
 
         /// <summary>
@@ -57,6 +53,7 @@ namespace Cassandra
         }
 
         /// <summary>
+        /// <b>This function is not supported. All query routing is handled by the Rust driver internally. </b>
         ///  Returns the hosts to use for a new query. <p> The returned plan will try each
         ///  known host of the cluster. Upon each call to this method, the ith host of the
         ///  plans returned will cycle over all the host of the cluster in a round-robin
@@ -66,26 +63,11 @@ namespace Cassandra
         /// <param name="query"> the query for which to build the plan. </param>
         /// <returns>a new query plan, i.e. an iterator indicating which host to try
         ///  first for querying, which one to use as failover, etc...</returns>
+        [Obsolete("NewQueryPlan is not supported. Load balancing is handled by the Rust driver internally.")]
         public IEnumerable<HostShard> NewQueryPlan(string keyspace, IStatement query)
         {
-            //shallow copy the all hosts
-            var hosts = (from h in _cluster.AllHosts() select h).ToArray();
-            var startIndex = 0;
-            if (query?.IsLwt() != true)
-            {
-                startIndex = Interlocked.Increment(ref _index);
-
-                //Simplified overflow protection
-                if (startIndex > int.MaxValue - 10000)
-                {
-                    Interlocked.Exchange(ref _index, 0);
-                }
-            }
-
-            for (var i = 0; i < hosts.Length; i++)
-            {
-                yield return new HostShard(hosts[(startIndex + i) % hosts.Length], -1);
-            }
+            throw new NotSupportedException(
+                "NewQueryPlan is not supported. Query routing is handled by the Rust driver internally.");
         }
     }
 }

--- a/src/Cassandra/Policies/TokenAwarePolicy.cs
+++ b/src/Cassandra/Policies/TokenAwarePolicy.cs
@@ -16,8 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 
 namespace Cassandra
 {
@@ -27,18 +25,10 @@ namespace Cassandra
     /// </para>
     /// <list type="number">
     /// <item>The <see cref="Distance(Host)"/> method is inherited  from the child policy.</item>
-    /// <item>The host yielded by the <see cref="NewQueryPlan(string, IStatement)"/> method will first return the
-    /// <see cref="HostDistance.Local"/> replicas for the statement, based on the <see cref="Statement.RoutingKey"/>.
-    /// </item>
     /// </list>
     /// </summary>
     public class TokenAwarePolicy : ILoadBalancingPolicy
     {
-        private ICluster _cluster;
-        private readonly ThreadLocal<Random> _prng = new ThreadLocal<Random>(() => new Random(
-            // Predictable random numbers are OK
-            Environment.TickCount * Environment.CurrentManagedThreadId));
-
         /// <summary>
         ///  Creates a new <c>TokenAware</c> policy that wraps the provided child
         ///  load balancing policy.
@@ -47,15 +37,16 @@ namespace Cassandra
         ///  awareness.</param>
         public TokenAwarePolicy(ILoadBalancingPolicy childPolicy)
         {
-            ChildPolicy = childPolicy;
+            ChildPolicy = childPolicy ?? throw new ArgumentNullException(nameof(childPolicy));
         }
 
         public ILoadBalancingPolicy ChildPolicy { get; }
 
+        [Obsolete("Initialize is not supported. Load balancing is handled by the Rust driver internally.")]
         public void Initialize(ICluster cluster)
         {
-            _cluster = cluster;
-            ChildPolicy.Initialize(cluster);
+            throw new NotSupportedException(
+                "Initialize is not supported. Load balancing is handled by the Rust driver internally.");
         }
 
         /// <summary>
@@ -71,6 +62,7 @@ namespace Cassandra
         }
 
         /// <summary>
+        /// <b> This function is not supported. All query routing is handled by the Rust driver internally.</b>
         ///  Returns the hosts to use for a new query. <p> The returned plan will first
         ///  return replicas (whose <c>HostDistance</c> for the child policy is
         ///  <c>Local</c>) for the query if it can determine them (i.e. mainly if
@@ -80,9 +72,11 @@ namespace Cassandra
         /// <param name="loggedKeyspace">Keyspace on which the query is going to be executed</param>
         /// <param name="query"> the query for which to build the plan. </param>
         /// <returns>the new query plan.</returns>
+        [Obsolete("NewQueryPlan is not supported. Load balancing is handled by the Rust driver internally.")]
         public IEnumerable<HostShard> NewQueryPlan(string loggedKeyspace, IStatement query)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException(
+                "NewQueryPlan is not supported. Query routing is handled by the Rust driver internally.");
         }
     }
 }

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -23,6 +23,8 @@ namespace Cassandra
     /// </remarks>
     internal sealed class BridgedSession : RustResource
     {
+        private static readonly Logger Logger = new Logger(typeof(BridgedSession));
+
         internal BridgedSession(ManuallyDestructible mdSession) : base(mdSession)
         {
         }
@@ -304,7 +306,78 @@ namespace Cassandra
                 };
             }
         }
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct BridgedLoadBalancingPolicy
+        {
+            internal FFIBool isTokenAware;
+            internal FFIBool permitDcFailover;
+            [MarshalAs(UnmanagedType.LPUTF8Str)]
+            internal string localDC;
 
+            /// <summary>
+            /// Extracts the relevant information from the provided ILoadBalancingPolicy and its potential child policies.
+            /// <p>The sensible policies that the user can specify are:</p>
+            /// <list type="bullet">
+            /// <item>RoundRobinPolicy</item>
+            /// <item>DCAwareRoundRobinPolicy</item>
+            /// <item>TokenAwarePolicy(RoundRobinPolicy)</item>
+            /// <item>TokenAwarePolicy(DCAwareRoundRobinPolicy)</item>
+            /// <item>DefaultLoadBalancingPolicy(TokenAwarePolicy(DCAwareRoundRobinPolicy))</item>
+            /// <item>DefaultLoadBalancingPolicy(TokenAwarePolicy(RoundRobinPolicy)) (that policy is constructed when the user does not specify any policy when creating a cluster)</item>
+            /// </list>
+            /// </summary>
+            /// <param name="lbp">The load balancing policy to extract configuration from.</param>
+            /// <returns>A <see cref="BridgedLoadBalancingPolicy"/> representing the extracted configuration.</returns>
+            /// <exception cref="NotSupportedException">Thrown when the policy type is not supported.</exception>
+            internal static BridgedLoadBalancingPolicy BuildFrom(ILoadBalancingPolicy lbp)
+            {
+                BridgedLoadBalancingPolicy rustLBP = new BridgedLoadBalancingPolicy
+                {
+                    isTokenAware = false,
+                    localDC = null,
+                };
+
+                // The loop unwraps layers of TokenAwarePolicy and DefaultLoadBalancingPolicy until it finds DCAwareRoundRobinPolicy or RoundRobinPolicy.
+                // The chain is finite and acyclic because every child policy is assigned once at construction and is
+                // exposed through a get-only property, so this loop is guaranteed to terminate.
+                while (lbp != null)
+                {
+                    switch (lbp)
+                    {
+                        case TokenAwarePolicy tokenAware:
+                            if (rustLBP.isTokenAware)
+                            {
+                                Logger.Warning("Found a TokenAwarePolicy that is a child of another TokenAwarePolicy. Such double wrapping is redundant and unnecessary.");
+                            }
+                            rustLBP.isTokenAware = true;
+                            lbp = tokenAware.ChildPolicy;
+                            break;
+
+                        case DefaultLoadBalancingPolicy defaultPolicy:
+                            lbp = defaultPolicy.ChildPolicy;
+                            break;
+
+                        case DCAwareRoundRobinPolicy dcAware:
+                            rustLBP.permitDcFailover = dcAware.PermitDcFailover;
+                            rustLBP.localDC = dcAware.LocalDc;
+                            return rustLBP;
+
+                        case RoundRobinPolicy:
+                            return rustLBP;
+
+                        case RetryLoadBalancingPolicy:
+                            throw new NotSupportedException(
+                                "RetryLoadBalancingPolicy is not supported. " +
+                                "The Rust driver handles node reconnection internally.");
+
+                        default:
+                            throw new NotSupportedException($"Load balancing policy {lbp.GetType().Name} is not supported.");
+                    }
+                }
+
+                throw new NotSupportedException("Load balancing policy cannot be null or have a null child policy.");
+            }
+        }
         /// <summary>
         /// Configuration struct used to pass session creation parameters from C# to Rust.
         /// Any changes to this struct must be mirrored in the corresponding Rust struct.
@@ -322,6 +395,8 @@ namespace Cassandra
 
             internal BridgedTcpConfig tcp;
 
+            internal BridgedLoadBalancingPolicy loadBalancingPolicy;
+
             internal static BridgedSessionConfig BuildFrom(string uri, string keyspace, Configuration clusterConfig)
             {
                 return new BridgedSessionConfig
@@ -330,6 +405,7 @@ namespace Cassandra
                     Keyspace = keyspace ?? "",
                     connectTimeoutMillis = clusterConfig.SocketOptions?.ConnectTimeoutMillis ?? SocketOptions.DefaultConnectTimeoutMillis,
                     tcp = BridgedTcpConfig.BuildFrom(clusterConfig.SocketOptions),
+                    loadBalancingPolicy = BridgedLoadBalancingPolicy.BuildFrom(clusterConfig.Policies.LoadBalancingPolicy)
                 };
             }
         }

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -42,6 +42,9 @@ namespace Cassandra
         [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
         private static extern FFIMaybeException session_get_cluster_state(IntPtr sessionPtr, out ManuallyDestructible clusterState, IntPtr constructorsPtr);
 
+        [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
+        private static extern FFIMaybeException session_check_local_dc_existence(IntPtr sessionPtr, [MarshalAs(UnmanagedType.LPUTF8Str)] string localDc, IntPtr constructorsPtr);
+
         /// <summary>
         /// Executes a query with values supplied via the populate-callback pattern.
         /// Rust invokes <paramref name="populateValuesCallback"/> synchronously during this call,
@@ -75,7 +78,8 @@ namespace Cassandra
         unsafe private static extern FFIMaybeException session_get_keyspace(IntPtr session, IntPtr writeToStr, IntPtr context, IntPtr constructorsPtr);
 
         /// <summary>
-        /// Creates a new session connected to the specified Cassandra URI.
+        /// Creates a new session connected to the specified Cassandra URI. 
+        /// Checks the existence of the configured local datacenter.
         /// </summary>
         /// <param name="uri"></param>
         /// <param name="keyspace"></param>
@@ -102,6 +106,27 @@ namespace Cassandra
             session_create(tcb, bridgedSessionConfig);
 
             var bridgedSession = new BridgedSession(await tcs.Task.ConfigureAwait(false));
+
+            // Validate the configured local datacenter against the connected cluster, mirroring
+            // the post-connect check the old driver performed in DCAwareRoundRobinPolicy.
+            // Only DC-aware policies set a local DC; null means there is nothing to validate.
+            string localDc = bridgedSessionConfig.loadBalancingPolicy.localDC;
+            if (localDc != null)
+            {
+                try
+                {
+                    unsafe
+                    {
+                        bridgedSession.RunWithIncrement(handle =>
+                            session_check_local_dc_existence(handle, localDc, (IntPtr)Globals.ConstructorsPtr));
+                    }
+                }
+                catch
+                {
+                    bridgedSession.Dispose();
+                    throw;
+                }
+            }
 
             return bridgedSession;
         }

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -77,8 +77,8 @@ namespace Cassandra
         /// </summary>
         /// <param name="uri"></param>
         /// <param name="keyspace"></param>
-        /// <param name="socketOptions">Socket options to be applied to the session.</param>
-        static internal Task<ManuallyDestructible> Create(string uri, string keyspace, SocketOptions socketOptions)
+        /// <param name="clusterConfig">Cluster configuration to be applied to the session.</param>
+        static internal async Task<BridgedSession> Create(string uri, string keyspace, Configuration clusterConfig)
         {
             /*
              * TaskCompletionSource is a way to programatically control a Task.
@@ -96,10 +96,12 @@ namespace Cassandra
             // So we pass a pointer to the method and Rust code will call it via that pointer.
             // This is a common pattern to call C# code from native code ("reversed P/Invoke").
             var tcb = Tcb<ManuallyDestructible>.WithTcs(tcs);
-            var bridgedSessionConfig = BridgedSessionConfig.BuildFrom(uri, keyspace, socketOptions);
+            var bridgedSessionConfig = BridgedSessionConfig.BuildFrom(uri, keyspace, clusterConfig);
             session_create(tcb, bridgedSessionConfig);
 
-            return tcs.Task;
+            var bridgedSession = new BridgedSession(await tcs.Task.ConfigureAwait(false));
+
+            return bridgedSession;
         }
 
         /// <summary>
@@ -320,14 +322,14 @@ namespace Cassandra
 
             internal BridgedTcpConfig tcp;
 
-            internal static BridgedSessionConfig BuildFrom(string uri, string keyspace, SocketOptions socketOptions)
+            internal static BridgedSessionConfig BuildFrom(string uri, string keyspace, Configuration clusterConfig)
             {
                 return new BridgedSessionConfig
                 {
                     Uri = uri,
                     Keyspace = keyspace ?? "",
-                    connectTimeoutMillis = socketOptions?.ConnectTimeoutMillis ?? SocketOptions.DefaultConnectTimeoutMillis,
-                    tcp = BridgedTcpConfig.BuildFrom(socketOptions),
+                    connectTimeoutMillis = clusterConfig.SocketOptions?.ConnectTimeoutMillis ?? SocketOptions.DefaultConnectTimeoutMillis,
+                    tcp = BridgedTcpConfig.BuildFrom(clusterConfig.SocketOptions),
                 };
             }
         }

--- a/src/Cassandra/RustBridge/RustBridge.cs
+++ b/src/Cassandra/RustBridge/RustBridge.cs
@@ -597,6 +597,7 @@ namespace Cassandra
             // Exception constructors passed to Rust
             unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIString, FFIGCHandle> AlreadyExistsConstructorPtr = &AlreadyExistsException.AlreadyExistsExceptionFromRust;
             unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> AlreadyShutdownExceptionConstructorPtr = &AlreadyShutdownException.AlreadyShutdownExceptionFromRust;
+            unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> ArgumentExceptionConstructorPtr = &ArgumentExceptionFromRust;
             unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> DeserializationExceptionConstructorPtr = &DeserializationException.DeserializationExceptionFromRust;
             unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> FunctionFailureExceptionConstructorPtr = &FunctionFailureException.FunctionFailureExceptionFromRust;
             unsafe readonly static delegate* unmanaged[Cdecl]<FFIString, FFIGCHandle> InvalidArgumentExceptionConstructorPtr = &InvalidArgumentException.InvalidArgumentExceptionFromRust;
@@ -625,6 +626,7 @@ namespace Cassandra
             {
                 internal readonly IntPtr already_exists_constructor;
                 internal readonly IntPtr already_shutdown_exception_constructor;
+                internal readonly IntPtr argument_exception_constructor;
                 internal readonly IntPtr deserialization_exception_constructor;
                 internal readonly IntPtr function_failure_exception_constructor;
                 internal readonly IntPtr invalid_argument_exception_constructor;
@@ -645,6 +647,7 @@ namespace Cassandra
                 internal Constructors(
                     IntPtr alreadyExistsException,
                     IntPtr alreadyShutdownException,
+                    IntPtr argumentException,
                     IntPtr deserializationException,
                     IntPtr functionFailureException,
                     IntPtr invalidArgumentException,
@@ -664,6 +667,7 @@ namespace Cassandra
                 {
                     already_exists_constructor = alreadyExistsException;
                     already_shutdown_exception_constructor = alreadyShutdownException;
+                    argument_exception_constructor = argumentException;
                     deserialization_exception_constructor = deserializationException;
                     function_failure_exception_constructor = functionFailureException;
                     invalid_argument_exception_constructor = invalidArgumentException;
@@ -702,6 +706,19 @@ namespace Cassandra
 
             [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
             private static unsafe extern void configure_rust_logging(IntPtr callback, byte min_level);
+
+            // Constructor for a System.ArgumentException meant for use by Rust.
+            // Defined here, because an exception from the C# Base Class Library cannot have custom constructors added.
+            [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+            private static FFIGCHandle ArgumentExceptionFromRust(FFIString message)
+            {
+                string msg = message.ToManagedString();
+
+                var exception = new ArgumentException(msg);
+
+                GCHandle handle = GCHandle.Alloc(exception);
+                return new(handle);
+            }
 
             [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
             private static void ForwardRustLog(byte level, FFIString message)
@@ -751,6 +768,7 @@ namespace Cassandra
                 *ConstructorsPtr = new Constructors(
                     (IntPtr)AlreadyExistsConstructorPtr,
                     (IntPtr)AlreadyShutdownExceptionConstructorPtr,
+                    (IntPtr)ArgumentExceptionConstructorPtr,
                     (IntPtr)DeserializationExceptionConstructorPtr,
                     (IntPtr)FunctionFailureExceptionConstructorPtr,
                     (IntPtr)InvalidArgumentExceptionConstructorPtr,

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -70,12 +70,12 @@ namespace Cassandra
 
         private Session(
             ICluster cluster,
-            RustBridge.ManuallyDestructible mdSession,
+            BridgedSession bridgedSession,
             ISerializerManager serializerManager)
         {
             _cluster = cluster;
             Configuration = cluster.Configuration;
-            bridgedSession = new BridgedSession(mdSession);
+            this.bridgedSession = bridgedSession;
             _serializerManager = serializerManager;
             UserDefinedTypes = new UdtMappingDefinitions(this, _serializerManager);
         }
@@ -86,11 +86,8 @@ namespace Cassandra
             string keyspace,
             ISerializerManager serializerManager)
         {
-            Task<RustBridge.ManuallyDestructible> mdSessionTask = BridgedSession.Create(contactPointUris, keyspace, cluster.Configuration.SocketOptions);
-
-            RustBridge.ManuallyDestructible mdSession = await mdSessionTask.ConfigureAwait(false);
-            var session = new Session(cluster, mdSession, serializerManager);
-            return session;
+            BridgedSession bridgedSession = await BridgedSession.Create(contactPointUris, keyspace, cluster.Configuration).ConfigureAwait(false);
+            return new Session(cluster, bridgedSession, serializerManager);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary

This PR  integrates the C# Load Balancing Policies (LBP) with the underlying Rust driver. This ensures that query routing behavior (such as token and DC awareness) configured in the C# client is correctly respected by the Rust session.

---

## Changes


### Load Balancing Policies

This change wires the LBP chosen by user from `Cluster.Configuration` into the Rust driver’s `DefaultPolicy`.

* **Rust Layer:**  Added `BridgedLoadBalancingPolicy` struct to handle `is_token_aware`, `is_dc_aware`, and `local_dc`.
* Implemented logic in `session_create` to resolve the local DC from the first contacted node if the user requested DC-aware routing but did not explicitly provide a DC name.


* **C# Bridge (`BridgedSession.cs`):** * `BuildFrom(ILoadBalancingPolicy)` now maps the following built-in policies: `DefaultLoadBalancingPolicy`, `DCAwareRoundRobinPolicy`, `TokenAwarePolicy`, and `RoundRobinPolicy`.
* Updated session creation to pass the full `Configuration` object, allowing LBP and other cluster-level settings to flow through a single channel.


* **Validation:**  Added `ValidateLocalDc` in `Session.cs`. It verifies the whether the configured DC exists, if not, throws. That's the same behaviour as old driver

---

## Testing

* Added some of  the `LoadBalancingPolicyShortTests.cs` from BrokenIntegratioinTests.
* Created new tests
* **Note:** Several legacy tests remain disabled as they require **Query Trace** support, which is not yet available in the bridge.

---

## Limitations

* **Custom Policies:** User-implemented `ILoadBalancingPolicy` classes are not supported and will result in a `NotImplementedException` during session construction.