### PR TITLE
Migrate to upstream Rust Driver

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -175,11 +175,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -189,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -225,16 +224,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures"
@@ -354,6 +347,12 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -413,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -460,9 +459,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -499,7 +498,7 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -541,7 +540,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -729,8 +728,8 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scylla"
-version = "1.5.0"
-source = "git+https://github.com/scylladb-zpp-2025-csharp-rs-driver/scylla-rust-driver.git?branch=main#5296af395d4481d9fee5132551f7353afcb4c37a"
+version = "1.7.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=60fd145#60fd145fd1a14ea999661481a4562de8283b55b3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -738,13 +737,14 @@ dependencies = [
  "chrono",
  "dashmap",
  "futures",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "itertools",
  "rand",
  "rand_pcg",
  "scylla-cql",
+ "scylla-cql-core",
  "smallvec",
- "socket2 0.5.10",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -753,15 +753,15 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "1.5.0"
-source = "git+https://github.com/scylladb-zpp-2025-csharp-rs-driver/scylla-rust-driver.git?branch=main#5296af395d4481d9fee5132551f7353afcb4c37a"
+version = "1.7.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=60fd145#60fd145fd1a14ea999661481a4562de8283b55b3"
 dependencies = [
  "byteorder",
  "bytes",
  "chrono",
  "itertools",
  "lz4_flex",
- "scylla-macros",
+ "scylla-cql-core",
  "snap",
  "stable_deref_trait",
  "thiserror",
@@ -771,9 +771,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "scylla-cql-core"
+version = "1.7.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=60fd145#60fd145fd1a14ea999661481a4562de8283b55b3"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "chrono",
+ "itertools",
+ "scylla-macros",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
 name = "scylla-macros"
-version = "1.5.0"
-source = "git+https://github.com/scylladb-zpp-2025-csharp-rs-driver/scylla-rust-driver.git?branch=main#5296af395d4481d9fee5132551f7353afcb4c37a"
+version = "1.7.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver.git?rev=60fd145#60fd145fd1a14ea999661481a4562de8283b55b3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -845,22 +859,12 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -952,9 +956,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1205,15 +1209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,7 +13,6 @@ futures = "0.3"
 thiserror = "2"
 tracing = "0.1.41"
 uuid = "1"
-# This is just for development. In production, we will probably get rid of this dependency.
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 
 [lib]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.0.0"
 edition = "2024"
 
 [dependencies]
-scylla = { version = "1.4.1", git = "https://github.com/scylladb-zpp-2025-csharp-rs-driver/scylla-rust-driver.git", branch = "main", features = [
+scylla = { version = "1.7.0", git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "60fd145", features = [
     "unstable-csharp-rs",
 ] }
-scylla-cql = { git = "https://github.com/scylladb-zpp-2025-csharp-rs-driver/scylla-rust-driver.git", branch = "main", package = "scylla-cql" }
+scylla-cql = { version = "1.7.0", git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "60fd145", package = "scylla-cql" }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 thiserror = "2"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 scylla = { version = "1.7.0", git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "60fd145", features = [
     "unstable-csharp-rs",
 ] }
-scylla-cql = { version = "1.7.0", git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "60fd145", package = "scylla-cql" }
+scylla-cql-core = { version = "1.7.0", git = "https://github.com/scylladb/scylla-rust-driver.git", rev = "60fd145", package = "scylla-cql" }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 thiserror = "2"

--- a/rust/src/error_conversion.rs
+++ b/rust/src/error_conversion.rs
@@ -585,6 +585,10 @@ impl ErrorToException for NewSessionError {
                 ctors.rust_exception_constructor.construct_from_rust(&self)
             }
 
+            NewSessionError::IllegalConfig(s) => ctors
+                .rust_exception_constructor
+                .construct_from_rust(format!("Illegal Session configuration: {}", s)),
+
             _ => ctors.rust_exception_constructor.construct_from_rust(&self),
         }
     }
@@ -600,7 +604,8 @@ impl ErrorToException for MetadataError {
             | MetadataError::Peers(_)
             | MetadataError::Keyspaces(_)
             | MetadataError::Udts(_)
-            | MetadataError::Tables(_) => {
+            | MetadataError::Tables(_)
+            | MetadataError::ClientRoutes(_) => {
                 ctors.rust_exception_constructor.construct_from_rust(&self)
             }
 

--- a/rust/src/pre_serialized_values.rs
+++ b/rust/src/pre_serialized_values.rs
@@ -1,11 +1,11 @@
 use crate::error_conversion::{FFIException, FFIMaybeException};
 use crate::ffi::{BridgedBorrowedExclusivePtr, FFI, FFIPtr, FFISlice, FromBox};
 use crate::task::ExceptionConstructors;
-use scylla_cql::frame::response::result::{ColumnType, NativeType};
-use scylla_cql::serialize::SerializationError;
-use scylla_cql::serialize::row::SerializedValues;
-use scylla_cql::serialize::value::SerializeValue;
-use scylla_cql::serialize::writers::CellWriter;
+use scylla::frame::response::result::{ColumnType, NativeType};
+use scylla::serialize::SerializationError;
+use scylla::serialize::value::SerializeValue;
+use scylla::serialize::writers::CellWriter;
+use scylla_cql_core::serialize::row::SerializedValues;
 
 /// A single pre-serialized cell: either a C#-backed value, or a
 /// logical null/unset marker.
@@ -22,7 +22,7 @@ impl SerializeValue for PreSerializedCell<'_> {
         &self,
         _typ: &ColumnType,
         writer: CellWriter<'b>,
-    ) -> Result<scylla_cql::serialize::writers::WrittenCellProof<'b>, SerializationError> {
+    ) -> Result<scylla::serialize::writers::WrittenCellProof<'b>, SerializationError> {
         match self {
             PreSerializedCell::Value(val) => writer
                 .set_value(val.as_slice())
@@ -34,7 +34,6 @@ impl SerializeValue for PreSerializedCell<'_> {
 }
 
 /// Holds the final serialized values that can be used with queries.
-/// Wraps scylla_cql::SerializedValues.
 pub(crate) struct PreSerializedValues {
     serialized_values: SerializedValues,
 }

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -7,7 +7,7 @@ use scylla::cluster::ClusterState;
 use scylla::errors::SchemaAgreementError;
 use scylla::errors::{NewSessionError, PagerExecutionError, PrepareError};
 use scylla::statement::Statement;
-use scylla_cql::serialize::row::SerializedValues;
+use scylla_cql_core::serialize::row::SerializedValues;
 use tokio::sync::RwLock;
 
 use crate::error_conversion::FFIMaybeException;

--- a/rust/src/session_config.rs
+++ b/rust/src/session_config.rs
@@ -64,8 +64,7 @@ impl BridgedTcpConfig {
         builder = builder.tcp_reuse_address(self.reuse_address.into());
 
         if self.so_linger.into() {
-            // FIXME: switch to `tcp_zero_linger()` upon Rust Driver version bump to 1.7.0.
-            builder = builder.tcp_linger(Duration::ZERO);
+            builder = builder.tcp_zero_linger();
         }
 
         builder

--- a/src/Cassandra.IntegrationTests/Core/MetadataGetReplicasTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MetadataGetReplicasTests.cs
@@ -25,7 +25,7 @@ namespace Cassandra.IntegrationTests.Core
             var tabletsClause = TestClusterManager.IsScylla ? " AND tablets = { 'enabled' : false }" : "";
             Session.Execute(
                 $"CREATE KEYSPACE {_keyspaceName} WITH replication = " +
-                $"{{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }}{tabletsClause}");
+                $"{{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2 }}{tabletsClause}");
         }
 
         #region Simple Partition Key Tests
@@ -237,20 +237,17 @@ namespace Cassandra.IntegrationTests.Core
             CollectionAssert.AreEqual(addresses1, addresses2);
         }
 
-        #region NetworkTopologyStrategy / tablet-aware path
+        #region NetworkTopologyStrategy
 
         [Test]
         public void GetReplicas_ReturnsCorrectReplicaCount_ForNetworkTopologyStrategy()
         {
             var dc = Cluster.AllHosts().First().Datacenter;
-            var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLowerInvariant();
-            Session.Execute($"CREATE KEYSPACE {keyspaceName} WITH replication = " +
-                            $"{{ 'class' : 'NetworkTopologyStrategy', '{dc}' : 2 }}");
             var tableName = TestUtils.GetUniqueTableName().ToLowerInvariant();
-            Session.Execute($"CREATE TABLE {keyspaceName}.{tableName} (id text PRIMARY KEY, value text)");
+            Session.Execute($"CREATE TABLE {_keyspaceName}.{tableName} (id text PRIMARY KEY, value text)");
             var allHosts = Cluster.AllHosts();
 
-            var replicas = Cluster.Metadata.GetReplicas(keyspaceName, tableName, new object[] { "key1" });
+            var replicas = Cluster.Metadata.GetReplicas(_keyspaceName, tableName, new object[] { "key1" });
 
             Assert.IsNotNull(replicas);
             Assert.AreEqual(2, replicas.Count);


### PR DESCRIPTION
It's time to switch Rust Driver dep to upstream repo!
    
Additionally, this PR bumps Rust Driver version to the newest commit on main (last tag: 1.7.0).

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
