### PR TITLE
Drop support for nonzero SO_LINGER timeout

### DIFF
--- a/docs/source/migration-guide/index.md
+++ b/docs/source/migration-guide/index.md
@@ -157,6 +157,10 @@ The underlying Rust driver only supports a global, session-level request timeout
 
 **Migration Impact:** Remove any calls to `SetReadTimeoutMillis`. Once the Rust driver gains support for per-attempt timeouts, this option will usable again.
 
+#### `soLinger`
+
+The underlying Rust driver, due to its architecture based on the tokio async framework, only supports `SO_LINGER` set to 0. Enabling non-0 linger is not supported and will result in an exception being thrown.
+
 ## SimpleStatement API
 
 ### Removed APIs
@@ -211,4 +215,3 @@ The nodes are chosen at random, exactly like in the Rust driver.
 
 ### NewQueryPlan()
 All the `NewQueryPlan` methods in the policy classes are no longer supported, since all query routing is handled by the Rust driver.
-

--- a/rust/src/session_config.rs
+++ b/rust/src/session_config.rs
@@ -35,8 +35,11 @@ pub(crate) struct BridgedTcpConfig {
     /// Send buffer size in bytes. Values <= 0 mean "use default".
     send_buffer_size: i32,
 
-    /// SO_LINGER time in seconds. Values < 0 mean "use default".
-    so_linger: i32,
+    /// Whether to enable SO_LINGER flag.
+    // NOTE: `tcp_set_linger()` in Rust Driver is deprecated, because tokio is incompatible with blocking sockets.
+    // Instead, Rust Driver exposes `tcp_zero_linger()` which sets SO_LINGER with a timeout of 0.
+    // Therefore, we only expose a boolean here to indicate whether to enable SO_LINGER with a timeout of 0.
+    so_linger: FFIBool,
 }
 
 impl BridgedTcpConfig {
@@ -60,8 +63,9 @@ impl BridgedTcpConfig {
 
         builder = builder.tcp_reuse_address(self.reuse_address.into());
 
-        if self.so_linger >= 0 {
-            builder = builder.tcp_linger(Duration::from_secs(self.so_linger as u64));
+        if self.so_linger.into() {
+            // FIXME: switch to `tcp_zero_linger()` upon Rust Driver version bump to 1.7.0.
+            builder = builder.tcp_linger(Duration::ZERO);
         }
 
         builder

--- a/rust/src/session_config.rs
+++ b/rust/src/session_config.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::ffi::CSharpStr;
+use crate::ffi::{CSharpStr, FFIBool};
 
 use scylla::client::SelfIdentity;
 use scylla::{
@@ -18,10 +18,10 @@ const DEFAULT_DRIVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct BridgedTcpConfig {
     /// Whether to enable TCP_NODELAY.
-    tcp_nodelay: bool,
+    tcp_nodelay: FFIBool,
 
     /// Whether to enable TCP keepalive.
-    keepalive: bool,
+    keepalive: FFIBool,
 
     /// TCP keepalive interval in milliseconds.
     tcp_keepalive_interval_millis: i32,
@@ -30,7 +30,7 @@ pub(crate) struct BridgedTcpConfig {
     receive_buffer_size: i32,
 
     /// Whether to enable SO_REUSEADDR.
-    reuse_address: bool,
+    reuse_address: FFIBool,
 
     /// Send buffer size in bytes. Values <= 0 mean "use default".
     send_buffer_size: i32,
@@ -42,9 +42,9 @@ pub(crate) struct BridgedTcpConfig {
 impl BridgedTcpConfig {
     /// Apply all TCP socket options in this config to `builder` and return it.
     pub(crate) fn apply_to_builder(self, mut builder: SessionBuilder) -> SessionBuilder {
-        builder = builder.tcp_nodelay(self.tcp_nodelay);
+        builder = builder.tcp_nodelay(self.tcp_nodelay.into());
 
-        if self.keepalive {
+        if self.keepalive.into() {
             builder = builder.tcp_keepalive_interval(Duration::from_millis(
                 self.tcp_keepalive_interval_millis as u64,
             ));
@@ -58,7 +58,7 @@ impl BridgedTcpConfig {
             builder = builder.tcp_send_buffer_size(self.send_buffer_size as usize);
         }
 
-        builder = builder.tcp_reuse_address(self.reuse_address);
+        builder = builder.tcp_reuse_address(self.reuse_address.into());
 
         if self.so_linger >= 0 {
             builder = builder.tcp_linger(Duration::from_secs(self.so_linger as u64));

--- a/src/Cassandra/RustBridge/BridgedSession.cs
+++ b/src/Cassandra/RustBridge/BridgedSession.cs
@@ -87,7 +87,7 @@ namespace Cassandra
         unsafe private static extern void session_await_schema_agreement_with_required_node(Tcb<EmptyAsyncResult> tcb, IntPtr session, byte* hostId);
 
         /// <summary>
-        /// Creates a new session connected to the specified Cassandra URI. 
+        /// Creates a new session connected to the specified Cassandra URI.
         /// Checks the existence of the configured local datacenter.
         /// </summary>
         /// <param name="uri"></param>
@@ -385,10 +385,14 @@ namespace Cassandra
             internal int receiveBufferSize;
             internal FFIBool reuseAddress;
             internal int sendBufferSize;
-            internal int soLinger;
+            internal FFIBool soLinger;
 
             internal static BridgedTcpConfig BuildFrom(SocketOptions socketOptions)
             {
+                // If soLinger is non null and greater than 0, throw an exception because the Rust driver does not support it.
+                if (socketOptions?.SoLinger != null && socketOptions.SoLinger > 0)
+                    throw new NotSupportedException("Passed SocketOptions.SoLinger greater than 0. The Rust driver does not support setting SO_LINGER with non-zero linger time.");
+
                 return new BridgedTcpConfig
                 {
                     tcpNoDelay = socketOptions?.TcpNoDelay ?? SocketOptions.DefaultTcpNoDelay,
@@ -397,7 +401,7 @@ namespace Cassandra
                     receiveBufferSize = socketOptions?.ReceiveBufferSize ?? 0,
                     reuseAddress = socketOptions?.ReuseAddress ?? false,
                     sendBufferSize = socketOptions?.SendBufferSize ?? 0,
-                    soLinger = socketOptions?.SoLinger ?? -1,
+                    soLinger = (socketOptions?.SoLinger ?? -1) == 0,
                 };
             }
         }

--- a/src/Cassandra/SocketOptions.cs
+++ b/src/Cassandra/SocketOptions.cs
@@ -155,6 +155,9 @@ namespace Cassandra
 
         /// <summary>
         /// Sets the number of seconds to remain open after the Socket.Close() is called.
+        /// Only 0 is supported, which means that the socket will be closed immediately and any unsent data will be discarded.
+        /// Passing a negative value will disable the linger option.
+        /// Passing a positive value will result in a NonSupportedException being thrown, as this is not supported by the driver.
         /// </summary>
         public SocketOptions SetSoLinger(int soLinger)
         {


### PR DESCRIPTION
It appears that the option `SO_LINGER` with non-zero timeout is incompatible with tokio, so we throw an exception if the user sets `soLinger > 0`.
See https://github.com/scylladb/scylla-rust-driver/pull/1618 for context.
    



## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- [x] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
