### PR TITLE
logging: add colours for better debugging experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,11 @@ TEST_LOGGING_CASES ?= Should_Forward_Rust_Log_Entries_Using_LoggerFactory Should
 .PHONY: test-logging
 test-logging: .use-development-snk build-rust-testing
 	dotnet build $(TEST_LOGGING_CSPROJ) --property:BuildRust=false
+	status=0; \
 	for test in $(TEST_LOGGING_CASES); do \
-		dotnet test --no-build $(TEST_TARGET_OPTIONS) $(TEST_LOGGING_CSPROJ) $(TEST_INTEGRATION_OPTIONS) --filter "FullyQualifiedName~RustLoggingTests.$$test"; \
-	done
+		dotnet test --no-build $(TEST_TARGET_OPTIONS) $(TEST_LOGGING_CSPROJ) $(TEST_INTEGRATION_OPTIONS) --filter "FullyQualifiedName~RustLoggingTests.$$test" || status=1; \
+	done; \
+	exit $$status
 
 .PHONY: test-integration-cassandra
 test-integration-cassandra: .use-development-snk .prepare-cassandra-ccm build-rust-testing

--- a/rust/src/logging.rs
+++ b/rust/src/logging.rs
@@ -68,16 +68,14 @@ impl From<CsharpLogLevel> for LevelFilter {
 struct FormattedFieldsVisitor {
     output: String,
     has_entry: bool,
-    field_separator: &'static str,
     message_field_name: Option<&'static str>,
 }
 
 impl FormattedFieldsVisitor {
-    fn new(field_separator: &'static str, message_field_name: Option<&'static str>) -> Self {
+    fn new(message_field_name: Option<&'static str>) -> Self {
         Self {
             output: String::new(),
             has_entry: false,
-            field_separator,
             message_field_name,
         }
     }
@@ -94,14 +92,7 @@ impl FormattedFieldsVisitor {
             // If this field is the "message" field, we omit the field name and separator to produce cleaner output.
             write!(self.output, "{prefix}{value:?}").unwrap();
         } else {
-            write!(
-                self.output,
-                "{prefix}{}{}{:?}",
-                field.name(),
-                self.field_separator,
-                value
-            )
-            .unwrap();
+            write!(self.output, "{prefix}{}={:?}", field.name(), value).unwrap();
         }
 
         self.has_entry = true;
@@ -138,7 +129,7 @@ where
             return;
         };
 
-        let mut visitor = FormattedFieldsVisitor::new("=", None);
+        let mut visitor = FormattedFieldsVisitor::new(None);
         attrs.record(&mut visitor);
         span.extensions_mut().insert(SpanFields(visitor.output));
     }
@@ -157,7 +148,7 @@ where
         let meta = event.metadata();
         let event_level = meta.level();
 
-        let mut visitor = FormattedFieldsVisitor::new(": ", Some("message"));
+        let mut visitor = FormattedFieldsVisitor::new(Some("message"));
         event.record(&mut visitor);
 
         let ffi_level = CsharpLogLevel::from(*event_level);

--- a/rust/src/logging.rs
+++ b/rust/src/logging.rs
@@ -88,7 +88,7 @@ impl FormattedFieldsVisitor {
             .message_field_name
             .is_some_and(|message_field_name| field.name() == message_field_name);
 
-        let prefix = if self.has_entry { ", " } else { "" };
+        let prefix = if self.has_entry { " " } else { "" };
 
         if should_omit_name {
             // If this field is the "message" field, we omit the field name and separator to produce cleaner output.

--- a/rust/src/logging.rs
+++ b/rust/src/logging.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Write};
 use std::sync::OnceLock;
 
-use crate::ffi::FFIStr;
+use crate::ffi::{FFIBool, FFIStr};
 use tracing::Level;
 use tracing::field::{Field, Visit};
 use tracing::span::Attributes;
@@ -15,6 +15,7 @@ type CSharpLogCallback = unsafe extern "C" fn(level: CsharpLogLevel, message: FF
 #[derive(Copy, Clone)]
 struct ProcessLogger {
     callback: CSharpLogCallback,
+    ansi_codes: AnsiCodes,
 }
 
 static LOGGER: OnceLock<ProcessLogger> = OnceLock::new();
@@ -25,8 +26,17 @@ fn logger() -> Option<&'static ProcessLogger> {
 }
 
 // Initializes the global logger with the provided C# callback.
-fn init_logger(callback: CSharpLogCallback) {
-    LOGGER.set(ProcessLogger { callback }).ok();
+fn init_logger(callback: CSharpLogCallback, ansi_enabled: bool) {
+    LOGGER
+        .set(ProcessLogger {
+            callback,
+            ansi_codes: if ansi_enabled {
+                AnsiCodes::ANSI
+            } else {
+                AnsiCodes::NO_ANSI
+            },
+        })
+        .ok();
 }
 
 /// This is equivalent of C# side Diagnostics.CassandraTraceSwitch.Level
@@ -64,6 +74,55 @@ impl From<CsharpLogLevel> for LevelFilter {
     }
 }
 
+// ANSI COLOR CODES
+//
+// Hardcoded to match the styling that tracing_subscriber's own ANSI formatter
+// uses (see `tracing-subscriber`'s `fmt::format::Pretty`/default formatter),
+// so Rust logs forwarded to C# keep a familiar look. Note that the log level
+// itself (TRACE/DEBUG/INFO/WARN/ERROR) is *not* colored here: that text is
+// added on the C# side (see RustBridge.cs/Logger.cs), which is also
+// responsible for coloring it.
+//
+// These are only ever written into a message when ANSI is enabled for the
+// process (see `ProcessLogger::ansi_enabled`); otherwise the plain (empty)
+// counterparts below are used, so no escape codes are generated at all.
+
+const ANSI_RESET: &str = "\x1b[0m";
+const ANSI_BOLD: &str = "\x1b[1m";
+const ANSI_DIMMED: &str = "\x1b[2m";
+const ANSI_ITALIC: &str = "\x1b[3m";
+
+const NO_ANSI_RESET: &str = "";
+const NO_ANSI_BOLD: &str = "";
+const NO_ANSI_DIMMED: &str = "";
+const NO_ANSI_ITALIC: &str = "";
+
+/// The set of formatting codes to use when building a forwarded log message.
+/// Either the real ANSI escape codes, or empty strings when ANSI is disabled.
+#[derive(Copy, Clone)]
+struct AnsiCodes {
+    reset: &'static str,
+    bold: &'static str,
+    dimmed: &'static str,
+    italic: &'static str,
+}
+
+impl AnsiCodes {
+    const NO_ANSI: Self = Self {
+        reset: NO_ANSI_RESET,
+        bold: NO_ANSI_BOLD,
+        dimmed: NO_ANSI_DIMMED,
+        italic: NO_ANSI_ITALIC,
+    };
+
+    const ANSI: Self = Self {
+        reset: ANSI_RESET,
+        bold: ANSI_BOLD,
+        dimmed: ANSI_DIMMED,
+        italic: ANSI_ITALIC,
+    };
+}
+
 /// Formats tracing span and event fields for the C# logger.
 struct FormattedFieldsVisitor {
     output: String,
@@ -92,7 +151,19 @@ impl FormattedFieldsVisitor {
             // If this field is the "message" field, we omit the field name and separator to produce cleaner output.
             write!(self.output, "{prefix}{value:?}").unwrap();
         } else {
-            write!(self.output, "{prefix}{}={:?}", field.name(), value).unwrap();
+            let AnsiCodes {
+                reset,
+                italic,
+                dimmed,
+                ..
+            } = LOGGER.get().map_or(AnsiCodes::NO_ANSI, |l| l.ansi_codes);
+            write!(
+                self.output,
+                "{prefix}{italic}{}{reset}{dimmed}={reset}{:?}",
+                field.name(),
+                value
+            )
+            .unwrap();
         }
 
         self.has_entry = true;
@@ -148,6 +219,14 @@ where
         let meta = event.metadata();
         let event_level = meta.level();
 
+        let codes = LOGGER.get().map_or(AnsiCodes::NO_ANSI, |l| l.ansi_codes);
+        let AnsiCodes {
+            reset,
+            bold,
+            dimmed,
+            ..
+        } = codes;
+
         let mut visitor = FormattedFieldsVisitor::new(Some("message"));
         event.record(&mut visitor);
 
@@ -157,23 +236,23 @@ where
         if let Some(scope) = ctx.event_scope(event)
             && let Some(span) = scope.from_root().last()
         {
-            prefixed_message.push_str(span.name());
+            write!(prefixed_message, "{bold}{}{reset}", span.name()).unwrap();
 
             if let Some(fields) = span.extensions().get::<SpanFields>()
                 && !fields.0.is_empty()
             {
-                prefixed_message.push('{');
-                prefixed_message.push_str(&fields.0);
-                prefixed_message.push('}');
+                write!(
+                    prefixed_message,
+                    "{bold}{{{reset}{}{bold}}}{reset}",
+                    fields.0
+                )
+                .unwrap();
             }
 
-            prefixed_message.push_str(": ");
+            write!(prefixed_message, "{dimmed}: {reset}").unwrap();
         }
 
-        prefixed_message.push('[');
-        prefixed_message.push_str(meta.target());
-        prefixed_message.push(']');
-        prefixed_message.push(' ');
+        write!(prefixed_message, "{dimmed}[{}]{reset} ", meta.target()).unwrap();
 
         prefixed_message.push_str(&visitor.output);
 
@@ -186,11 +265,18 @@ where
 /// Must be called at least once before any logging is performed;
 /// otherwise, no log output will be produced.
 /// Subsequent calls are no-ops.
+///
+/// `ansi_enabled` controls whether forwarded messages are annotated with ANSI
+/// escape codes - should be `true` only for the default Trace-based console/trace-listener path.
 #[unsafe(no_mangle)]
-pub extern "C" fn configure_rust_logging(callback: CSharpLogCallback, min_level: CsharpLogLevel) {
+pub extern "C" fn configure_rust_logging(
+    callback: CSharpLogCallback,
+    min_level: CsharpLogLevel,
+    ansi_enabled: FFIBool,
+) {
     static INIT: std::sync::Once = std::sync::Once::new();
     INIT.call_once(|| {
-        init_logger(callback);
+        init_logger(callback, ansi_enabled.into());
 
         tracing::subscriber::set_global_default(
             tracing_subscriber::registry()

--- a/src/Cassandra/Logger.cs
+++ b/src/Cassandra/Logger.cs
@@ -162,11 +162,28 @@ namespace Cassandra
         internal class TraceBasedLoggerHandler : ILoggerHandler
         {
             private const string DateFormat = "MM/dd/yyyy H:mm:ss.fff zzz";
+
+            // ANSI color codes for the level tag, matching the palette used by the Rust driver's
+            // own `tracing_subscriber` ANSI formatter (see rust/src/logging.rs), so that native C#
+            // log lines look consistent with Rust logs forwarded through the C#-Rust logging bridge.
+            // Note: Rust's TRACE and DEBUG levels are both coalesced into "Verbose" on the C# side
+            // (there's no separate C# level for them), so a single color is used for both.
+            private const string AnsiReset = "\x1b[0m";
+            private const string AnsiDimmed = "\x1b[2m";
+            private const string AnsiBold = "\x1b[1m";
+            private const string AnsiCyan = "\x1b[36m";
+            private const string AnsiError = "\x1b[31m"; // red, matches Rust's ERROR
+            private const string AnsiWarning = "\x1b[33m"; // yellow, matches Rust's WARN
+            private const string AnsiInfo = "\x1b[32m"; // green, matches Rust's INFO
+            private const string AnsiVerbose = "\x1b[34m"; // blue, matches Rust's DEBUG
+
             private readonly string _category;
 
             public TraceBasedLoggerHandler(Type type)
             {
-                _category = type.Name;
+                // Bold + cyan, so the source ("Rust"/"Cluster"/etc.) stands out from the
+                // (dimmed) timestamp and the (level-colored) level tag that follow it.
+                _category = $"{AnsiBold}{AnsiCyan}{type.Name}{AnsiReset}";
             }
 
             private static string PrintStackTrace(Exception ex)
@@ -211,7 +228,7 @@ namespace Cassandra
                     return;
                 }
                 Trace.WriteLine(
-                    string.Format("{0} ERROR {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), GetExceptionAndAllInnerEx(ex)), _category);
+                    string.Format("{0}{1}{2} {3}ERROR{4} {5}", AnsiDimmed, DateTimeOffset.Now.DateTime.ToString(DateFormat), AnsiReset, AnsiError, AnsiReset, GetExceptionAndAllInnerEx(ex)), _category);
             }
 
             public void Error(string msg, Exception ex = null)
@@ -221,7 +238,7 @@ namespace Cassandra
                     return;
                 }
                 Trace.WriteLine(
-                    string.Format("{0} ERROR {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat),
+                    string.Format("{0}{1}{2} {3}ERROR{4} {5}", AnsiDimmed, DateTimeOffset.Now.DateTime.ToString(DateFormat), AnsiReset, AnsiError, AnsiReset,
                         msg + (ex != null ? "\nEXCEPTION:\n " + GetExceptionAndAllInnerEx(ex) : string.Empty)), _category);
             }
 
@@ -235,7 +252,7 @@ namespace Cassandra
                 {
                     message = string.Format(message, args);
                 }
-                Trace.WriteLine(string.Format("{0} ERROR {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), message), _category);
+                Trace.WriteLine(string.Format("{0}{1}{2} {3}ERROR{4} {5}", AnsiDimmed, DateTimeOffset.Now.DateTime.ToString(DateFormat), AnsiReset, AnsiError, AnsiReset, message), _category);
             }
 
             public void Warning(string message, params object[] args)
@@ -248,7 +265,7 @@ namespace Cassandra
                 {
                     message = string.Format(message, args);
                 }
-                Trace.WriteLine(string.Format("{0} WARNING {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), message), _category);
+                Trace.WriteLine(string.Format("{0}{1}{2} {3}WARNING{4} {5}", AnsiDimmed, DateTimeOffset.Now.DateTime.ToString(DateFormat), AnsiReset, AnsiWarning, AnsiReset, message), _category);
             }
 
             public void Info(string message, params object[] args)
@@ -261,7 +278,7 @@ namespace Cassandra
                 {
                     message = string.Format(message, args);
                 }
-                Trace.WriteLine(string.Format("{0} INFO {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), message), _category);
+                Trace.WriteLine(string.Format("{0}{1}{2} {3}INFO{4} {5}", AnsiDimmed, DateTimeOffset.Now.DateTime.ToString(DateFormat), AnsiReset, AnsiInfo, AnsiReset, message), _category);
             }
 
             public void Verbose(string message, params object[] args)
@@ -274,7 +291,7 @@ namespace Cassandra
                 {
                     message = string.Format(message, args);
                 }
-                Trace.WriteLine(string.Format("{0} VERBOSE {1}", DateTimeOffset.Now.DateTime.ToString(DateFormat), message), _category);
+                Trace.WriteLine(string.Format("{0}{1}{2} {3}VERBOSE{4} {5}", AnsiDimmed, DateTimeOffset.Now.DateTime.ToString(DateFormat), AnsiReset, AnsiVerbose, AnsiReset, message), _category);
             }
         }
     }

--- a/src/Cassandra/RustBridge/RustBridge.cs
+++ b/src/Cassandra/RustBridge/RustBridge.cs
@@ -778,7 +778,7 @@ namespace Cassandra
             /// </summary>
 
             [DllImport(NativeLibrary.CSharpWrapper, CallingConvention = CallingConvention.Cdecl)]
-            private static unsafe extern void configure_rust_logging(IntPtr callback, byte min_level);
+            private static unsafe extern void configure_rust_logging(IntPtr callback, byte min_level, FFIBool ansi_enabled);
 
             // Constructor for a System.ArgumentException meant for use by Rust.
             // Defined here, because an exception from the C# Base Class Library cannot have custom constructors added.
@@ -864,7 +864,8 @@ namespace Cassandra
                     (IntPtr)UnauthorizedExceptionConstructorPtr
                 );
 
-                configure_rust_logging((IntPtr)RustLogCallbackPtr, GetRustMinLogLevel());
+                bool ansiEnabled = !Diagnostics.UseLoggerFactory;
+                configure_rust_logging((IntPtr)RustLogCallbackPtr, GetRustMinLogLevel(), ansiEnabled);
             }
         }
 

--- a/src/LoggingTests/RustLoggingTests.cs
+++ b/src/LoggingTests/RustLoggingTests.cs
@@ -133,6 +133,8 @@ namespace Cassandra.LoggingTests
                     record.Contains("This is a"));
 
                 Assert.That(rustLogCount, Is.EqualTo(expectedMessageCount), $"Expected logger factory to capture {expectedMessageCount} Rust log entries. Captured: {string.Join(" | ", provider.Records)}");
+                Assert.That(provider.Records.Any(record => record.Contains('\x1b')), Is.False,
+                    $"Rust log entries forwarded to an ILoggerProvider must not contain ANSI escape codes. Captured: {string.Join(" | ", provider.Records)}");
             }
             finally
             {

--- a/src/LoggingTests/RustLoggingTests.cs
+++ b/src/LoggingTests/RustLoggingTests.cs
@@ -86,7 +86,7 @@ namespace Cassandra.LoggingTests
 
                 if (assertConnectLog)
                 {
-                    var hasRustLog = writer.ToString().Contains("Rust:");
+                    var hasRustLog = writer.ToString().Contains("Rust");
                     Assert.That(hasRustLog, Is.True, "The trace listener should have captured at least one log message forwarded from the Rust bridge.");
                     return;
                 }


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~
- [x] I added appropriate `Fixes:` annotations to PR description.

Fixes: #137 

Before:
<img width="1320" height="101" alt="Screenshot_20260728_120211" src="https://github.com/user-attachments/assets/83e14ba0-b5d8-4ca3-8004-8028c47aae41" />

After:
<img width="1336" height="103" alt="Screenshot_20260728_120019" src="https://github.com/user-attachments/assets/4c2cd8a0-22d5-4444-bfcd-c7f5e2ac30a9" />

There are also some minor formatting changes suggested by Copilot.
Makefile is updated to not check the loop exit code, but exit with error on any log test failure.