### PR TITLE
Exec info

### DIFF
--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -715,6 +715,27 @@ const _: [(); std::mem::size_of::<FFISlice<'static, u8>>()] =
 const _: [(); std::mem::align_of::<FFISlice<'static, u8>>()] =
     [(); std::mem::align_of::<(*const u8, usize)>()];
 
+pub(crate) enum IpOctets {
+    V4([u8; 4]),
+    V6([u8; 16]),
+}
+
+impl IpOctets {
+    pub(crate) fn new(ip: std::net::IpAddr) -> Self {
+        match ip {
+            std::net::IpAddr::V4(v4) => IpOctets::V4(v4.octets()),
+            std::net::IpAddr::V6(v6) => IpOctets::V6(v6.octets()),
+        }
+    }
+
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        match self {
+            IpOctets::V4(bytes) => bytes,
+            IpOctets::V6(bytes) => bytes,
+        }
+    }
+}
+
 /// Represents a string passed over FFI from Rust to C#.
 /// SAFETY: `slice` must be a valid pointer a UTF-8 encoded string with correctly set length.
 #[repr(transparent)]

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -1,7 +1,7 @@
 use crate::error_conversion::FFIMaybeException;
 use crate::ffi::{
     ArcFFI, BridgedBorrowedSharedPtr, CSharpStr, FFI, FFIBool, FFIPtr, FFISlice, FFIStr, FromArc,
-    RefFFI, ffi_callback_for_each,
+    IpOctets, RefFFI, ffi_callback_for_each,
 };
 use crate::row_set::column_type_to_code;
 use crate::task::ExceptionConstructors;
@@ -70,29 +70,9 @@ pub extern "C" fn cluster_state_fill_nodes(
         // UUID as bytes
         let uuid_bytes = FFISlice::new(node.host_id.as_bytes());
 
-        // The octets() returns an owned stack array. We store it in outer-scope
-        // variables so we can take a slice that outlives the match expression.
-        let ip_bytes_storage_v4: [u8; 4];
-        let ip_bytes_storage_v6: [u8; 16];
-
-        // Serialize IP address to bytes
         let port = node.address.port();
-        let ip_bytes_slice: &[u8] = match node.address.ip() {
-            std::net::IpAddr::V4(ipv4) => {
-                ip_bytes_storage_v4 = ipv4.octets();
-                let bytes = &ip_bytes_storage_v4[..];
-                tracing::trace!("[FFI] Node IPv4: {:?}, port: {}", bytes, port);
-                bytes
-            }
-            std::net::IpAddr::V6(ipv6) => {
-                ip_bytes_storage_v6 = ipv6.octets();
-                let bytes = &ip_bytes_storage_v6[..];
-                tracing::trace!("[FFI] Node IPv6: {:?}, port: {}", bytes, port);
-                bytes
-            }
-        };
-
-        let ip_bytes = FFISlice::new(ip_bytes_slice);
+        let ip_octets = IpOctets::new(node.address.ip());
+        let ip_bytes = FFISlice::new(ip_octets.as_slice());
 
         // Get datacenter (Option<String>) - pass null when missing
         let dc_str = match node.datacenter.as_deref() {

--- a/rust/src/row_set.rs
+++ b/rust/src/row_set.rs
@@ -8,7 +8,7 @@ use scylla::frame::response::result::{ColumnType, NativeType};
 use crate::error_conversion::{ErrorToException as _, FFIException, FFIMaybeException};
 use crate::ffi::{
     ArcFFI, BridgedBorrowedSharedPtr, FFI, FFIGCHandle, FFINonNullPtr, FFISlice, FFIStr, FromArc,
-    FromRef, GCHandlePtr, RefFFI,
+    FromRef, GCHandlePtr, IpOctets, RefFFI,
 };
 use crate::task::{BridgedFuture, ExceptionConstructors, Tcb};
 
@@ -567,6 +567,45 @@ pub extern "C" fn row_set_type_info_get_vector_dimensions(
     match type_info {
         ColumnType::Vector { dimensions, .. } => *dimensions,
         _ => panic!("row_set_type_info_get_vector_dimensions called on non-Vector ColumnType"),
+    }
+}
+
+// --- Coordinator / ExecutionInfo bridge ---
+
+/// Opaque C# representation of an `IPEndPoint` to be filled with coordinator data.
+pub enum IpEndPoint {}
+
+/// Callback that writes a single coordinator's address into the C# endpoint.
+/// `ip_bytes` is 4 bytes for IPv4 or 16 bytes for IPv6; `port` is the connection port.
+type SetCoordinator = unsafe extern "C" fn(
+    ip_endpoint_ptr: FFINonNullPtr<'_, IpEndPoint>,
+    ip_bytes: FFISlice<'_, u8>,
+    port: u16,
+) -> FFIMaybeException;
+
+/// Fills the provided endpoint with the coordinator that served the initial request.
+#[unsafe(no_mangle)]
+pub extern "C" fn row_set_fill_coordinator(
+    row_set_ptr: BridgedBorrowedSharedPtr<'_, RowSet>,
+    ip_endpoint_ptr: FFINonNullPtr<'_, IpEndPoint>,
+    set_coordinator: SetCoordinator,
+) -> FFIMaybeException {
+    let row_set = ArcFFI::as_ref(row_set_ptr).unwrap();
+    let pager = row_set.pager.blocking_lock();
+
+    let Some(coordinator) = pager.request_coordinators().next() else {
+        return FFIMaybeException::ok();
+    };
+
+    let addr = coordinator.connection_address();
+    let octets = IpOctets::new(addr.ip());
+
+    unsafe {
+        set_coordinator(
+            ip_endpoint_ptr,
+            FFISlice::new(octets.as_slice()),
+            addr.port(),
+        )
     }
 }
 

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -17,7 +17,7 @@ use crate::ffi::{
 use crate::pre_serialized_values::{PopulateValues, PopulateValuesContext, PreSerializedValues};
 use crate::prepared_statement::BridgedPreparedStatement;
 use crate::row_set::RowSet;
-use crate::session_config::BridgedSessionConfig;
+use crate::session_config::{BridgedSessionConfig, BridgedSessionConfigResult};
 use crate::task::{BridgedFuture, ExceptionConstructors, ManuallyDestructible, Tcb};
 
 /// Internal representation of a session bridged to C#.
@@ -74,14 +74,19 @@ pub extern "C" fn empty_bridged_result_free(ptr: BridgedOwnedSharedPtr<EmptyBrid
 
 #[unsafe(no_mangle)]
 pub extern "C" fn session_create(tcb: Tcb<ManuallyDestructible>, config: BridgedSessionConfig<'_>) {
-    let (uri, keyspace, session_builder) = config.into_session_builder();
+    let BridgedSessionConfigResult {
+        uri,
+        keyspace,
+        builder,
+    } = config.into_session_builder();
+    // Own the strings so they can be captured into the 'static creation future.
     let uri = uri.to_owned();
     let keyspace = keyspace.to_owned();
 
     BridgedFuture::spawn::<_, _, NewSessionError, _>(tcb, async move {
         tracing::debug!("[FFI] Create Session... {}", uri);
 
-        let session = session_builder.build().await?;
+        let session = builder.build().await?;
 
         tracing::info!(
             "[FFI] Session created! URI: {}, Keyspace: {}",

--- a/rust/src/session_config.rs
+++ b/rust/src/session_config.rs
@@ -65,6 +65,17 @@ impl BridgedTcpConfig {
     }
 }
 
+/// Output of [`BridgedSessionConfig::into_session_builder`]: a fully-configured
+/// [`SessionBuilder`] together with the URI and keyspace it was built from,
+/// borrowed directly from the C#-managed config memory.
+///
+/// The `&'a str` fields borrow from the source config; a caller that needs them to
+/// outlive that borrow (e.g. to capture into a `'static` future) must `.to_owned()`.
+pub(crate) struct BridgedSessionConfigResult<'a> {
+    pub(crate) uri: &'a str,
+    pub(crate) keyspace: &'a str,
+    pub(crate) builder: SessionBuilder,
+}
 /// Configuration for creating a new session passed from C#.
 ///
 /// Any changes to this struct must be mirrored in the corresponding C# struct.
@@ -85,16 +96,12 @@ pub(crate) struct BridgedSessionConfig<'a> {
 }
 
 impl<'a> BridgedSessionConfig<'a> {
-    /// Consume this config and produce a fully-configured [`SessionBuilder`],
-    /// returning borrowed URI and keyspace string slices alongside it.
-    ///
-    /// The returned `&'a str` slices borrow directly from the C#-managed memory;
-    /// callers that need the strings to outlive the config's source lifetime must
-    /// call `.to_owned()` themselves.
+    /// Consume this config and produce a [`BridgedSessionConfigResult`] holding a
+    /// fully-configured [`SessionBuilder`] alongside the borrowed URI and keyspace.
     ///
     /// This is the single place where all session configuration is applied, so
     /// adding new options only requires changes here and in the struct definition.
-    pub(crate) fn into_session_builder(self) -> (&'a str, &'a str, SessionBuilder) {
+    pub(crate) fn into_session_builder(self) -> BridgedSessionConfigResult<'a> {
         let uri = self.uri.as_cstr().unwrap().to_str().unwrap();
         let keyspace = self.keyspace.as_cstr().unwrap().to_str().unwrap();
 
@@ -119,6 +126,10 @@ impl<'a> BridgedSessionConfig<'a> {
             .with_custom_driver_version(DEFAULT_DRIVER_VERSION);
         builder = builder.custom_identity(identity);
 
-        (uri, keyspace, builder)
+        BridgedSessionConfigResult {
+            uri,
+            keyspace,
+            builder,
+        }
     }
 }

--- a/src/Cassandra.IntegrationTests/Core/ExecutionInfoTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ExecutionInfoTests.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using Cassandra.Tests;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Cassandra.IntegrationTests.Core
+{
+    [TestFixture, Category(TestCategory.Short), Category(TestCategory.RealCluster)]
+    public class ExecutionInfoTests : SharedClusterTest
+    {
+        public ExecutionInfoTests() : base(1, true)
+        {
+        }
+
+        [Test]
+        public void QueriedHost_Is_Set_After_Simple_Query()
+        {
+            var rs = Session.Execute("SELECT key FROM system.local WHERE key='local'");
+            Assert.IsNotNull(rs.Info.QueriedHost);
+        }
+
+        [Test]
+        public void QueriedHost_Matches_Cluster_Host()
+        {
+            var rs = Session.Execute("SELECT key FROM system.local WHERE key='local'");
+            var knownAddresses = Cluster.AllHosts().Select(h => h.Address).ToList();
+            Assert.That(knownAddresses.Contains(rs.Info.QueriedHost),
+                $"QueriedHost {rs.Info.QueriedHost} not found in known hosts: [{string.Join(", ", knownAddresses)}]");
+        }
+
+        [Test]
+        public void QueriedHost_Is_Set_After_Prepared_Statement()
+        {
+            var ps = Session.Prepare("SELECT key FROM system.local WHERE key='local'");
+            var rs = Session.Execute(ps.Bind());
+            Assert.IsNotNull(rs.Info.QueriedHost);
+        }
+
+        [Test]
+        public void TriedHosts_Is_Populated_After_Query()
+        {
+            var rs = Session.Execute("SELECT key FROM system.local WHERE key='local'");
+            Assert.IsNotNull(rs.Info.TriedHosts);
+            Assert.Greater(rs.Info.TriedHosts.Count, 0, "TriedHosts should contain at least one entry");
+        }
+
+        [Test]
+        public void QueriedHost_Matches_Last_TriedHost()
+        {
+            var rs = Session.Execute("SELECT key FROM system.local WHERE key='local'");
+            var triedHosts = rs.Info.TriedHosts;
+            Assert.IsTrue(triedHosts.Count > 0);
+            Assert.AreEqual(triedHosts[triedHosts.Count - 1], rs.Info.QueriedHost);
+        }
+    }
+}

--- a/src/Cassandra/RowPopulators/RowSet.cs
+++ b/src/Cassandra/RowPopulators/RowSet.cs
@@ -123,6 +123,7 @@ namespace Cassandra
             Columns = bridgedRowSet.ExtractColumnsFromRust();
             _exhausted = Columns.Length == 0;
             Info = new ExecutionInfo();
+            Info.SetTriedHosts(bridgedRowSet.ExtractCoordinatorFromRust());
             _genericSerializer = serializerManager?.GetGenericSerializer() ?? new GenericSerializer();
         }
 

--- a/src/Cassandra/RustBridge/BridgedRowSet.cs
+++ b/src/Cassandra/RustBridge/BridgedRowSet.cs
@@ -1,5 +1,6 @@
 using System;
-
+using System.Collections.Generic;
+using System.Net;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -453,6 +454,50 @@ namespace Cassandra
             CqlColumn column = columns[valueIndex];
             ReadOnlySpan<byte> frameSlice = frameSliceRaw.As<byte>().ToSpan();
             values[valueIndex] = serializer.Deserialize(ProtocolVersion.V4, frameSlice, column.TypeCode, column.TypeInfo);
+        }
+
+
+        [DllImport("csharp_wrapper", CallingConvention = CallingConvention.Cdecl)]
+        private static extern FFIMaybeException row_set_fill_coordinator(
+            IntPtr rowSetPtr,
+            IntPtr endpointPtr,
+            IntPtr setCoordinatorCallback);
+
+        unsafe static readonly delegate* unmanaged[Cdecl]<IntPtr, FFISliceRaw, ushort, FFIMaybeException> setCoordinatorPtr = &SetCoordinator;
+
+        [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        private static unsafe FFIMaybeException SetCoordinator(
+            IntPtr endpointPtr,
+            FFISliceRaw ipBytes,
+            ushort port)
+        {
+            try
+            {
+                var ipAddress = new IPAddress(ipBytes.As<byte>().ToSpan());
+                Unsafe.AsRef<IPEndPoint>((void*)endpointPtr) = new IPEndPoint(ipAddress, port);
+            }
+            catch (Exception ex)
+            {
+                return FFIMaybeException.FromException(ex);
+            }
+            return FFIMaybeException.Ok();
+        }
+
+        internal List<IPEndPoint> ExtractCoordinatorFromRust()
+        {
+            IPEndPoint endpoint = null;
+            unsafe
+            {
+                IntPtr endpointPtr = (IntPtr)Unsafe.AsPointer(ref endpoint);
+                RunWithIncrement(handle =>
+                    row_set_fill_coordinator(
+                        handle,
+                        endpointPtr,
+                        (IntPtr)setCoordinatorPtr
+                    )
+                );
+            }
+            return endpoint != null ? new List<IPEndPoint> { endpoint } : new List<IPEndPoint>(0);
         }
 
         internal static Type MapTypeFromCode(ColumnTypeCode code)


### PR DESCRIPTION
PR bridges ExecutionInfo.QueriedHost from Rust to C#. 
It passes the host extracted from the Rust `QueryPager` to the C# `RowSet`, owner of the `ExecutionInfo`. 

PR also includes two style changes: 

- Puts the result of `BridgedSessionConfig.into_session_builder()` into a clean struct.
- Deduplicates the handling of IPv4 and IPv6 octets across the project. 