### PR TITLE
Advertise driver's name and version to the server

### DIFF
--- a/rust/src/session_config.rs
+++ b/rust/src/session_config.rs
@@ -2,7 +2,11 @@ use std::time::Duration;
 
 use crate::ffi::CSharpStr;
 
+use scylla::client::SelfIdentity;
 use scylla::client::session_builder::SessionBuilder;
+
+const DEFAULT_DRIVER_NAME: &str = "ScyllaDB C# RS Driver";
+const DEFAULT_DRIVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// TCP socket options passed from C#.
 ///
@@ -109,6 +113,11 @@ impl<'a> BridgedSessionConfig<'a> {
         }
 
         builder = self.tcp.apply_to_builder(builder);
+
+        let identity = SelfIdentity::new()
+            .with_custom_driver_name(DEFAULT_DRIVER_NAME)
+            .with_custom_driver_version(DEFAULT_DRIVER_VERSION);
+        builder = builder.custom_identity(identity);
 
         (uri, keyspace, builder)
     }


### PR DESCRIPTION
Before, this driver would advertise itself as "ScyllaDB Rust Driver", with version of the ScyllaDB Rust Driver.
Now, it will advertise itself as "ScyllaDB C# RS Driver", with version taken from Cargo.toml.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
