### PR TITLE
Bridge unprepared statement execution options + page size for prepared statements

### DIFF
--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -42,9 +42,7 @@ pub struct BoundStatementExecutionOptions {
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct SimpleStatementExecutionOptions {
-    // Placeholder field so the struct is non-empty (required for FFI safety).
-    // Will be replaced by actual fields in subsequent commits.
-    pub _padding: u8,
+    pub is_idempotent: FFIBool,
 }
 
 /// BridgedSession is a thread-safe, asynchronously accessible session wrapper.
@@ -135,7 +133,7 @@ pub extern "C" fn session_query(
     tcb: Tcb<ManuallyDestructible>,
     session_ptr: BridgedBorrowedSharedPtr<'_, BridgedSession>,
     statement: CSharpStr<'_>,
-    _execution_options: SimpleStatementExecutionOptions,
+    execution_options: SimpleStatementExecutionOptions,
 ) {
     // Convert the raw C string to a Rust string.
     let statement = statement.as_cstr().unwrap().to_str().unwrap().to_owned();
@@ -164,7 +162,8 @@ pub extern "C" fn session_query(
             return Err(MaybeShutdownError::AlreadyShutdown);
         };
 
-        let statement = Statement::new(statement);
+        let mut statement = Statement::new(statement);
+        statement.set_is_idempotent(bool::from(execution_options.is_idempotent));
 
         // Lock is held for the entire duration of the query operation,
         // preventing shutdown until this future completes
@@ -190,7 +189,7 @@ pub extern "C" fn session_query_with_values(
     statement: CSharpStr<'_>,
     populate_values_context: PopulateValuesContext<'_>,
     populate_values: PopulateValues,
-    _execution_options: SimpleStatementExecutionOptions,
+    execution_options: SimpleStatementExecutionOptions,
 ) {
     let psv =
         match PreSerializedValues::from_populate_callback(populate_values_context, populate_values)
@@ -230,10 +229,12 @@ pub extern "C" fn session_query_with_values(
 
         // First, prepare the statement. Map PrepareError into PagerExecutionError::PrepareError
         // and then into MaybeShutdownError::Inner so the error type matches.
-        let prepared = session
+        let mut prepared = session
             .prepare(statement)
             .await
             .map_err(|e| MaybeShutdownError::Inner(PagerExecutionError::PrepareError(e)))?;
+
+        prepared.set_is_idempotent(bool::from(execution_options.is_idempotent));
 
         // Convert our FFI wrapper into SerializedValues by consuming it.
         let serialized_values: SerializedValues = psv.into_serialized_values();

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -35,6 +35,7 @@ pub struct BoundStatementExecutionOptions {
     pub consistency_level: u16,
     pub has_consistency_level: FFIBool,
     pub is_idempotent: FFIBool,
+    pub page_size: i32,
 }
 
 /// Execution options for simple (unprepared) statements mirrored with
@@ -397,6 +398,7 @@ pub extern "C" fn session_query_bound(
         }
 
         prepared_statement.set_is_idempotent(bool::from(execution_options.is_idempotent));
+        prepared_statement.set_page_size(execution_options.page_size);
 
         // Lock is held for the entire duration of the query operation,
         // preventing shutdown until this future completes
@@ -486,6 +488,7 @@ pub extern "C" fn session_query_bound_with_values(
         }
 
         prepared_statement.set_is_idempotent(bool::from(execution_options.is_idempotent));
+        prepared_statement.set_page_size(execution_options.page_size);
 
         // Convert our FFI wrapper into SerializedValues by consuming it.
         let serialized_values: SerializedValues = psv.into_serialized_values();

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -5,6 +5,7 @@ use std::sync::RwLock as StdRwLock;
 use scylla::client::session::Session;
 use scylla::cluster::ClusterState;
 use scylla::errors::{NewSessionError, PagerExecutionError, PrepareError};
+use scylla::statement::Statement;
 use scylla_cql::serialize::row::SerializedValues;
 use tokio::sync::RwLock;
 
@@ -34,6 +35,16 @@ pub struct BoundStatementExecutionOptions {
     pub consistency_level: u16,
     pub has_consistency_level: FFIBool,
     pub is_idempotent: FFIBool,
+}
+
+/// Execution options for simple (unprepared) statements mirrored with
+/// the managed FFI struct.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct SimpleStatementExecutionOptions {
+    // Placeholder field so the struct is non-empty (required for FFI safety).
+    // Will be replaced by actual fields in subsequent commits.
+    pub _padding: u8,
 }
 
 /// BridgedSession is a thread-safe, asynchronously accessible session wrapper.
@@ -124,6 +135,7 @@ pub extern "C" fn session_query(
     tcb: Tcb<ManuallyDestructible>,
     session_ptr: BridgedBorrowedSharedPtr<'_, BridgedSession>,
     statement: CSharpStr<'_>,
+    _execution_options: SimpleStatementExecutionOptions,
 ) {
     // Convert the raw C string to a Rust string.
     let statement = statement.as_cstr().unwrap().to_str().unwrap().to_owned();
@@ -152,6 +164,8 @@ pub extern "C" fn session_query(
             return Err(MaybeShutdownError::AlreadyShutdown);
         };
 
+        let statement = Statement::new(statement);
+
         // Lock is held for the entire duration of the query operation,
         // preventing shutdown until this future completes
         // Map underlying `PagerExecutionError` into `MaybeShutdownError::Inner` so
@@ -176,6 +190,7 @@ pub extern "C" fn session_query_with_values(
     statement: CSharpStr<'_>,
     populate_values_context: PopulateValuesContext<'_>,
     populate_values: PopulateValues,
+    _execution_options: SimpleStatementExecutionOptions,
 ) {
     let psv =
         match PreSerializedValues::from_populate_callback(populate_values_context, populate_values)

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -45,6 +45,7 @@ pub struct SimpleStatementExecutionOptions {
     pub consistency_level: u16,
     pub has_consistency_level: FFIBool,
     pub is_idempotent: FFIBool,
+    pub page_size: i32,
 }
 
 /// BridgedSession is a thread-safe, asynchronously accessible session wrapper.
@@ -166,6 +167,7 @@ pub extern "C" fn session_query(
 
         let mut statement = Statement::new(statement);
         statement.set_is_idempotent(bool::from(execution_options.is_idempotent));
+        statement.set_page_size(execution_options.page_size);
 
         if bool::from(execution_options.has_consistency_level) {
             let consistency = execution_options
@@ -252,6 +254,7 @@ pub extern "C" fn session_query_with_values(
             .map_err(|e| MaybeShutdownError::Inner(PagerExecutionError::PrepareError(e)))?;
 
         prepared.set_is_idempotent(bool::from(execution_options.is_idempotent));
+        prepared.set_page_size(execution_options.page_size);
 
         if bool::from(execution_options.has_consistency_level) {
             let consistency = execution_options

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -42,6 +42,8 @@ pub struct BoundStatementExecutionOptions {
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct SimpleStatementExecutionOptions {
+    pub consistency_level: u16,
+    pub has_consistency_level: FFIBool,
     pub is_idempotent: FFIBool,
 }
 
@@ -165,6 +167,21 @@ pub extern "C" fn session_query(
         let mut statement = Statement::new(statement);
         statement.set_is_idempotent(bool::from(execution_options.is_idempotent));
 
+        if bool::from(execution_options.has_consistency_level) {
+            let consistency = execution_options
+                .consistency_level
+                .try_into()
+                .map_err(|err| {
+                    MaybeShutdownError::InvalidArgument(format!(
+                        "Invalid consistency level value {0} passed from C# for simple query: {1}",
+                        execution_options.consistency_level, err
+                    ))
+                })?;
+            statement.set_consistency(consistency);
+        } else {
+            statement.unset_consistency();
+        }
+
         // Lock is held for the entire duration of the query operation,
         // preventing shutdown until this future completes
         // Map underlying `PagerExecutionError` into `MaybeShutdownError::Inner` so
@@ -235,6 +252,21 @@ pub extern "C" fn session_query_with_values(
             .map_err(|e| MaybeShutdownError::Inner(PagerExecutionError::PrepareError(e)))?;
 
         prepared.set_is_idempotent(bool::from(execution_options.is_idempotent));
+
+        if bool::from(execution_options.has_consistency_level) {
+            let consistency = execution_options
+                .consistency_level
+                .try_into()
+                .map_err(|err| {
+                    MaybeShutdownError::InvalidArgument(format!(
+                        "Invalid consistency level value {0} passed from C# for simple query with values: {1}",
+                        execution_options.consistency_level, err
+                    ))
+                })?;
+            prepared.set_consistency(consistency);
+        } else {
+            prepared.unset_consistency();
+        }
 
         // Convert our FFI wrapper into SerializedValues by consuming it.
         let serialized_values: SerializedValues = psv.into_serialized_values();

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -179,16 +179,19 @@ namespace Cassandra
         /// <param name="hasConsistencyLevel">Whether a consistency level override was specified.</param>
         /// <param name="consistencyLevel">Consistency level to use for the query.</param>
         /// <param name="isIdempotent">Indicates whether the query is idempotent.</param>
+        /// <param name="pageSize">Page size for the query (must be positive).</param>
         internal Task<ManuallyDestructible> QueryBound(
             IntPtr preparedStatement,
             bool hasConsistencyLevel,
             ushort consistencyLevel,
-            bool isIdempotent)
+            bool isIdempotent,
+            int pageSize)
         {
             var executionOptions = new PreparedStatementExecutionOptions(
                 hasConsistencyLevel,
                 consistencyLevel,
-                isIdempotent);
+                isIdempotent,
+                pageSize);
 
             return RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) => session_query_bound(
                 tcb,
@@ -206,13 +209,15 @@ namespace Cassandra
         /// <param name="hasConsistencyLevel">Whether a consistency level override was specified.</param>
         /// <param name="consistencyLevel">Consistency level to use for the query.</param>
         /// <param name="isIdempotent">Indicates whether the query is idempotent.</param>
+        /// <param name="pageSize">Page size for the query (must be positive).</param>
         internal unsafe Task<ManuallyDestructible> QueryBoundWithValues(
             IntPtr preparedStatement,
             object[] queryValues,
             ISerializer serializer,
             bool hasConsistencyLevel,
             ushort consistencyLevel,
-            bool isIdempotent)
+            bool isIdempotent,
+            int pageSize)
         {
             var populateCtx = SerializationHandler.CreateContext(queryValues, serializer);
             var ctxIntPtr = (IntPtr)Unsafe.AsPointer(ref populateCtx);
@@ -220,7 +225,8 @@ namespace Cassandra
             var executionOptions = new PreparedStatementExecutionOptions(
                 hasConsistencyLevel,
                 consistencyLevel,
-                isIdempotent);
+                isIdempotent,
+                pageSize);
 
             var task = RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) =>
                 session_query_bound_with_values(
@@ -336,15 +342,18 @@ namespace Cassandra
             internal readonly ushort ConsistencyLevel;
             internal readonly FFIBool HasConsistencyLevel;
             internal readonly FFIBool IsIdempotent;
+            internal readonly int PageSize;
 
             internal PreparedStatementExecutionOptions(
                 bool hasConsistencyLevel,
                 ushort consistencyLevel,
-                bool isIdempotent)
+                bool isIdempotent,
+                int pageSize)
             {
                 HasConsistencyLevel = hasConsistencyLevel;
                 ConsistencyLevel = consistencyLevel;
                 IsIdempotent = isIdempotent;
+                PageSize = pageSize;
             }
         }
 

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -35,7 +35,7 @@ namespace Cassandra
         unsafe private static extern void session_shutdown(Tcb<ManuallyDestructible> tcb, IntPtr session);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern void session_query(Tcb<ManuallyDestructible> tcb, IntPtr session, [MarshalAs(UnmanagedType.LPUTF8Str)] string statement);
+        unsafe private static extern void session_query(Tcb<ManuallyDestructible> tcb, IntPtr session, [MarshalAs(UnmanagedType.LPUTF8Str)] string statement, SimpleStatementExecutionOptions executionOptions);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         private static extern FFIMaybeException session_get_cluster_state(IntPtr sessionPtr, out ManuallyDestructible clusterState, IntPtr constructorsPtr);
@@ -49,7 +49,7 @@ namespace Cassandra
         /// of the call; it is not used after this function returns.
         /// </summary>
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
-        unsafe private static extern void session_query_with_values(Tcb<ManuallyDestructible> tcb, IntPtr session, [MarshalAs(UnmanagedType.LPUTF8Str)] string statement, IntPtr populateValuesContext, IntPtr populateValuesCallback);
+        unsafe private static extern void session_query_with_values(Tcb<ManuallyDestructible> tcb, IntPtr session, [MarshalAs(UnmanagedType.LPUTF8Str)] string statement, IntPtr populateValuesContext, IntPtr populateValuesCallback, SimpleStatementExecutionOptions executionOptions);
 
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         unsafe private static extern void session_prepare(Tcb<ManuallyDestructible> tcb, IntPtr session, [MarshalAs(UnmanagedType.LPUTF8Str)] string statement);
@@ -116,7 +116,8 @@ namespace Cassandra
         /// <param name="statement">CQL statement to be executed on the session.</param>
         internal Task<ManuallyDestructible> Query(string statement)
         {
-            return RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) => session_query(tcb, ptr, statement));
+            var executionOptions = new SimpleStatementExecutionOptions();
+            return RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) => session_query(tcb, ptr, statement, executionOptions));
         }
 
         /// <summary>
@@ -129,11 +130,13 @@ namespace Cassandra
         {
             var populateCtx = SerializationHandler.CreateContext(queryValues, serializer);
             var ctxIntPtr = (IntPtr)Unsafe.AsPointer(ref populateCtx);
+            var executionOptions = new SimpleStatementExecutionOptions();
             var task = RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) =>
                 session_query_with_values(
                     tcb, ptr, statement,
                     ctxIntPtr,
-                    (IntPtr)SerializationHandler.PopulateValuesPtr));
+                    (IntPtr)SerializationHandler.PopulateValuesPtr,
+                    executionOptions));
             GC.KeepAlive(populateCtx);
             return task;
         }
@@ -321,6 +324,18 @@ namespace Cassandra
                 ConsistencyLevel = consistencyLevel;
                 IsIdempotent = isIdempotent;
             }
+        }
+
+        /// <summary>
+        /// Execution options passed alongside a simple (unprepared) statement.
+        /// Any changes to this struct must be mirrored in the Rust FFI definition.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct SimpleStatementExecutionOptions
+        {
+            // Placeholder field so the struct is non-empty (required for FFI safety).
+            // Will be replaced by actual fields in subsequent commits.
+            private readonly byte _padding;
         }
     }
 }

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -117,14 +117,16 @@ namespace Cassandra
         /// <param name="hasConsistencyLevel">Whether a consistency level override was specified.</param>
         /// <param name="consistencyLevel">Consistency level to use for the query.</param>
         /// <param name="isIdempotent">Whether the query is idempotent.</param>
+        /// <param name="pageSize">Page size for the query (must be positive).</param>
         internal Task<ManuallyDestructible> Query(
             string statement,
             bool hasConsistencyLevel,
             ushort consistencyLevel,
-            bool isIdempotent)
+            bool isIdempotent,
+            int pageSize)
         {
             var executionOptions = new SimpleStatementExecutionOptions(
-                hasConsistencyLevel, consistencyLevel, isIdempotent);
+                hasConsistencyLevel, consistencyLevel, isIdempotent, pageSize);
             return RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) => session_query(tcb, ptr, statement, executionOptions));
         }
 
@@ -137,18 +139,20 @@ namespace Cassandra
         /// <param name="hasConsistencyLevel">Whether a consistency level override was specified.</param>
         /// <param name="consistencyLevel">Consistency level to use for the query.</param>
         /// <param name="isIdempotent">Whether the query is idempotent.</param>
+        /// <param name="pageSize">Page size for the query (must be positive).</param>
         internal unsafe Task<ManuallyDestructible> QueryWithValues(
             string statement,
             object[] queryValues,
             ISerializer serializer,
             bool hasConsistencyLevel,
             ushort consistencyLevel,
-            bool isIdempotent)
+            bool isIdempotent,
+            int pageSize)
         {
             var populateCtx = SerializationHandler.CreateContext(queryValues, serializer);
             var ctxIntPtr = (IntPtr)Unsafe.AsPointer(ref populateCtx);
             var executionOptions = new SimpleStatementExecutionOptions(
-                hasConsistencyLevel, consistencyLevel, isIdempotent);
+                hasConsistencyLevel, consistencyLevel, isIdempotent, pageSize);
             var task = RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) =>
                 session_query_with_values(
                     tcb, ptr, statement,
@@ -354,15 +358,18 @@ namespace Cassandra
             internal readonly ushort ConsistencyLevel;
             internal readonly FFIBool HasConsistencyLevel;
             internal readonly FFIBool IsIdempotent;
+            internal readonly int PageSize;
 
             internal SimpleStatementExecutionOptions(
                 bool hasConsistencyLevel,
                 ushort consistencyLevel,
-                bool isIdempotent)
+                bool isIdempotent,
+                int pageSize)
             {
                 HasConsistencyLevel = hasConsistencyLevel;
                 ConsistencyLevel = consistencyLevel;
                 IsIdempotent = isIdempotent;
+                PageSize = pageSize;
             }
         }
     }

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -114,9 +114,10 @@ namespace Cassandra
         /// Executes a query on the session.
         /// </summary>
         /// <param name="statement">CQL statement to be executed on the session.</param>
-        internal Task<ManuallyDestructible> Query(string statement)
+        /// <param name="isIdempotent">Whether the query is idempotent.</param>
+        internal Task<ManuallyDestructible> Query(string statement, bool isIdempotent)
         {
-            var executionOptions = new SimpleStatementExecutionOptions();
+            var executionOptions = new SimpleStatementExecutionOptions(isIdempotent);
             return RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) => session_query(tcb, ptr, statement, executionOptions));
         }
 
@@ -126,11 +127,12 @@ namespace Cassandra
         /// <param name="statement">CQL statement to be executed on the session.</param>
         /// <param name="queryValues">Values to be serialized on demand and bound to the query.</param>
         /// <param name="serializer">Serializer to use for converting CLR values to CQL bytes.</param>
-        internal unsafe Task<ManuallyDestructible> QueryWithValues(string statement, object[] queryValues, ISerializer serializer)
+        /// <param name="isIdempotent">Whether the query is idempotent.</param>
+        internal unsafe Task<ManuallyDestructible> QueryWithValues(string statement, object[] queryValues, ISerializer serializer, bool isIdempotent)
         {
             var populateCtx = SerializationHandler.CreateContext(queryValues, serializer);
             var ctxIntPtr = (IntPtr)Unsafe.AsPointer(ref populateCtx);
-            var executionOptions = new SimpleStatementExecutionOptions();
+            var executionOptions = new SimpleStatementExecutionOptions(isIdempotent);
             var task = RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) =>
                 session_query_with_values(
                     tcb, ptr, statement,
@@ -333,9 +335,12 @@ namespace Cassandra
         [StructLayout(LayoutKind.Sequential)]
         private readonly struct SimpleStatementExecutionOptions
         {
-            // Placeholder field so the struct is non-empty (required for FFI safety).
-            // Will be replaced by actual fields in subsequent commits.
-            private readonly byte _padding;
+            internal readonly FFIBool IsIdempotent;
+
+            internal SimpleStatementExecutionOptions(bool isIdempotent)
+            {
+                IsIdempotent = isIdempotent;
+            }
         }
     }
 }

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -114,10 +114,17 @@ namespace Cassandra
         /// Executes a query on the session.
         /// </summary>
         /// <param name="statement">CQL statement to be executed on the session.</param>
+        /// <param name="hasConsistencyLevel">Whether a consistency level override was specified.</param>
+        /// <param name="consistencyLevel">Consistency level to use for the query.</param>
         /// <param name="isIdempotent">Whether the query is idempotent.</param>
-        internal Task<ManuallyDestructible> Query(string statement, bool isIdempotent)
+        internal Task<ManuallyDestructible> Query(
+            string statement,
+            bool hasConsistencyLevel,
+            ushort consistencyLevel,
+            bool isIdempotent)
         {
-            var executionOptions = new SimpleStatementExecutionOptions(isIdempotent);
+            var executionOptions = new SimpleStatementExecutionOptions(
+                hasConsistencyLevel, consistencyLevel, isIdempotent);
             return RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) => session_query(tcb, ptr, statement, executionOptions));
         }
 
@@ -127,12 +134,21 @@ namespace Cassandra
         /// <param name="statement">CQL statement to be executed on the session.</param>
         /// <param name="queryValues">Values to be serialized on demand and bound to the query.</param>
         /// <param name="serializer">Serializer to use for converting CLR values to CQL bytes.</param>
+        /// <param name="hasConsistencyLevel">Whether a consistency level override was specified.</param>
+        /// <param name="consistencyLevel">Consistency level to use for the query.</param>
         /// <param name="isIdempotent">Whether the query is idempotent.</param>
-        internal unsafe Task<ManuallyDestructible> QueryWithValues(string statement, object[] queryValues, ISerializer serializer, bool isIdempotent)
+        internal unsafe Task<ManuallyDestructible> QueryWithValues(
+            string statement,
+            object[] queryValues,
+            ISerializer serializer,
+            bool hasConsistencyLevel,
+            ushort consistencyLevel,
+            bool isIdempotent)
         {
             var populateCtx = SerializationHandler.CreateContext(queryValues, serializer);
             var ctxIntPtr = (IntPtr)Unsafe.AsPointer(ref populateCtx);
-            var executionOptions = new SimpleStatementExecutionOptions(isIdempotent);
+            var executionOptions = new SimpleStatementExecutionOptions(
+                hasConsistencyLevel, consistencyLevel, isIdempotent);
             var task = RunAsyncWithIncrement<ManuallyDestructible>((tcb, ptr) =>
                 session_query_with_values(
                     tcb, ptr, statement,
@@ -335,10 +351,17 @@ namespace Cassandra
         [StructLayout(LayoutKind.Sequential)]
         private readonly struct SimpleStatementExecutionOptions
         {
+            internal readonly ushort ConsistencyLevel;
+            internal readonly FFIBool HasConsistencyLevel;
             internal readonly FFIBool IsIdempotent;
 
-            internal SimpleStatementExecutionOptions(bool isIdempotent)
+            internal SimpleStatementExecutionOptions(
+                bool hasConsistencyLevel,
+                ushort consistencyLevel,
+                bool isIdempotent)
             {
+                HasConsistencyLevel = hasConsistencyLevel;
+                ConsistencyLevel = consistencyLevel;
                 IsIdempotent = isIdempotent;
             }
         }

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -261,18 +261,20 @@ namespace Cassandra
                     {
                         string queryString = s.QueryString;
                         object[] queryValues = s.QueryValues ?? [];
+                        bool isIdempotent = s.IsIdempotent ?? Configuration.QueryOptions.GetDefaultIdempotence();
 
                         Task<RustBridge.ManuallyDestructible> task;
                         if (queryValues.Length == 0)
                         {
-                            task = bridgedSession.Query(queryString);
+                            task = bridgedSession.Query(queryString, isIdempotent);
                         }
                         else
                         {
                             task = bridgedSession.QueryWithValues(
                                 queryString,
                                 queryValues,
-                                _serializerManager.GetCurrentSerializer()
+                                _serializerManager.GetCurrentSerializer(),
+                                isIdempotent
                             );
                         }
 
@@ -286,6 +288,7 @@ namespace Cassandra
                             return rowSet;
                         }, TaskContinuationOptions.ExecuteSynchronously);
                     }
+
                 case BoundStatement bs:
                     {
                         // Extract consistency level and idempotence overrides from the BoundStatement, if provided.
@@ -334,6 +337,7 @@ namespace Cassandra
                             return new RowSet(mdRowSet, _serializerManager);
                         }, TaskContinuationOptions.ExecuteSynchronously);
                     }
+
                 case BatchStatement s:
                     throw new NotImplementedException("Batches are not yet supported");
 

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -261,12 +261,19 @@ namespace Cassandra
                     {
                         string queryString = s.QueryString;
                         object[] queryValues = s.QueryValues ?? [];
+                        bool hasConsistencyLevel = s.ConsistencyLevel.HasValue;
+                        ushort consistencyLevel = s.ConsistencyLevel.HasValue ? (ushort)s.ConsistencyLevel.Value : (ushort)999;
                         bool isIdempotent = s.IsIdempotent ?? Configuration.QueryOptions.GetDefaultIdempotence();
 
                         Task<RustBridge.ManuallyDestructible> task;
                         if (queryValues.Length == 0)
                         {
-                            task = bridgedSession.Query(queryString, isIdempotent);
+                            task = bridgedSession.Query(
+                                queryString,
+                                hasConsistencyLevel,
+                                consistencyLevel,
+                                isIdempotent
+                            );
                         }
                         else
                         {
@@ -274,6 +281,8 @@ namespace Cassandra
                                 queryString,
                                 queryValues,
                                 _serializerManager.GetCurrentSerializer(),
+                                hasConsistencyLevel,
+                                consistencyLevel,
                                 isIdempotent
                             );
                         }

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -264,6 +264,13 @@ namespace Cassandra
                         bool hasConsistencyLevel = s.ConsistencyLevel.HasValue;
                         ushort consistencyLevel = s.ConsistencyLevel.HasValue ? (ushort)s.ConsistencyLevel.Value : (ushort)999;
                         bool isIdempotent = s.IsIdempotent ?? Configuration.QueryOptions.GetDefaultIdempotence();
+                        int pageSize = s.PageSize <= 0 ? Configuration.QueryOptions.GetPageSize() : s.PageSize;
+                        if (pageSize == int.MaxValue)
+                        {
+                            throw new NotImplementedException(
+                                "Disabling paging (PageSize == int.MaxValue) is not yet supported. " +
+                                "This requires using the Rust driver's unpaged query API, which is not yet bridged.");
+                        }
 
                         Task<RustBridge.ManuallyDestructible> task;
                         if (queryValues.Length == 0)
@@ -272,7 +279,8 @@ namespace Cassandra
                                 queryString,
                                 hasConsistencyLevel,
                                 consistencyLevel,
-                                isIdempotent
+                                isIdempotent,
+                                pageSize
                             );
                         }
                         else
@@ -283,7 +291,8 @@ namespace Cassandra
                                 _serializerManager.GetCurrentSerializer(),
                                 hasConsistencyLevel,
                                 consistencyLevel,
-                                isIdempotent
+                                isIdempotent,
+                                pageSize
                             );
                         }
 
@@ -324,7 +333,8 @@ namespace Cassandra
                                 queryPrepared,
                                 hasConsistencyLevel,
                                 consistencyLevel,
-                                isIdempotent);
+                                isIdempotent
+                            );
                         }
                         else
                         {

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -258,80 +258,82 @@ namespace Cassandra
             switch (statement)
             {
                 case RegularStatement s:
-                    string queryString = s.QueryString;
-                    object[] queryValues = s.QueryValues ?? [];
-
-                    Task<RustBridge.ManuallyDestructible> task;
-                    if (queryValues.Length == 0)
                     {
-                        task = bridgedSession.Query(queryString);
+                        string queryString = s.QueryString;
+                        object[] queryValues = s.QueryValues ?? [];
+
+                        Task<RustBridge.ManuallyDestructible> task;
+                        if (queryValues.Length == 0)
+                        {
+                            task = bridgedSession.Query(queryString);
+                        }
+                        else
+                        {
+                            task = bridgedSession.QueryWithValues(
+                                queryString,
+                                queryValues,
+                                _serializerManager.GetCurrentSerializer()
+                            );
+                        }
+
+                        return task.ContinueWith(t =>
+                        {
+                            // Use GetAwaiter().GetResult() to unwrap AggregateException
+                            // and throw the inner exception directly, avoiding double-wrapping.
+                            RustBridge.ManuallyDestructible mdRowSet = t.GetAwaiter().GetResult();
+                            var rowSet = new RowSet(mdRowSet, _serializerManager);
+
+                            return rowSet;
+                        }, TaskContinuationOptions.ExecuteSynchronously);
                     }
-                    else
-                    {
-                        task = bridgedSession.QueryWithValues(
-                            queryString,
-                            queryValues,
-                            _serializerManager.GetCurrentSerializer()
-                        );
-                    }
-
-                    return task.ContinueWith(t =>
-                    {
-                        // Use GetAwaiter().GetResult() to unwrap AggregateException
-                        // and throw the inner exception directly, avoiding double-wrapping.
-                        RustBridge.ManuallyDestructible mdRowSet = t.GetAwaiter().GetResult();
-                        var rowSet = new RowSet(mdRowSet, _serializerManager);
-
-                        return rowSet;
-                    }, TaskContinuationOptions.ExecuteSynchronously);
-
                 case BoundStatement bs:
-                    // Extract consistency level and idempotence overrides from the BoundStatement, if provided.
-                    // If no consistency level override is provided, we pass false and an arbitrary consistency level (999).
-                    // When the Rust driver sees hasConsistencyLevel=false, it ignores the consistency level value.
-                    bool hasConsistencyLevel = bs.ConsistencyLevel.HasValue;
-                    ushort consistencyLevel = bs.ConsistencyLevel.HasValue ? (ushort)bs.ConsistencyLevel.Value : (ushort)999;
-
-                    // When the idempotence property is null, the driver will use the default value from QueryOptions.GetDefaultIdempotence().
-                    bool isIdempotent = bs.IsIdempotent ?? Configuration.QueryOptions.GetDefaultIdempotence();
-
-                    // The managed PreparedStatement object (and the BoundStatement that
-                    // references it) is rooted here by the local variable `bs`. Because there's an
-                    // active reference in this scope, the GC will not collect the managed object
-                    // while this method is executing — so the native resource under the pointer
-                    // is guaranteed to still exist for the duration of this call.
-                    IntPtr queryPrepared = bs.PreparedStatement.bridgedPreparedStatement.DangerousGetHandle();
-                    object[] queryValuesBound = bs.QueryValues ?? [];
-
-                    Task<RustBridge.ManuallyDestructible> boundTask;
-                    if (queryValuesBound.Length == 0)
                     {
-                        boundTask = bridgedSession.QueryBound(
-                            queryPrepared,
-                            hasConsistencyLevel,
-                            consistencyLevel,
-                            isIdempotent);
+                        // Extract consistency level and idempotence overrides from the BoundStatement, if provided.
+                        // If no consistency level override is provided, we pass false and an arbitrary consistency level (999).
+                        // When the Rust driver sees hasConsistencyLevel=false, it ignores the consistency level value.
+                        bool hasConsistencyLevel = bs.ConsistencyLevel.HasValue;
+                        ushort consistencyLevel = bs.ConsistencyLevel.HasValue ? (ushort)bs.ConsistencyLevel.Value : (ushort)999;
+
+                        // When the idempotence property is null, the driver will use the default value from QueryOptions.GetDefaultIdempotence().
+                        bool isIdempotent = bs.IsIdempotent ?? Configuration.QueryOptions.GetDefaultIdempotence();
+
+                        // The managed PreparedStatement object (and the BoundStatement that
+                        // references it) is rooted here by the local variable `bs`. Because there's an
+                        // active reference in this scope, the GC will not collect the managed object
+                        // while this method is executing — so the native resource under the pointer
+                        // is guaranteed to still exist for the duration of this call.
+                        IntPtr queryPrepared = bs.PreparedStatement.bridgedPreparedStatement.DangerousGetHandle();
+                        object[] queryValuesBound = bs.QueryValues ?? [];
+
+                        Task<RustBridge.ManuallyDestructible> boundTask;
+                        if (queryValuesBound.Length == 0)
+                        {
+                            boundTask = bridgedSession.QueryBound(
+                                queryPrepared,
+                                hasConsistencyLevel,
+                                consistencyLevel,
+                                isIdempotent);
+                        }
+                        else
+                        {
+                            boundTask = bridgedSession.QueryBoundWithValues(
+                                queryPrepared,
+                                queryValuesBound,
+                                _serializerManager.GetCurrentSerializer(),
+                                hasConsistencyLevel,
+                                consistencyLevel,
+                                isIdempotent
+                            );
+                        }
+
+                        return boundTask.ContinueWith(t =>
+                        {
+                            // Use GetAwaiter().GetResult() to unwrap AggregateException
+                            // and throw the inner exception directly, avoiding double-wrapping.
+                            RustBridge.ManuallyDestructible mdRowSet = t.GetAwaiter().GetResult();
+                            return new RowSet(mdRowSet, _serializerManager);
+                        }, TaskContinuationOptions.ExecuteSynchronously);
                     }
-                    else
-                    {
-                        boundTask = bridgedSession.QueryBoundWithValues(
-                            queryPrepared,
-                            queryValuesBound,
-                            _serializerManager.GetCurrentSerializer(),
-                            hasConsistencyLevel,
-                            consistencyLevel,
-                            isIdempotent
-                        );
-                    }
-
-                    return boundTask.ContinueWith(t =>
-                    {
-                        // Use GetAwaiter().GetResult() to unwrap AggregateException
-                        // and throw the inner exception directly, avoiding double-wrapping.
-                        RustBridge.ManuallyDestructible mdRowSet = t.GetAwaiter().GetResult();
-                        return new RowSet(mdRowSet, _serializerManager);
-                    }, TaskContinuationOptions.ExecuteSynchronously);
-
                 case BatchStatement s:
                     throw new NotImplementedException("Batches are not yet supported");
 

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -317,6 +317,13 @@ namespace Cassandra
 
                         // When the idempotence property is null, the driver will use the default value from QueryOptions.GetDefaultIdempotence().
                         bool isIdempotent = bs.IsIdempotent ?? Configuration.QueryOptions.GetDefaultIdempotence();
+                        int pageSize = bs.PageSize <= 0 ? Configuration.QueryOptions.GetPageSize() : bs.PageSize;
+                        if (pageSize == int.MaxValue)
+                        {
+                            throw new NotImplementedException(
+                                "Disabling paging (PageSize == int.MaxValue) is not yet supported. " +
+                                "This requires using the Rust driver's unpaged query API, which is not yet bridged.");
+                        }
 
                         // The managed PreparedStatement object (and the BoundStatement that
                         // references it) is rooted here by the local variable `bs`. Because there's an
@@ -333,7 +340,8 @@ namespace Cassandra
                                 queryPrepared,
                                 hasConsistencyLevel,
                                 consistencyLevel,
-                                isIdempotent
+                                isIdempotent,
+                                pageSize
                             );
                         }
                         else
@@ -344,7 +352,8 @@ namespace Cassandra
                                 _serializerManager.GetCurrentSerializer(),
                                 hasConsistencyLevel,
                                 consistencyLevel,
-                                isIdempotent
+                                isIdempotent,
+                                pageSize
                             );
                         }
 


### PR DESCRIPTION
This PR:
1. introduces `SimpleStatementExecutionOptions`, analogous to `PreparedStatementExecutionOptions`;
2. populates it with `isIdempotent` and `consistencyLevel`, which were already present in `PreparedStatementExecutionOptions`;
3. adds `pageSize` to both `{Simple,Prepared}StatementExecutionOptions`.

Unfortunately, no new tests are enabled:
- unit tests are not portable, because we don't/can't mock `PreparedStatement` (we currently require a Rust PreparedStatement inside, which is itself not mockable);
- all integration tests that I saw were still missing some functionality or were using internal APIs which are no longer available. I encourage reviewers (especially @sylwiaszunejko and @hmarszalek) to help me identify portable tests;
- writing tests for the C#->Rust statement execution bridge is hard (#139).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.
- [ ] I added appropriate `Fixes:` annotations to PR description.