### PR TITLE
Simple fixes for bridging Hosts and MaybeShutdownError

### DIFF
--- a/rust/src/error_conversion.rs
+++ b/rust/src/error_conversion.rs
@@ -308,10 +308,11 @@ impl DeserializationExceptionConstructor {
 
 // Special errors for C# wrapper.
 
-/// Wrapper enum to represent errors that may occur normally or indicate that the session has been
-/// shut down. It allows to return a clear error condition while satisfying the return type requirements.
+/// Wrapper enum to represent errors that may occur during session operations:
+/// session shutdown errors, invalid argument errors, or normal operation errors.
+/// It allows to return a clear error condition while satisfying the return type requirements.
 #[derive(Error, Debug, Clone)]
-pub(crate) enum MaybeShutdownError<E> {
+pub(crate) enum SessionOperationError<E> {
     #[error("Error: {0}")]
     Inner(E),
 
@@ -683,19 +684,19 @@ impl ErrorToException for TypeCheckError {
     }
 }
 
-impl<E> ErrorToException for MaybeShutdownError<E>
+impl<E> ErrorToException for SessionOperationError<E>
 where
     E: ErrorToException,
 {
     fn to_exception(self, ctors: &ExceptionConstructors) -> FFIException {
         match self {
-            MaybeShutdownError::Inner(e) => e.to_exception(ctors),
-            MaybeShutdownError::AlreadyShutdown => ctors
+            SessionOperationError::Inner(e) => e.to_exception(ctors),
+            SessionOperationError::AlreadyShutdown => ctors
                 .already_shutdown_exception_constructor
                 .construct_from_rust(
                     "Session has been shut down and can no longer execute operations",
                 ),
-            MaybeShutdownError::InvalidArgument(msg) => ctors
+            SessionOperationError::InvalidArgument(msg) => ctors
                 .invalid_argument_exception_constructor
                 .construct_from_rust(&msg),
         }

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -28,16 +28,23 @@ pub struct RefreshContextPtr(FFIPtr<'static, RefreshContext>);
 ///
 /// # Safety
 /// - All pointer parameters must be immediately copied/consumed during the callback invocation
-/// - String pointers (datacenter_ptr, rack_ptr) are only valid for the duration of the callback
+/// - String pointers are only valid for the duration of the callback
 /// - The callback must not store these pointers or access them after returning
 type ConstructCSharpHost = unsafe extern "C" fn(
     refresh_context_ptr: RefreshContextPtr,
-    id_bytes: FFISlice<'_, u8>,
-    ip_bytes: FFISlice<'_, u8>,
-    port: u16,
-    datacenter: FFIStr<'_>,
-    rack: FFIStr<'_>,
+    csharp_host_data: CSharpHostData<'_>,
 ) -> FFIMaybeException;
+
+/// Struct for passing node metadata from Rust to C# in a single callback parameter.
+/// Any change to this struct must be reflected in the C# definition and the AddHostToList method.
+#[repr(C)]
+pub struct CSharpHostData<'a> {
+    id_bytes: FFISlice<'a, u8>,
+    ip_bytes: FFISlice<'a, u8>,
+    port: u16,
+    datacenter: FFIStr<'a>,
+    rack: FFIStr<'a>,
+}
 
 /// Populates a C# RefreshContext with node information from the cluster state.
 /// For each node in the cluster state, this function:
@@ -105,11 +112,13 @@ pub extern "C" fn cluster_state_fill_nodes(
         unsafe {
             let ffi_exception = callback(
                 refresh_context_ptr,
-                uuid_bytes,
-                ip_bytes,
-                port,
-                dc_str,
-                rack_str,
+                CSharpHostData {
+                    id_bytes: uuid_bytes,
+                    ip_bytes,
+                    port,
+                    datacenter: dc_str,
+                    rack: rack_str,
+                },
             );
             if ffi_exception.has_exception() {
                 return ffi_exception;

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -30,7 +30,6 @@ pub struct RefreshContextPtr(FFIPtr<'static, RefreshContext>);
 /// - All pointer parameters must be immediately copied/consumed during the callback invocation
 /// - String pointers (datacenter_ptr, rack_ptr) are only valid for the duration of the callback
 /// - The callback must not store these pointers or access them after returning
-/// - The callback must not throw exceptions across the FFI boundary
 type ConstructCSharpHost = unsafe extern "C" fn(
     refresh_context_ptr: RefreshContextPtr,
     id_bytes: FFISlice<'_, u8>,
@@ -38,7 +37,7 @@ type ConstructCSharpHost = unsafe extern "C" fn(
     port: u16,
     datacenter: FFIStr<'_>,
     rack: FFIStr<'_>,
-);
+) -> FFIMaybeException;
 
 /// Populates a C# RefreshContext with node information from the cluster state.
 /// For each node in the cluster state, this function:
@@ -50,7 +49,7 @@ type ConstructCSharpHost = unsafe extern "C" fn(
 /// - `refresh_context_ptr` must point to a valid C# RefreshContext that remains allocated during this call
 /// - All string pointers passed to the callback are temporary and only valid during that invocation
 /// - The callback must copy string data (e.g., via Marshal.PtrToStringUTF8) and byte arrays (IP, host ID) immediately.
-/// - The callback must not throw exceptions; use Environment.FailFast on errors
+/// - The callback must return a valid FFIMaybeException.
 #[unsafe(no_mangle)]
 pub extern "C" fn cluster_state_fill_nodes(
     cluster_state_ptr: BridgedBorrowedSharedPtr<'_, ClusterState>,
@@ -104,7 +103,7 @@ pub extern "C" fn cluster_state_fill_nodes(
         // All pointers passed to the callback are only valid during this invocation.
         // The callback must copy all data immediately.
         unsafe {
-            callback(
+            let ffi_exception = callback(
                 refresh_context_ptr,
                 uuid_bytes,
                 ip_bytes,
@@ -112,6 +111,9 @@ pub extern "C" fn cluster_state_fill_nodes(
                 dc_str,
                 rack_str,
             );
+            if ffi_exception.has_exception() {
+                return ffi_exception;
+            }
         }
     }
 

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -9,7 +9,7 @@ use scylla::statement::Statement;
 use scylla_cql::serialize::row::SerializedValues;
 use tokio::sync::RwLock;
 
-use crate::error_conversion::{FFIMaybeException, MaybeShutdownError};
+use crate::error_conversion::{FFIMaybeException, SessionOperationError};
 use crate::ffi::{
     ArcFFI, BridgedBorrowedSharedPtr, BridgedOwnedSharedPtr, CSharpManagedStringPtr, CSharpStr,
     FFI, FFIBool, FFIStr, FromArc, WriteStringCallback,
@@ -152,18 +152,18 @@ pub extern "C" fn session_query(
     // If the operation fails, treat it as session shutting down.
     let session_guard_res = session_arc.try_read_owned();
 
-    BridgedFuture::spawn::<_, _, MaybeShutdownError<PagerExecutionError>, _>(tcb, async move {
+    BridgedFuture::spawn::<_, _, SessionOperationError<PagerExecutionError>, _>(tcb, async move {
         tracing::debug!("[FFI] Executing statement \"{}\"", statement);
 
         let Ok(session_guard) = session_guard_res else {
             // Session is currently shutting down - exit with appropriate error.
-            return Err(MaybeShutdownError::AlreadyShutdown);
+            return Err(SessionOperationError::AlreadyShutdown);
         };
 
         // Check if session is connected or if it has been shut down.
         // If it has been shut down, return appropriate error.
         let Some(session) = session_guard.session.as_ref() else {
-            return Err(MaybeShutdownError::AlreadyShutdown);
+            return Err(SessionOperationError::AlreadyShutdown);
         };
 
         let mut statement = Statement::new(statement);
@@ -175,7 +175,7 @@ pub extern "C" fn session_query(
                 .consistency_level
                 .try_into()
                 .map_err(|err| {
-                    MaybeShutdownError::InvalidArgument(format!(
+                    SessionOperationError::InvalidArgument(format!(
                         "Invalid consistency level value {0} passed from C# for simple query: {1}",
                         execution_options.consistency_level, err
                     ))
@@ -187,12 +187,12 @@ pub extern "C" fn session_query(
 
         // Lock is held for the entire duration of the query operation,
         // preventing shutdown until this future completes
-        // Map underlying `PagerExecutionError` into `MaybeShutdownError::Inner` so
+        // Map underlying `PagerExecutionError` into `SessionOperationError::Inner` so
         // the BridgedFuture's error type matches.
         let query_pager = session
             .query_iter(statement, ())
             .await
-            .map_err(MaybeShutdownError::Inner)?;
+            .map_err(SessionOperationError::Inner)?;
 
         tracing::trace!("[FFI] Statement executed");
 
@@ -230,7 +230,7 @@ pub extern "C" fn session_query_with_values(
     // If the operation fails, treat it as session shutting down.
     let session_guard_res = session_arc.try_read_owned();
 
-    BridgedFuture::spawn::<_, _, MaybeShutdownError<PagerExecutionError>, _>(tcb, async move {
+    BridgedFuture::spawn::<_, _, SessionOperationError<PagerExecutionError>, _>(tcb, async move {
         tracing::debug!(
             "[FFI] Preparing and executing statement with pre-serialized values \"{}\"",
             statement
@@ -238,21 +238,21 @@ pub extern "C" fn session_query_with_values(
 
         let Ok(session_guard) = session_guard_res else {
             // Session is currently shutting down - exit with appropriate error.
-            return Err(MaybeShutdownError::AlreadyShutdown);
+            return Err(SessionOperationError::AlreadyShutdown);
         };
 
         // Check if session is connected or if it has been shut down.
         // If it has been shut down, return appropriate error.
         let Some(session) = session_guard.session.as_ref() else {
-            return Err(MaybeShutdownError::AlreadyShutdown);
+            return Err(SessionOperationError::AlreadyShutdown);
         };
 
         // First, prepare the statement. Map PrepareError into PagerExecutionError::PrepareError
-        // and then into MaybeShutdownError::Inner so the error type matches.
+        // and then into SessionOperationError::Inner so the error type matches.
         let mut prepared = session
             .prepare(statement)
             .await
-            .map_err(|e| MaybeShutdownError::Inner(PagerExecutionError::PrepareError(e)))?;
+            .map_err(|e| SessionOperationError::Inner(PagerExecutionError::PrepareError(e)))?;
 
         prepared.set_is_idempotent(bool::from(execution_options.is_idempotent));
         prepared.set_page_size(execution_options.page_size);
@@ -262,7 +262,7 @@ pub extern "C" fn session_query_with_values(
                 .consistency_level
                 .try_into()
                 .map_err(|err| {
-                    MaybeShutdownError::InvalidArgument(format!(
+                    SessionOperationError::InvalidArgument(format!(
                         "Invalid consistency level value {0} passed from C# for simple query with values: {1}",
                         execution_options.consistency_level, err
                     ))
@@ -280,7 +280,7 @@ pub extern "C" fn session_query_with_values(
         let query_pager = session
             .execute_iter_preserialized(prepared, serialized_values)
             .await
-            .map_err(MaybeShutdownError::Inner)?;
+            .map_err(SessionOperationError::Inner)?;
 
         tracing::trace!("[FFI] Prepared statement executed with pre-serialized values");
 
@@ -309,28 +309,28 @@ pub extern "C" fn session_prepare(
     // If the operation fails, treat it as session shutting down.
     let session_guard_res = session_arc.try_read_owned();
 
-    BridgedFuture::spawn::<_, _, MaybeShutdownError<PrepareError>, _>(tcb, async move {
+    BridgedFuture::spawn::<_, _, SessionOperationError<PrepareError>, _>(tcb, async move {
         tracing::debug!("[FFI] Preparing statement \"{}\"", statement);
 
         let Ok(session_guard) = session_guard_res else {
             // Session is currently shutting down - exit with appropriate error.
-            return Err(MaybeShutdownError::AlreadyShutdown);
+            return Err(SessionOperationError::AlreadyShutdown);
         };
 
         // Check if session is connected or if it has been shut down.
         // If it has been shut down, return appropriate error.
         let Some(session) = session_guard.session.as_ref() else {
-            return Err(MaybeShutdownError::AlreadyShutdown);
+            return Err(SessionOperationError::AlreadyShutdown);
         };
 
         // Lock is held for the entire duration of the prepare operation,
         // preventing shutdown until this future completes
-        // Map underlying `PrepareError` into `MaybeShutdownError::Inner` so
+        // Map underlying `PrepareError` into `SessionOperationError::Inner` so
         // the BridgedFuture's error type matches.
         let ps = session
             .prepare(statement)
             .await
-            .map_err(MaybeShutdownError::Inner)?;
+            .map_err(SessionOperationError::Inner)?;
 
         tracing::trace!("[FFI] Statement prepared");
 
@@ -364,18 +364,18 @@ pub extern "C" fn session_query_bound(
         .expect("poisoning impossible due to process-aborting panics")
         .clone();
 
-    BridgedFuture::spawn::<_, _, MaybeShutdownError<PagerExecutionError>, _>(tcb, async move {
+    BridgedFuture::spawn::<_, _, SessionOperationError<PagerExecutionError>, _>(tcb, async move {
         tracing::debug!("[FFI] Executing prepared statement");
 
         let Ok(session_guard) = session_guard_res else {
             // Session is currently shutting down - exit with appropriate error.
-            return Err(MaybeShutdownError::AlreadyShutdown);
+            return Err(SessionOperationError::AlreadyShutdown);
         };
 
         // Check if session is connected or if it has been shut down.
         // If it has been shut down, return appropriate error.
         let Some(session) = session_guard.session.as_ref() else {
-            return Err(MaybeShutdownError::AlreadyShutdown);
+            return Err(SessionOperationError::AlreadyShutdown);
         };
 
         // If consistency level was provided, apply it to the prepared statement. Otherwise, if consistency level
@@ -387,7 +387,7 @@ pub extern "C" fn session_query_bound(
                 .consistency_level
                 .try_into()
                 .map_err(|err| {
-                    MaybeShutdownError::InvalidArgument(format!(
+                    SessionOperationError::InvalidArgument(format!(
                         "Invalid consistency level value {0} passed from C# for bound query: {1}",
                         execution_options.consistency_level, err
                     ))
@@ -402,12 +402,12 @@ pub extern "C" fn session_query_bound(
 
         // Lock is held for the entire duration of the query operation,
         // preventing shutdown until this future completes
-        // Map underlying `PagerExecutionError` into `MaybeShutdownError::Inner` so
+        // Map underlying `PagerExecutionError` into `SessionOperationError::Inner` so
         // the BridgedFuture's error type matches.
         let query_pager = session
             .execute_iter(prepared_statement, ())
             .await
-            .map_err(MaybeShutdownError::Inner)?;
+            .map_err(SessionOperationError::Inner)?;
 
         tracing::trace!("[FFI] Prepared statement executed");
 
@@ -453,18 +453,18 @@ pub extern "C" fn session_query_bound_with_values(
         .expect("poisoning impossible due to process-aborting panics")
         .clone();
 
-    BridgedFuture::spawn::<_, _, MaybeShutdownError<PagerExecutionError>, _>(tcb, async move {
+    BridgedFuture::spawn::<_, _, SessionOperationError<PagerExecutionError>, _>(tcb, async move {
         tracing::debug!("[FFI] Executing prepared statement");
 
         let Ok(session_guard) = session_guard_res else {
             // Session is currently shutting down - exit with appropriate error.
-            return Err(MaybeShutdownError::AlreadyShutdown);
+            return Err(SessionOperationError::AlreadyShutdown);
         };
 
         // Check if session is connected or if it has been shut down.
         // If it has been shut down, return appropriate error.
         let Some(session) = session_guard.session.as_ref() else {
-            return Err(MaybeShutdownError::AlreadyShutdown);
+            return Err(SessionOperationError::AlreadyShutdown);
         };
 
         // If consistency level was provided, apply it to the prepared statement. Otherwise, if consistency level
@@ -476,7 +476,7 @@ pub extern "C" fn session_query_bound_with_values(
                 .consistency_level
                 .try_into()
                 .map_err(|err| {
-                    MaybeShutdownError::InvalidArgument(format!(
+                    SessionOperationError::InvalidArgument(format!(
                         "Invalid consistency level value {0} passed from C# for bound query with values: {1}",
                         execution_options.consistency_level,
                         err
@@ -496,7 +496,7 @@ pub extern "C" fn session_query_bound_with_values(
         let query_pager = session
             .execute_iter_preserialized(prepared_statement, serialized_values)
             .await
-            .map_err(MaybeShutdownError::Inner)?;
+            .map_err(SessionOperationError::Inner)?;
 
         tracing::trace!("[FFI] Prepared statement executed");
 

--- a/src/Cassandra.Tests/BaseUnitTest.cs
+++ b/src/Cassandra.Tests/BaseUnitTest.cs
@@ -81,11 +81,13 @@ namespace Cassandra.Tests
 
             public IEnumerable<HostShard> NewQueryPlan(string keyspace, IStatement query)
             {
+#pragma warning disable CS0618
                 return new[]
                 {
                     new HostShard(new Host(new IPEndPoint(101L, 9042), ReconnectionPolicy), -1),
                     new HostShard(new Host(new IPEndPoint(102L, 9042), ReconnectionPolicy), -1)
                 };
+#pragma warning restore CS0618
             }
         }
     }

--- a/src/Cassandra.Tests/TestHelper.cs
+++ b/src/Cassandra.Tests/TestHelper.cs
@@ -153,6 +153,7 @@ namespace Cassandra.Tests
         public static Host CreateHost(string address, string dc = "dc1", string rack = "rack1",
                                       IEnumerable<string> tokens = null, string cassandraVersion = null)
         {
+#pragma warning disable CS0618
             var h = new Host(new IPEndPoint(IPAddress.Parse(address), ProtocolOptions.DefaultPort),
                              new ConstantReconnectionPolicy(1));
             // FIXME: internal API usage
@@ -164,6 +165,7 @@ namespace Cassandra.Tests
             //     { "release_version", cassandraVersion },
             // }));
             return h;
+#pragma warning restore CS0618
         }
 
         internal class DictionaryBasedRow : IRow

--- a/src/Cassandra/Host.cs
+++ b/src/Cassandra/Host.cs
@@ -80,10 +80,13 @@ namespace Cassandra
         /// <summary>
         /// Creates a new instance of <see cref="Host"/>.
         /// </summary>
-        // ReSharper disable once UnusedParameter.Local : Part of the public API
+        /// <note>
+        /// This constructor is obsolete and should not be used directly, reconnection policies set here are ignored.
+        /// </note>
+        [Obsolete("Custom Host instances are obsolete, since the driver manages them internally.")]
         public Host(IPEndPoint address, IReconnectionPolicy reconnectionPolicy)
         {
-            // FIXME
+            Address = address;
         }
 
         /// <summary>

--- a/src/Cassandra/RustBridge/BridgedClusterState.cs
+++ b/src/Cassandra/RustBridge/BridgedClusterState.cs
@@ -25,9 +25,9 @@ namespace Cassandra
             IntPtr contextPtr,
             IntPtr callback);
 
-        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFISliceRaw, FFISliceRaw, ushort, FFIString, FFIString, void> AddHostPtr = &AddHostToList;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFISliceRaw, FFISliceRaw, ushort, FFIString, FFIString, FFIMaybeException> AddHostPtr = &AddHostToList;
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        private static unsafe void AddHostToList(
+        private static unsafe FFIMaybeException AddHostToList(
             IntPtr contextPtr,
             FFISliceRaw idBytes,
             FFISliceRaw ipBytes,
@@ -63,7 +63,7 @@ namespace Cassandra
                     if (host.Address.Equals(address))
                     {
                         context.AddHost(host);
-                        return;
+                        return FFIMaybeException.Ok();
                     }
                 }
 
@@ -77,10 +77,10 @@ namespace Cassandra
             }
             catch (Exception ex)
             {
-                // Do not throw across FFI boundary - causes undefined behavior.
-                // Fail fast to match Rust's panic=abort behavior and make the error obvious.
-                Environment.FailFast("Fatal error in AddHostCallback", ex);
+                return FFIMaybeException.FromException(ex);
             }
+
+            return FFIMaybeException.Ok();
         }
 
         internal void FillHostCache(Metadata.RefreshContext context)

--- a/src/Cassandra/RustBridge/BridgedClusterState.cs
+++ b/src/Cassandra/RustBridge/BridgedClusterState.cs
@@ -19,21 +19,27 @@ namespace Cassandra
             return handle == other.handle;
         }
 
+        [StructLayout(LayoutKind.Sequential)]
+        struct CSharpHostData
+        {
+            public FFISliceRaw IdBytes;
+            public FFISliceRaw IpBytes;
+            public ushort Port;
+            public FFIString Datacenter;
+            public FFIString Rack;
+        }
+
         [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
         private static extern RustBridge.FFIMaybeException cluster_state_fill_nodes(
             IntPtr clusterState,
             IntPtr contextPtr,
             IntPtr callback);
 
-        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, FFISliceRaw, FFISliceRaw, ushort, FFIString, FFIString, FFIMaybeException> AddHostPtr = &AddHostToList;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<IntPtr, CSharpHostData, FFIMaybeException> AddHostPtr = &AddHostToList;
         [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
         private static unsafe FFIMaybeException AddHostToList(
             IntPtr contextPtr,
-            FFISliceRaw idBytes,
-            FFISliceRaw ipBytes,
-            ushort port,
-            FFIString datacenter,
-            FFIString rack)
+            CSharpHostData hostData)
         {
             try
             {
@@ -48,13 +54,13 @@ namespace Cassandra
                 // This matches the pattern used in row_set_fill_columns_metadata.
                 var context = Unsafe.AsRef<Metadata.RefreshContext>((void*)contextPtr);
 
-                var hostId = new Guid(idBytes.As<byte>().ToSpan());
+                var hostId = new Guid(hostData.IdBytes.As<byte>().ToSpan());
 
                 // Construct IPAddress directly from bytes (4 for IPv4, 16 for IPv6). ipBytes is an FFISlice<byte>
                 // and it accesses unmanaged memory that is only valid for the duration of this callback invocation.
                 // The IPAddress constructor must be called synchronously here so it can copy the data immediately.
-                var ipAddress = new IPAddress(ipBytes.As<byte>().ToSpan());
-                var address = new IPEndPoint(ipAddress, port);
+                var ipAddress = new IPAddress(hostData.IpBytes.As<byte>().ToSpan());
+                var address = new IPEndPoint(ipAddress, hostData.Port);
 
                 // Try to reuse existing host object if id matches and address is the same
                 if (context.OldHosts != null && context.OldHosts.TryGetValue(hostId, out var host))
@@ -68,8 +74,8 @@ namespace Cassandra
                 }
 
                 // If either datacenter or rack is null, the method ToManagedString returns null.
-                var dcString = datacenter.ToManagedString();
-                var rackString = rack.ToManagedString();
+                var dcString = hostData.Datacenter.ToManagedString();
+                var rackString = hostData.Rack.ToManagedString();
 
                 // Create Host instance and add it to the dictionaries.
                 host = new Host(address, hostId, dcString, rackString);


### PR DESCRIPTION
## Host
During callback filling `Host` metadata, return `FFIMaybeException` on exception instead of calling `FailFast`. Modify `Host` public constructor to create a valid `Host` object with only the address known.

## MaybeShutdownError
Replace `MaybeShutdownError` with `SessionOperationError` wrapper to avoid naming confusion.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
