### PR TITLE
Stage native library instead of using symlinks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,9 +56,6 @@ jobs:
       - name: Build Rust lib
         run: make build-rust
 
-      - name: Symlink Rust lib
-        run: make create-rust-lib-symlinks
-
       - name: Build the project
         run: dotnet build src/Cassandra/Cassandra.csproj
 
@@ -143,9 +140,6 @@ jobs:
       - name: Build Rust lib
         run: make build-rust
 
-      - name: Symlink Rust lib
-        run: make create-rust-lib-symlinks
-
       - name: Run unit tests
         run: make test-unit
 
@@ -201,9 +195,6 @@ jobs:
 
       - name: Build Rust lib
         run: make build-rust
-
-      - name: Symlink Rust lib
-        run: make create-rust-lib-symlinks
 
       - name: Run unit tests
         run: make test-unit

--- a/Makefile
+++ b/Makefile
@@ -202,43 +202,6 @@ clean-csharp:
 clean-rust:
 	cd rust; cargo clean
 
-### SYMLINK RUST LIBRARY INTO C# PROJECTS ###
-# This is inherently hacky and brittle, but it's the easiest way I've found to get the Rust
-# library loaded by the C# projects during testing and execution.
-
-LINK_PROJECTS 	 := Cassandra Cassandra.IntegrationTests LoggingTests Cassandra.Tests
-FRAMEWORKS    	 := net9 net8
-
-UNAME_S := $(shell uname -s)
-ifeq ($(OS),Windows_NT)
-	RUST_LIB_FILENAME := csharp_wrapper.dll
-else ifeq ($(UNAME_S),Darwin)
-	RUST_LIB_FILENAME := libcsharp_wrapper.dylib
-else
-	RUST_LIB_FILENAME := libcsharp_wrapper.so
-endif
-
-RUST_LIB_RELATIVE_PATH := ../../../../../rust/target/debug/$(RUST_LIB_FILENAME)
-
-define symlink-to-rust
-	mkdir -p $(1); \
-	cd $(1); \
-	ln -f -s $(RUST_LIB_RELATIVE_PATH) || true; \
-	cd - >/dev/null
-endef
-
-TARGET_DIRS := $(foreach p,$(LINK_PROJECTS), \
-                 $(foreach f,$(FRAMEWORKS), \
-                   src/$(p)/bin/Debug/$(f)))
-
-.PHONY: create-rust-lib-symlinks
-create-rust-lib-symlinks:
-	@$(foreach d,$(TARGET_DIRS), \
-		echo "Linking in $(d)"; \
-		$(call symlink-to-rust,$(d));)
-
-### END SYMLINK ###
-
 # TODO: Put --release for production builds
 .PHONY: build-rust
 build-rust:

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -34,6 +34,24 @@
 
   <ItemGroup>
     <DirectPInvoke Include="csharp_wrapper"/>
+    
+    <!-- Native library staging for proper runtime loading -->
+    <Content Include="../../rust/target/debug/libcsharp_wrapper.so" 
+              Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux))) and Exists('$(RustNativeLibDir)/libcsharp_wrapper.so')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>false</Pack>
+    </Content>
+    <Content Include="../../rust/target/debug/libcsharp_wrapper.dylib" 
+              Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX))) and Exists('$(RustNativeLibDir)/libcsharp_wrapper.dylib')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>false</Pack>
+    </Content>
+    <Content Include="../../rust/target/debug/csharp_wrapper.dll" 
+              Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows))) and Exists('$(RustNativeLibDir)/csharp_wrapper.dll')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>false</Pack>
+    </Content>
+    
     <None Include="..\..\LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
   </ItemGroup>
 

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -32,21 +32,28 @@
     <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
   </PropertyGroup>
 
+  <!--  Determine the directory where the Rust native library is built based on the current configuration -->
+  <PropertyGroup>
+    <MyMode>debug</MyMode>
+    <MyMode Condition="'$(Configuration)' == 'Release'">release</MyMode>
+    <RustNativeLibDir>../../rust/target/$(MyMode)</RustNativeLibDir>
+  </PropertyGroup>
+
   <ItemGroup>
     <DirectPInvoke Include="csharp_wrapper"/>
     
     <!-- Native library staging for proper runtime loading -->
-    <Content Include="../../rust/target/debug/libcsharp_wrapper.so" 
+    <Content Include="$(RustNativeLibDir)/libcsharp_wrapper.so" 
               Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux))) and Exists('$(RustNativeLibDir)/libcsharp_wrapper.so')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>false</Pack>
     </Content>
-    <Content Include="../../rust/target/debug/libcsharp_wrapper.dylib" 
+    <Content Include="$(RustNativeLibDir)/libcsharp_wrapper.dylib" 
               Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX))) and Exists('$(RustNativeLibDir)/libcsharp_wrapper.dylib')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>false</Pack>
     </Content>
-    <Content Include="../../rust/target/debug/csharp_wrapper.dll" 
+    <Content Include="$(RustNativeLibDir)/csharp_wrapper.dll" 
               Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows))) and Exists('$(RustNativeLibDir)/csharp_wrapper.dll')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>false</Pack>

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -92,14 +92,4 @@
 
     <Exec WorkingDirectory="$(RustProjectDir)" Command="cargo build --release" />
   </Target>
-
-  <Target Name="LinkRustNativeWrapperDebug"
-          AfterTargets="Build"
-      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Debug' and '$(IsCrossTargetingBuild)' == 'true'">
-    <PropertyGroup>
-      <RepoRootDir>$(MSBuildThisFileDirectory)../..</RepoRootDir>
-    </PropertyGroup>
-
-    <Exec WorkingDirectory="$(RepoRootDir)" Command="make create-rust-lib-symlinks" />
-  </Target>
 </Project>

--- a/src/Cassandra/RustBridge/BridgedRowSet.cs
+++ b/src/Cassandra/RustBridge/BridgedRowSet.cs
@@ -457,7 +457,7 @@ namespace Cassandra
         }
 
 
-        [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
         private static extern FFIMaybeException row_set_fill_coordinator(
             IntPtr rowSetPtr,
             IntPtr endpointPtr,


### PR DESCRIPTION
This PR simplifies how the Rust native wrapper is integrated into the C# projects:

- Remove the fragile symlink-based approach used by the Makefile and CI workflows.
- Stage/copy the built Rust artifacts from `rust/target/debug` or `rust/target/release` into the C# project outputs via `Cassandra.csproj`.
- Make runtime/platform-aware `Content` entries in the project file so the correct native library is included when present.

These changes make native library handling more reliable across platforms and build configurations, and remove brittle symlink logic.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
