### PR TITLE
Cassandra.csproj: Fix rust build targets

### DIFF
--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -41,24 +41,24 @@
 
   <ItemGroup>
     <DirectPInvoke Include="csharp_wrapper"/>
-    
+
     <!-- Native library staging for proper runtime loading -->
-    <Content Include="$(RustNativeLibDir)/libcsharp_wrapper.so" 
+    <Content Include="$(RustNativeLibDir)/libcsharp_wrapper.so"
               Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux))) and Exists('$(RustNativeLibDir)/libcsharp_wrapper.so')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>false</Pack>
     </Content>
-    <Content Include="$(RustNativeLibDir)/libcsharp_wrapper.dylib" 
+    <Content Include="$(RustNativeLibDir)/libcsharp_wrapper.dylib"
               Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX))) and Exists('$(RustNativeLibDir)/libcsharp_wrapper.dylib')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>false</Pack>
     </Content>
-    <Content Include="$(RustNativeLibDir)/csharp_wrapper.dll" 
+    <Content Include="$(RustNativeLibDir)/csharp_wrapper.dll"
               Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows))) and Exists('$(RustNativeLibDir)/csharp_wrapper.dll')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>false</Pack>
     </Content>
-    
+
     <None Include="..\..\LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
   </ItemGroup>
 

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -75,7 +75,7 @@
 
   <Target Name="BuildRustNativeWrapperDebug"
           BeforeTargets="Build"
-      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Debug' and '$(IsCrossTargetingBuild)' == 'true'">
+      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Debug'">
     <PropertyGroup>
       <RepoRootDir>$(MSBuildThisFileDirectory)../..</RepoRootDir>
     </PropertyGroup>
@@ -85,7 +85,7 @@
 
   <Target Name="BuildRustNativeWrapperRelease"
           BeforeTargets="Build"
-      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Release' and '$(IsCrossTargetingBuild)' == 'true'">
+      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Release'">
     <PropertyGroup>
       <RustProjectDir>$(MSBuildThisFileDirectory)../../rust</RustProjectDir>
     </PropertyGroup>


### PR DESCRIPTION
Rust build targets were present, but they were not being executed because of the condition that checked for `IsCrossTargetingBuild` being true. This condition was preventing the build targets from running during normal builds. The fix removes this condition, allowing the Rust build targets to execute as intended. The author (@Akvear) confirmed that the flag `IsCrossTargetingBuild` appeared there by mistake.


## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
