### PR TITLE
Fix rust build target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,9 +53,6 @@ jobs:
       - name: Copy development signing key
         run: "cp -f build/scylladb-dev.snk build/scylladb.snk"
 
-      - name: Build Rust lib
-        run: make build-rust
-
       - name: Build the project
         run: dotnet build src/Cassandra/Cassandra.csproj
 
@@ -137,9 +134,6 @@ jobs:
             exit 1
           fi
 
-      - name: Build Rust lib
-        run: make build-rust
-
       - name: Run unit tests
         run: make test-unit
 
@@ -192,9 +186,6 @@ jobs:
             echo "Opening for 127.0.$sub"
             for i in {0..255}; do sudo ifconfig lo0 alias 127.0.$sub.$i up; done
           done
-
-      - name: Build Rust lib
-        run: make build-rust
 
       - name: Run unit tests
         run: make test-unit

--- a/Makefile
+++ b/Makefile
@@ -207,9 +207,7 @@ clean-rust:
 .PHONY: build-rust
 build-rust:
 	cd rust; \
-	cargo build; \
-	cd ../examples/RustWrapper/bin/Debug/net9/; \
-	ln -f -s ../../../../../rust/target/debug/libcsharp_wrapper.so . || true
+	cargo build;
 
 .PHONY: build-rust-testing
 build-rust-testing:
@@ -224,9 +222,7 @@ build-rust-asan:
 		-Zsanitizer=address \
 		-C link-arg=-Wl,--whole-archive \
 		-C link-arg=/usr/lib/clang/20/lib/x86_64-redhat-linux-gnu/libclang_rt.asan_static.a" \
-	cargo +nightly build -Zbuild-std --target x86_64-unknown-linux-gnu; \
-	cd ../examples/RustWrapper/bin/Debug/net9/ ; \
-	ln -f -s ../../../../../rust/target/x86_64-unknown-linux-gnu/debug/libcsharp_wrapper.so . || true
+	cargo +nightly build -Zbuild-std --target x86_64-unknown-linux-gnu;
 
 .PHONY: run-wrapper-example
 run-wrapper-example:

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ fix-rust:
 	cd rust; cargo fmt && cargo fix && cargo clippy --all-targets --all-features --fix
 
 .PHONY: test-unit
-test-unit: .use-development-snk
+test-unit: .use-development-snk build-rust-testing
 	dotnet build-server shutdown
 	dotnet test $(TEST_TARGET_OPTIONS) src/Cassandra.Tests/Cassandra.Tests.csproj
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ fix-rust:
 .PHONY: test-unit
 test-unit: .use-development-snk build-rust-testing
 	dotnet build-server shutdown
-	dotnet test $(TEST_TARGET_OPTIONS) src/Cassandra.Tests/Cassandra.Tests.csproj
+	dotnet test $(TEST_TARGET_OPTIONS) src/Cassandra.Tests/Cassandra.Tests.csproj --property:BuildRust=false
 
 TEST_INTEGRATION_SCYLLA_FILTER ?= (FullyQualifiedName!~ClientWarningsTests & FullyQualifiedName!~CustomPayloadTests & FullyQualifiedName!~Connect_With_Ssl_Test & FullyQualifiedName!~Should_UpdateHosts_When_HostIpChanges & FullyQualifiedName!~Should_UseNewHostInQueryPlans_When_HostIsDecommissionedAndJoinsAgain & FullyQualifiedName!~Should_RemoveNodeMetricsAndDisposeMetricsContext_When_HostIsRemoved & FullyQualifiedName!~Virtual_Keyspaces_Are_Included & FullyQualifiedName!~Virtual_Table_Metadata_Test & FullyQualifiedName!~SessionAuthenticationTests & FullyQualifiedName!~Custom_MetadataTest & FullyQualifiedName!~Should_Use_Custom_TypeSerializers & FullyQualifiedName!~LinqWhere_WithVectors & FullyQualifiedName!~SimpleStatement_With_No_Compact_Enabled_Should_Reveal_Non_Schema_Columns & FullyQualifiedName!~SimpleStatement_With_No_Compact_Disabled_Should_Not_Reveal_Non_Schema_Columns & FullyQualifiedName!~ColumnClusteringOrderReversedTest & FullyQualifiedName!~GetMaterializedView_Should_Refresh_View_Metadata_Via_Events & FullyQualifiedName!~MaterializedView_Base_Table_Column_Addition & FullyQualifiedName!~MultipleSecondaryIndexTest & FullyQualifiedName!~RaiseErrorOnInvalidMultipleSecondaryIndexTest & FullyQualifiedName!~TableMetadataAllTypesTest & FullyQualifiedName!~TableMetadataClusteringOrderTest & FullyQualifiedName!~TableMetadataCollectionsSecondaryIndexTest & FullyQualifiedName!~TableMetadataCompositePartitionKeyTest & FullyQualifiedName!~TupleMetadataTest & FullyQualifiedName!~Udt_Case_Sensitive_Metadata_Test & FullyQualifiedName!~UdtMetadataTest & FullyQualifiedName!~Should_Retrieve_Table_Metadata & FullyQualifiedName!~CreateTable_With_Frozen_Key & FullyQualifiedName!~CreateTable_With_Frozen_Udt & FullyQualifiedName!~CreateTable_With_Frozen_Value & FullyQualifiedName!~Should_AllMetricsHaveValidValues_When_AllNodesAreUp & FullyQualifiedName!~SimpleStatement_Dictionary_Parameters_CaseInsensitivity_ExcessOfParams & FullyQualifiedName!~SimpleStatement_Dictionary_Parameters_CaseInsensitivity_NoOverload & FullyQualifiedName!~TokenAware_TransientReplication_NoHopsAndOnlyFullReplicas & FullyQualifiedName!~GetFunction_Should_Return_Most_Up_To_Date_Metadata_Via_Events & FullyQualifiedName!~LargeDataTests & FullyQualifiedName!~MetadataTests & FullyQualifiedName!~MultiThreadingTests & FullyQualifiedName!~PoolTests & FullyQualifiedName!~PrepareLongTests & FullyQualifiedName!~SpeculativeExecutionLongTests & FullyQualifiedName!~StressTests & FullyQualifiedName!~TransitionalAuthenticationTests & FullyQualifiedName!~ProxyAuthenticationTests & FullyQualifiedName!~CloudIntegrationTests & FullyQualifiedName!~CoreGraphTests & FullyQualifiedName!~GraphTests & FullyQualifiedName!~InsightsIntegrationTests & FullyQualifiedName!~DateRangeTests & FullyQualifiedName!~FoundBugTests & FullyQualifiedName!~GeometryTests & FullyQualifiedName!~LoadBalancingPolicyTests & FullyQualifiedName!~ConsistencyTests & FullyQualifiedName!~LoadBalancingPolicyTests & FullyQualifiedName!~ReconnectionPolicyTests & FullyQualifiedName!~RetryPolicyTests)
 TEST_INTEGRATION_SIMULACRON_FILTER ?= (FullyQualifiedName~SessionExecuteAsyncTests | FullyQualifiedName~BasicTypeTests | FullyQualifiedName~TupleTests | FullyQualifiedName~ClusterSimulacronTests)
@@ -80,19 +80,19 @@ TEST_INTEGRATION_CSPROJ ?= src/Cassandra.IntegrationTests/Cassandra.IntegrationT
 .PHONY: test-integration-scylla
 test-integration-scylla: .use-development-snk .prepare-scylla-ccm build-rust-testing
 	dotnet build-server shutdown
-	CCM_DISTRIBUTION=scylla dotnet test $(TEST_TARGET_OPTIONS) $(TEST_INTEGRATION_CSPROJ) $(TEST_INTEGRATION_OPTIONS)
+	CCM_DISTRIBUTION=scylla dotnet test $(TEST_TARGET_OPTIONS) $(TEST_INTEGRATION_CSPROJ) $(TEST_INTEGRATION_OPTIONS) --property:BuildRust=false
 
 .PHONY: test-integration-simulacron build-rust-testing
 test-integration-simulacron: .use-development-snk
 	dotnet build-server shutdown
-	dotnet test $(TEST_TARGET_OPTIONS) $(TEST_INTEGRATION_CSPROJ) $(TEST_INTEGRATION_OPTIONS) --filter "$(TEST_INTEGRATION_SIMULACRON_FILTER)"
+	dotnet test $(TEST_TARGET_OPTIONS) $(TEST_INTEGRATION_CSPROJ) $(TEST_INTEGRATION_OPTIONS) --filter "$(TEST_INTEGRATION_SIMULACRON_FILTER)" --property:BuildRust=false
 
 TEST_LOGGING_CSPROJ ?= src/LoggingTests/LoggingTests.csproj
 TEST_LOGGING_CASES ?= Should_Forward_Rust_Log_Entries_Using_LoggerFactory Should_Forward_Rust_Log_On_Connect Should_Filter_Rust_Log_Entries_At_Off Should_Filter_Rust_Log_Entries_At_Error Should_Filter_Rust_Log_Entries_At_Warning Should_Filter_Rust_Log_Entries_At_Info Should_Filter_Rust_Log_Entries_At_Verbose
 
 .PHONY: test-logging
 test-logging: .use-development-snk build-rust-testing
-	dotnet build $(TEST_LOGGING_CSPROJ)
+	dotnet build $(TEST_LOGGING_CSPROJ) --property:BuildRust=false
 	for test in $(TEST_LOGGING_CASES); do \
 		dotnet test --no-build $(TEST_TARGET_OPTIONS) $(TEST_LOGGING_CSPROJ) $(TEST_INTEGRATION_OPTIONS) --filter "FullyQualifiedName~RustLoggingTests.$$test"; \
 	done

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -37,6 +37,7 @@
     <MyMode>debug</MyMode>
     <MyMode Condition="'$(Configuration)' == 'Release'">release</MyMode>
     <RustNativeLibDir>../../rust/target/$(MyMode)</RustNativeLibDir>
+    <BuildRust Condition="'$(BuildRust)' == ''">true</BuildRust>
   </PropertyGroup>
 
   <ItemGroup>
@@ -75,7 +76,7 @@
 
   <Target Name="BuildRustNativeWrapperDebug"
           BeforeTargets="Build"
-      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Debug'">
+      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Debug' and '$(BuildRust)' == 'true'">
     <PropertyGroup>
       <RepoRootDir>$(MSBuildThisFileDirectory)../..</RepoRootDir>
     </PropertyGroup>
@@ -85,7 +86,7 @@
 
   <Target Name="BuildRustNativeWrapperRelease"
           BeforeTargets="Build"
-      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Release'">
+      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Release' and '$(BuildRust)' == 'true'">
     <PropertyGroup>
       <RustProjectDir>$(MSBuildThisFileDirectory)../../rust</RustProjectDir>
     </PropertyGroup>

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -41,24 +41,24 @@
 
   <ItemGroup>
     <DirectPInvoke Include="csharp_wrapper"/>
-    
+
     <!-- Native library staging for proper runtime loading -->
-    <Content Include="$(RustNativeLibDir)/libcsharp_wrapper.so" 
+    <Content Include="$(RustNativeLibDir)/libcsharp_wrapper.so"
               Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux))) and Exists('$(RustNativeLibDir)/libcsharp_wrapper.so')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>false</Pack>
     </Content>
-    <Content Include="$(RustNativeLibDir)/libcsharp_wrapper.dylib" 
+    <Content Include="$(RustNativeLibDir)/libcsharp_wrapper.dylib"
               Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX))) and Exists('$(RustNativeLibDir)/libcsharp_wrapper.dylib')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>false</Pack>
     </Content>
-    <Content Include="$(RustNativeLibDir)/csharp_wrapper.dll" 
+    <Content Include="$(RustNativeLibDir)/csharp_wrapper.dll"
               Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows))) and Exists('$(RustNativeLibDir)/csharp_wrapper.dll')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>false</Pack>
     </Content>
-    
+
     <None Include="..\..\LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
   </ItemGroup>
 

--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -75,7 +75,7 @@
 
   <Target Name="BuildRustNativeWrapperDebug"
           BeforeTargets="Build"
-      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Debug' and '$(IsCrossTargetingBuild)' == 'true'">
+      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Debug'">
     <PropertyGroup>
       <RepoRootDir>$(MSBuildThisFileDirectory)../..</RepoRootDir>
     </PropertyGroup>
@@ -85,7 +85,7 @@
 
   <Target Name="BuildRustNativeWrapperRelease"
           BeforeTargets="Build"
-      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Release' and '$(IsCrossTargetingBuild)' == 'true'">
+      Condition="'$(OS)' != 'Windows_NT' and '$(DesignTimeBuild)' != 'true' and '$(Configuration)' == 'Release'">
     <PropertyGroup>
       <RustProjectDir>$(MSBuildThisFileDirectory)../../rust</RustProjectDir>
     </PropertyGroup>


### PR DESCRIPTION
Rust build targets were present, but they were not being executed because of the condition that checked for IsCrossTargetingBuild being true. This condition was preventing the build targets from running during normal builds. The fix removes this condition, allowing the Rust build targets to execute as intended. The author (@Akvear) confirmed that the flag IsCrossTargetingBuild appeared there by mistake. 

Additionally, the `BuildRust` flag was introduced. It defaults to true, but when set to false disables the native Rust build. This option is useful for testing, where we need a special build with the integration_tests feature enabled. 

Fixes: #160

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
